### PR TITLE
Added patch scripts to enable releasing fork to existing PoB installs

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -1,370 +1,371 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <PoBVersion>
-	<Version number="1.4.152"/>
-	<Source part="program" url="https://raw.githubusercontent.com/Openarl/PathOfBuilding/{branch}/"/>
-	<Source part="tree" url="https://raw.githubusercontent.com/Openarl/PathOfBuilding/{branch}/"/>
-	<Source part="tree-2_6" url="https://raw.githubusercontent.com/Openarl/PathOfBuilding/{branch}/tree-2_6.zip"/>
-	<Source part="tree-3_6" url="https://raw.githubusercontent.com/Openarl/PathOfBuilding/{branch}/tree-3_6.zip"/>
-	<Source part="tree-3_7" url="https://raw.githubusercontent.com/Openarl/PathOfBuilding/{branch}/tree-3_7.zip"/>
-	<Source part="tree-3_8" url="https://raw.githubusercontent.com/Openarl/PathOfBuilding/{branch}/tree-3_8.zip"/>
-	<Source url="https://raw.githubusercontent.com/Openarl/PathOfBuilding/{branch}/runtime-win32.zip" part="runtime" platform="win32"/>
-	<File sha1="74cd89091c4db01f0673217a5bd0927f232391e2" name="Launch.lua" part="program"/>
-	<File sha1="72b9bea1871e94a643e4471fd84bbedbc7810336" name="UpdateCheck.lua" part="program"/>
-	<File sha1="4f17937f2b37784e169a3792b235f2a0a3961e61" name="UpdateApply.lua" part="program"/>
-	<File sha1="4be21620b1c7149c7dca35c883bd8b7dd2c5eea9" name="GameVersions.lua" part="program"/>
-	<File sha1="309dabf6c0322c4f972b565d9e198f8d2cb7a8b6" name="changelog.txt" part="program"/>
-	<File sha1="b093a2709f30c1f83ce5ba9df88c80f22c1beb4a" name="Classes/BuildListControl.lua" part="program"/>
-	<File sha1="16fc5eaa04cc14b2022f6705a12717935454dab0" name="Classes/ButtonControl.lua" part="program"/>
-	<File sha1="d91c206afbe018ad8573280254e958d982fa4b5f" name="Classes/CalcBreakdownControl.lua" part="program"/>
-	<File sha1="7f3747edd121907622e075ce3fd0a2abf1577c3f" name="Classes/CalcSectionControl.lua" part="program"/>
-	<File sha1="c195cbe31e7c2f76e2c7f76535495ff2b188c9b8" name="Classes/CalcsTab.lua" part="program"/>
-	<File sha1="d2e5a1d2717da6853a9c5e788bc45c309d925e77" name="Classes/CheckBoxControl.lua" part="program"/>
-	<File sha1="ab06b5a5717be18b05b7aea5ba8d0439c3370205" name="Classes/ConfigTab.lua" part="program"/>
-	<File sha1="64fc5fd8e3d4ade976f51c4a28d782b9b2ad31ac" name="Classes/Control.lua" part="program"/>
-	<File sha1="8bc9c45c9223fb0d51e67cde556849678862817a" name="Classes/ControlHost.lua" part="program"/>
-	<File sha1="5efd9a36853d6fb5214a9e4b88a5ca94d470b44f" name="Classes/DropDownControl.lua" part="program"/>
-	<File sha1="8e8340df34a9a27374fe48e0ebcb633ef03af550" name="Classes/EditControl.lua" part="program"/>
-	<File sha1="bcb52d02b8ca9288be255219956d6f0bc4efeedd" name="Classes/FolderListControl.lua" part="program"/>
-	<File sha1="d64d726b51a5d25dcfcccd674722e88dae60b76e" name="Classes/GemSelectControl.lua" part="program"/>
-	<File sha1="3f894501b2b59276c010b78e8f8ccfccc61f9bcc" name="Classes/ImportTab.lua" part="program"/>
-	<File sha1="fdb40edb425ca2dcc4dba6c2e400ff76a9f8b34d" name="Classes/Item.lua" part="program"/>
-	<File sha1="10a80027f6c1f27893ba08c3a1b4c5a56aefc151" name="Classes/ItemDBControl.lua" part="program"/>
-	<File sha1="8298506b88cea37e78c1c5faebc05335b3ace240" name="Classes/ItemListControl.lua" part="program"/>
-	<File sha1="7ecee459d3c477b46c6b6115bfeb2480995e17ed" name="Classes/ItemSetListControl.lua" part="program"/>
-	<File sha1="ce1f69ab2716013511aeca61fb4e9867c77abb3a" name="Classes/ItemSlotControl.lua" part="program"/>
-	<File sha1="24acd5cd21cb8baa0b3f7d1c99801e02d084d4d0" name="Classes/ItemsTab.lua" part="program"/>
-	<File sha1="d2ffe0071641c07b63d152c0f48b691eba0cffb0" name="Classes/LabelControl.lua" part="program"/>
-	<File sha1="45ec0b7e2345533caca3f4eb6575298bc280d6a2" name="Classes/ListControl.lua" part="program"/>
-	<File sha1="f7281f889c87c8de45d5af4243c49d9998d4a272" name="Classes/MinionListControl.lua" part="program"/>
-	<File sha1="b67204a03fc51b91cb3e73c398e57ebc50dd9df1" name="Classes/ModDB.lua" part="program"/>
-	<File sha1="2fa5f20b12a4b366dc4b28a2a873699b834766d6" name="Classes/ModList.lua" part="program"/>
-	<File sha1="dcd61c9b14509a09554f109602f5c0e797374f27" name="Classes/ModStore.lua" part="program"/>
-	<File sha1="cc7c5eff58c2868cdc7d4c1bf9a967aa8c448c9e" name="Classes/NotesTab.lua" part="program"/>
-	<File sha1="85735f795096fff6ddbb6551be397d409e5a4f5b" name="Classes/PassiveSpec.lua" part="program"/>
-	<File sha1="d449391ea879a20728f7e9a0345398c0141a45f6" name="Classes/PassiveSpecListControl.lua" part="program"/>
-	<File sha1="251d4315696c0c540a56fad32f0931312aefd37e" name="Classes/PassiveTree.lua" part="program"/>
-	<File sha1="001742dc39dcd7bf0eb7da70e6b202824295892b" name="Classes/PassiveTreeView.lua" part="program"/>
-	<File sha1="3acd77612e658766260129ffab70373d8ee60c59" name="Classes/PathControl.lua" part="program"/>
-	<File sha1="2bfb5bb91475432d23a29c1eb36daec2d76914f0" name="Classes/PopupDialog.lua" part="program"/>
-	<File sha1="0690e86bb59d80be8ec3cbd0c902d54850338371" name="Classes/ScrollBarControl.lua" part="program"/>
-	<File sha1="35e760f9dd2a5fc51ab9e5ba7f0e9e37eaad1c5a" name="Classes/SectionControl.lua" part="program"/>
-	<File sha1="917978ae386092c1d37b2bf121fbc9107e4d2b6b" name="Classes/SharedItemListControl.lua" part="program"/>
-	<File sha1="441ad6269d2992ee1de9e249ecbb4638653bcbde" name="Classes/SharedItemSetListControl.lua" part="program"/>
-	<File sha1="c3ac5329ade721b25e7ae38563368d6e71791f5a" name="Classes/SkillListControl.lua" part="program"/>
-	<File sha1="5931dadab66caaee0d070a59f2acde839d5ef6d7" name="Classes/SkillsTab.lua" part="program"/>
-	<File sha1="c6dea22945dcfa8b2a681468ed8dab16eeae7929" name="Classes/SliderControl.lua" part="program"/>
-	<File sha1="bb62a34443d64f21c5f0e3e00cae736a8eb6bd87" name="Classes/TextListControl.lua" part="program"/>
-	<File sha1="a9c6a1965fb2d7b7435bd635cd4241ee6e771ec9" name="Classes/Tooltip.lua" part="program"/>
-	<File sha1="23274906162877c09d2119237414b6747a0e6cea" name="Classes/TooltipHost.lua" part="program"/>
-	<File sha1="d5cfc4a40f4a2514186ea373e1e37904b1686c63" name="Classes/TreeTab.lua" part="program"/>
-	<File sha1="ce4835c384c834da0de47b0302b1e774c8300c6b" name="Classes/UndoHandler.lua" part="program"/>
-	<File sha1="f1c0eec51cf78d1955cd375bafad6f557134321e" name="Modules/Build.lua" part="program"/>
-	<File sha1="bcda0c5148b9e40274acd13702896cc430c89eba" name="Modules/BuildList.lua" part="program"/>
-	<File sha1="af0c71e966bcf55ab39f66790532bad7d5a323a7" name="Modules/CalcActiveSkill.lua" part="program"/>
-	<File sha1="2408b55c894b81fbcd0456a3540cdb07c5a7c4a1" name="Modules/CalcBreakdown.lua" part="program"/>
-	<File sha1="f49b47b90a18902c30db9693a7949172c72944e7" name="Modules/CalcDefence-2_6.lua" part="program"/>
-	<File sha1="62f0fafbec4dd52394cfa27e23e320f5ea8cdf7f" name="Modules/CalcDefence-3_0.lua" part="program"/>
-	<File sha1="fdfcb2daf9f582e3d2fa065c4b61ecfe66d8ba4f" name="Modules/CalcOffence-2_6.lua" part="program"/>
-	<File sha1="73965dc6a6db5c3ff336bbf52b882d36cd2cea96" name="Modules/CalcOffence-3_0.lua" part="program"/>
-	<File sha1="9ed0548ef1caedb8fbfa2de983f218e42a1ce3f9" name="Modules/CalcPerform.lua" part="program"/>
-	<File sha1="582806808b1646f18bfde93db45658d66c4569d8" name="Modules/Calcs.lua" part="program"/>
-	<File sha1="32da2a949a5fe0ab10d54078a96caff0dccb5f3f" name="Modules/CalcSections-2_6.lua" part="program"/>
-	<File sha1="b0540699c6309faa3dcb6666696a7224b1f7d29c" name="Modules/CalcSections-3_0.lua" part="program"/>
-	<File sha1="e937bbc21e115e8ed2794867bbf8b23eb2842c2f" name="Modules/CalcSetup.lua" part="program"/>
-	<File sha1="3c92a7629f7e3a5b7eafae6ee4a0b03ae86420b8" name="Modules/CalcTools.lua" part="program"/>
-	<File sha1="fef899d2413e9fa67df808e4f6de533b263ddcd7" name="Modules/Common.lua" part="program"/>
-	<File sha1="7feaf8138551e90d6de4cd49b6c9969980d2a5eb" name="Modules/ConfigOptions.lua" part="program"/>
-	<File sha1="b506939cd7f627edb6ec29c6132ea942e97e6765" name="Modules/Data.lua" part="program"/>
-	<File sha1="d74918586d5ae396fc9bea4c4b6e4aa6bfad8d3e" name="Modules/ItemTools.lua" part="program"/>
-	<File sha1="e5d6aaa67de05434ba86623d89c42514ec8e7b8d" name="Modules/Main.lua" part="program"/>
-	<File sha1="fc2d3bdf7a4e57894b3d04beb83485cc6dcc5e26" name="Modules/ModParser-2_6.lua" part="program"/>
-	<File sha1="7b2009757c5cd09bf24c2dcf68d16a1587905379" name="Modules/ModParser-3_0.lua" part="program"/>
-	<File sha1="2ce4f3b83db992a286bd92f3849d037d6dcc8db2" name="Modules/ModTools.lua" part="program"/>
-	<File sha1="6b0b5ac8fdb764b47fd7a1657bd470bd275f9069" name="Modules/StatDescriber.lua" part="program"/>
-	<File sha1="c345cdcf374d271411aa424ab150c0edbb5a362d" name="Assets/game_ui_small.png" part="program"/>
-	<File sha1="97b020d8213e09c313536a91528ba5d5ebc4ca0a" name="Assets/patreon_logo.png" part="program"/>
-	<File sha1="4ebea5031fd03771a9b637a3fdccf394344e4782" name="Assets/range_guide.png" part="program"/>
-	<File sha1="e7ee7e5b6388facb7bf568517ecc401590757df7" name="Assets/ring.png" part="program"/>
-	<File sha1="9a320bfe629b1cf3f14fc77fbbf2508d0a5b2841" name="Assets/small_ring.png" part="program"/>
-	<File sha1="31557624a3065d2f6ea1f8a22f4867cce8904d02" name="Data/Global.lua" part="program"/>
-	<File sha1="5cc6eebe60c60e21b76ddc4cf257ee44f937463a" name="Data/New.lua" part="program"/>
-	<File sha1="d04ccfebe8b7245bc9fbc1cd8507cce41b4a58f2" name="Data/Uniques/amulet.lua" part="program"/>
-	<File sha1="56d843be627814777b2bbef14c3027688c3dfb4e" name="Data/Uniques/axe.lua" part="program"/>
-	<File sha1="967fcb4328461798da9b0f99a8c28ee90d70dcb7" name="Data/Uniques/belt.lua" part="program"/>
-	<File sha1="2b33cbadfe99d6f90f445caf73a6a3c77130db16" name="Data/Uniques/body.lua" part="program"/>
-	<File sha1="01c1faebc890abaefed103f97a64afe4b6cfa34c" name="Data/Uniques/boots.lua" part="program"/>
-	<File sha1="c8e0c83c5eebc44433d38148c4dd6d8c116ea52a" name="Data/Uniques/bow.lua" part="program"/>
-	<File sha1="7df6eb13d15c142d09f3a58c840b78eb329dee29" name="Data/Uniques/claw.lua" part="program"/>
-	<File sha1="30522f064fb7c07c39cf6421fba10ca66115c296" name="Data/Uniques/dagger.lua" part="program"/>
-	<File sha1="aed8c04554b29f1328c8158a1fcbe11f896d21da" name="Data/Uniques/flask.lua" part="program"/>
-	<File sha1="c896056012604656604ff811c327dab8e4795c5e" name="Data/Uniques/gloves.lua" part="program"/>
-	<File sha1="c18bdc16c7616f053c695401fecbcd9876fa140f" name="Data/Uniques/helmet.lua" part="program"/>
-	<File sha1="3a9ce53f75ef7bd34657105ed92f75739fb4bfb1" name="Data/Uniques/jewel.lua" part="program"/>
-	<File sha1="0de1a49fcc9f069334a4585af6a4c15a3438a0af" name="Data/Uniques/mace.lua" part="program"/>
-	<File sha1="cfd77a3d679eade7932e89add801ee39f0a3cf91" name="Data/Uniques/quiver.lua" part="program"/>
-	<File sha1="083f33e0099c5e439ee8f8043c4465eaa25183f0" name="Data/Uniques/ring.lua" part="program"/>
-	<File sha1="3df40502c1f1bb1ef400ff995f9790c8b494067c" name="Data/Uniques/shield.lua" part="program"/>
-	<File sha1="3144e9b35462a549dff42c1b031a9667f1b3eb39" name="Data/Uniques/staff.lua" part="program"/>
-	<File sha1="7a3d7dbd9df30707dd7546dffc5c6cc8a158c33e" name="Data/Uniques/sword.lua" part="program"/>
-	<File sha1="f039ab590f5d90d149339577900dc278a5f72491" name="Data/Uniques/wand.lua" part="program"/>
-	<File sha1="4a2651bfcb3beb6fe8b9acab18a6792072f7e9b4" name="Data/2_6/EnchantmentBoots.lua" part="program"/>
-	<File sha1="cc36a59b04a69c76ef76f5b6bc6899fd0ee1666e" name="Data/2_6/EnchantmentGloves.lua" part="program"/>
-	<File sha1="b305198cafc6800aa5556da07a5eea699c718d3b" name="Data/2_6/EnchantmentHelmet.lua" part="program"/>
-	<File sha1="170d14d9176a1d7425d4bfa1b3bcc08c5f4fe73c" name="Data/2_6/Essence.lua" part="program"/>
-	<File sha1="0d124348e8ec0aa3944c68e2789aea2e82dbd740" name="Data/2_6/Gems.lua" part="program"/>
-	<File sha1="2fbdc82acb8016c40d91ae77a8a8cee914b85d81" name="Data/2_6/Minions.lua" part="program"/>
-	<File sha1="9a5c9b0a3f75ba2c573376d53a8cf87a54ac8a96" name="Data/2_6/Misc.lua" part="program"/>
-	<File sha1="31396cc76162aa98fe06a39bc149c09c45200040" name="Data/2_6/ModCache.lua" part="program"/>
-	<File sha1="d96fc1e31349cb8aba1336c1f356b69ff436269b" name="Data/2_6/ModFlask.lua" part="program"/>
-	<File sha1="19036f1ef6a61d5cb673ef1fd4eef1ddb8bed1e3" name="Data/2_6/ModItem.lua" part="program"/>
-	<File sha1="0671f7f062f06c68ec6c659d2121620a1782fecf" name="Data/2_6/ModJewel.lua" part="program"/>
-	<File sha1="6bf966e95660cd986c2a94cfb730a426a0964781" name="Data/2_6/ModMaster.lua" part="program"/>
-	<File sha1="8ac06e060e843345ad8b3fd14e9cc262ead9cd69" name="Data/2_6/Rares.lua" part="program"/>
-	<File sha1="842ba7e78b399a9c943bb5f9002cf4d60748ae05" name="Data/2_6/SkillStatMap.lua" part="program"/>
-	<File sha1="7ba7a3bc11cb3dbbb269d2efcca06cc740254f4f" name="Data/2_6/Spectres.lua" part="program"/>
-	<File sha1="4538254d9b6867e463d0c95022cd574c9a89c783" name="Data/2_6/Bases/amulet.lua" part="program"/>
-	<File sha1="3ae2b135f2081039ac5917a20e39de000e01000e" name="Data/2_6/Bases/axe.lua" part="program"/>
-	<File sha1="4f9d73ef3f59866a64cbc5836b9bc5210c619224" name="Data/2_6/Bases/belt.lua" part="program"/>
-	<File sha1="f70b2fe71f7787b1f4a3c364ba0d359f21221a8d" name="Data/2_6/Bases/body.lua" part="program"/>
-	<File sha1="df8d1ed2298d203caeff6d55553b996f9375b679" name="Data/2_6/Bases/boots.lua" part="program"/>
-	<File sha1="01b66c55d9722b39b584880efa0347696c7f47c2" name="Data/2_6/Bases/bow.lua" part="program"/>
-	<File sha1="55cd289d21bba64ee017770278a0beb9ade08854" name="Data/2_6/Bases/claw.lua" part="program"/>
-	<File sha1="1ea544481024738aadd42e80864cf19dbe640580" name="Data/2_6/Bases/dagger.lua" part="program"/>
-	<File sha1="2b0612f9de80f97c168919a2b91bb4d01af97123" name="Data/2_6/Bases/flask.lua" part="program"/>
-	<File sha1="cc9865d7d4fe62bd6005d0d8ac34602616cad975" name="Data/2_6/Bases/gloves.lua" part="program"/>
-	<File sha1="5637471b83bc5d7e374f2af4d635c0e4a9b9d4fd" name="Data/2_6/Bases/helmet.lua" part="program"/>
-	<File sha1="768eea50f8995473c66d39b507f3f3d9a8d9a75a" name="Data/2_6/Bases/jewel.lua" part="program"/>
-	<File sha1="0886861547b564906c0d29eedd662172e4fdaadd" name="Data/2_6/Bases/mace.lua" part="program"/>
-	<File sha1="19523099a7ec81317c6cd8e14366d6b85a3599ab" name="Data/2_6/Bases/quiver.lua" part="program"/>
-	<File sha1="9291f3eafc2749b7d1cd4732406d6bcc5b6f2abe" name="Data/2_6/Bases/ring.lua" part="program"/>
-	<File sha1="5c3c81c17d4c1d1481f0d0cf45267185632d31fe" name="Data/2_6/Bases/shield.lua" part="program"/>
-	<File sha1="d86048fae69d25db4d20ef6aaa867e769bc1626e" name="Data/2_6/Bases/staff.lua" part="program"/>
-	<File sha1="6e894851b10cafbdd00d8ce5eaa44a25bd712d71" name="Data/2_6/Bases/sword.lua" part="program"/>
-	<File sha1="c8d18eddf62b1b3ba22fb3233da329a29a200f4b" name="Data/2_6/Bases/wand.lua" part="program"/>
-	<File sha1="ec37909b9d4bba33d68d2ab91744956b835d27b1" name="Data/2_6/Skills/act_dex.lua" part="program"/>
-	<File sha1="9114076b8a213fdda01a4307fff031e3c77e15fe" name="Data/2_6/Skills/act_int.lua" part="program"/>
-	<File sha1="fbb92d3cf35261e9b1a90ad4090ec7dce70b7785" name="Data/2_6/Skills/act_str.lua" part="program"/>
-	<File sha1="a7b57aa42617334e532173d9ee275d9633628f36" name="Data/2_6/Skills/glove.lua" part="program"/>
-	<File sha1="cfa3597b4aceff8e519f0bd04a685b1dfe716eba" name="Data/2_6/Skills/minion.lua" part="program"/>
-	<File sha1="aa58c860e606ac3f99151f597376f4a1f930eed6" name="Data/2_6/Skills/other.lua" part="program"/>
-	<File sha1="679a20a3f7ab566ccc5d4095844b29a88e88b929" name="Data/2_6/Skills/spectre.lua" part="program"/>
-	<File sha1="497ff50f4ec90ce331b431598bdf5b142d2858a9" name="Data/2_6/Skills/sup_dex.lua" part="program"/>
-	<File sha1="f1376f24e3efb1359fe636fd22d64fe6fc61aa43" name="Data/2_6/Skills/sup_int.lua" part="program"/>
-	<File sha1="7b2113799018833a76908d024c8b5aa937324483" name="Data/2_6/Skills/sup_str.lua" part="program"/>
-	<File sha1="94b77c91487b78185ff26605c5fc4e41ce6c7f8b" name="Data/3_0/EnchantmentBoots.lua" part="program"/>
-	<File sha1="1fcdacb6f5e454b41163c0ddef1e4aa3444fe0fb" name="Data/3_0/EnchantmentGloves.lua" part="program"/>
-	<File sha1="e9c8a9cb77a4b3335036bce6374cfe1a82eb302c" name="Data/3_0/EnchantmentHelmet.lua" part="program"/>
-	<File sha1="05bf7be7aa8219e16fba64aca2cdb7bd262c4339" name="Data/3_0/Essence.lua" part="program"/>
-	<File sha1="7a678a4d874cecc2b31e06e0549df1d49f6656ff" name="Data/3_0/Gems.lua" part="program"/>
-	<File sha1="adb21034a36b059f54363b9995d790c8d6b7f39c" name="Data/3_0/Minions.lua" part="program"/>
-	<File sha1="ae310ea401f6ad8a10e048d57cbc10178d1f4da3" name="Data/3_0/Misc.lua" part="program"/>
-	<File sha1="ccf0599d33b6e21d63da47b729d98c99f79eeb14" name="Data/3_0/ModCache.lua" part="program"/>
-	<File sha1="4d63f91c23e7a4ac481b8ad7bae9e70bb46200c6" name="Data/3_0/ModFlask.lua" part="program"/>
-	<File sha1="272a32ab3acd6c3476e63a98b17d434c7db2e5fb" name="Data/3_0/ModItem.lua" part="program"/>
-	<File sha1="f708ff3d8d15911980ccd1ee91e76a45f083b741" name="Data/3_0/ModJewel.lua" part="program"/>
-	<File sha1="81d71f84f0ff16c4d45415e9c6f12f5282313413" name="Data/3_0/ModJewelAbyss.lua" part="program"/>
-	<File sha1="3239982439814f451aa948167f1cc4845be95b3c" name="Data/3_0/ModMaster.lua" part="program"/>
-	<File sha1="f1a52475b331c1c644145760342017a65f8d40fc" name="Data/3_0/Rares.lua" part="program"/>
-	<File sha1="0dfa60796615b7da8a6a48ddfa7516e2e2152478" name="Data/3_0/SkillStatMap.lua" part="program"/>
-	<File sha1="54ba5008fd8cb1a88aa3c04e92721e30c116ef54" name="Data/3_0/Spectres.lua" part="program"/>
-	<File sha1="95dfa07c930fd5178baaac5d8a23dfbaeaa56edf" name="Data/3_0/Bases/amulet.lua" part="program"/>
-	<File sha1="9292f38aa5c33e044e775a1df62d60cfc48e4e66" name="Data/3_0/Bases/axe.lua" part="program"/>
-	<File sha1="c69a5cce068314f65bb9f5f0fd2577be7ac0f1cd" name="Data/3_0/Bases/belt.lua" part="program"/>
-	<File sha1="5a9238d084698a2d36bd73d6d042493c4949b71f" name="Data/3_0/Bases/body.lua" part="program"/>
-	<File sha1="2ae3b0d76c7fb5840befefa2664831c659707b3c" name="Data/3_0/Bases/boots.lua" part="program"/>
-	<File sha1="939580b5c10f21e4d9cde26929bb9955e22f13fc" name="Data/3_0/Bases/bow.lua" part="program"/>
-	<File sha1="feec29f491d2ff239d6441543375ff7f80ff3a4c" name="Data/3_0/Bases/claw.lua" part="program"/>
-	<File sha1="7b9415341e8b254bc30d05ced401073657f69ac9" name="Data/3_0/Bases/dagger.lua" part="program"/>
-	<File sha1="057772b3b2e3525f2caeaf7a9732eaab5b055bd4" name="Data/3_0/Bases/flask.lua" part="program"/>
-	<File sha1="1486365549d7ddd029c09da5cf36080fc7d9189e" name="Data/3_0/Bases/gloves.lua" part="program"/>
-	<File sha1="4cd0c68aefcae4fe93a082af20ebccf25f3600dd" name="Data/3_0/Bases/helmet.lua" part="program"/>
-	<File sha1="083f846560679d903d088eda9794b42d3fdf490c" name="Data/3_0/Bases/jewel.lua" part="program"/>
-	<File sha1="2928471a828e4e32604f0153ff74bf2ec6ae9ae2" name="Data/3_0/Bases/mace.lua" part="program"/>
-	<File sha1="5982f667bfeccd7e2b978f3955a5b96fe88aba93" name="Data/3_0/Bases/quiver.lua" part="program"/>
-	<File sha1="d7b43fd70235a7ac9010ed265a12d4b1e7182b77" name="Data/3_0/Bases/ring.lua" part="program"/>
-	<File sha1="eb0485638eb1f1632c5b7e414ff9c4a0c99d12e5" name="Data/3_0/Bases/shield.lua" part="program"/>
-	<File sha1="439c3c038cdbc6133367fecfe119dd13d8248775" name="Data/3_0/Bases/staff.lua" part="program"/>
-	<File sha1="2c0bb96c9310711060beb010b282018bc1425cbd" name="Data/3_0/Bases/sword.lua" part="program"/>
-	<File sha1="5ee7725728e14929c4339eded5e19aa15f55e803" name="Data/3_0/Bases/wand.lua" part="program"/>
-	<File sha1="b94ccee3abf90551c66e3520d11f8ae7499a2911" name="Data/3_0/Skills/act_dex.lua" part="program"/>
-	<File sha1="cc01d4a65e5ff0e193c6cd957a0d73080ac3ee8e" name="Data/3_0/Skills/act_int.lua" part="program"/>
-	<File sha1="c197c977f1af490ca66c1f2d7fc1d42efff8b0fe" name="Data/3_0/Skills/act_str.lua" part="program"/>
-	<File sha1="5588b65dd69431c775af937d9db59e242ce23647" name="Data/3_0/Skills/glove.lua" part="program"/>
-	<File sha1="88d624836ae96f9036aa1264dcb4da4750cd7699" name="Data/3_0/Skills/minion.lua" part="program"/>
-	<File sha1="d0940c85ab07c8d1ab1fe35f61da68430465ef00" name="Data/3_0/Skills/other.lua" part="program"/>
-	<File sha1="3d236ea161a34bdc440fb07d9d371b7a0fc567e1" name="Data/3_0/Skills/spectre.lua" part="program"/>
-	<File sha1="c555d9205caa3ea6e12619eeffcf10d72e165e45" name="Data/3_0/Skills/sup_dex.lua" part="program"/>
-	<File sha1="beae2cee21cef4da714c8a554de372ff28918a92" name="Data/3_0/Skills/sup_int.lua" part="program"/>
-	<File sha1="3d4b42062433a25bab078c3a45576e46d52c0367" name="Data/3_0/Skills/sup_str.lua" part="program"/>
-	<File sha1="35cc503815893143504a9109191f6469e3a0e902" name="Data/3_0/StatDescriptions/active_skill_gem_stat_descriptions.lua" part="program"/>
-	<File sha1="3c86e0db7e27e95d1ceebd3beeed89e8248f9250" name="Data/3_0/StatDescriptions/aura_skill_stat_descriptions.lua" part="program"/>
-	<File sha1="eeb9f2acc81f104b066a5c7c1a7c8e37d1c48b36" name="Data/3_0/StatDescriptions/banner_aura_skill_stat_descriptions.lua" part="program"/>
-	<File sha1="37462abd0417b82b89e30ab36191b32869c18aa1" name="Data/3_0/StatDescriptions/beam_skill_stat_descriptions.lua" part="program"/>
-	<File sha1="9f7429786065be0619854ebe5541490fb13e938f" name="Data/3_0/StatDescriptions/brand_skill_stat_descriptions.lua" part="program"/>
-	<File sha1="f110532addb4086bca044933c6a83f2b18af155f" name="Data/3_0/StatDescriptions/buff_skill_stat_descriptions.lua" part="program"/>
-	<File sha1="c5e6249c1bcd49b2f36ddd36fb1e407308220461" name="Data/3_0/StatDescriptions/curse_skill_stat_descriptions.lua" part="program"/>
-	<File sha1="c36a4a5102dfafb468758999cd5e19c3014e2a8d" name="Data/3_0/StatDescriptions/debuff_skill_stat_descriptions.lua" part="program"/>
-	<File sha1="b603ec84e05e5fad7fb1c868362edcaedf60a26b" name="Data/3_0/StatDescriptions/gem_stat_descriptions.lua" part="program"/>
-	<File sha1="bd2824418e3c6d346e2bd292f9b7e7eecd473fc3" name="Data/3_0/StatDescriptions/minion_attack_skill_stat_descriptions.lua" part="program"/>
-	<File sha1="8794bbba79e883e00f88d265624f6f897b5b6803" name="Data/3_0/StatDescriptions/minion_skill_stat_descriptions.lua" part="program"/>
-	<File sha1="0e63b7f3c04f944d38077d4680dcad51512fffac" name="Data/3_0/StatDescriptions/minion_spell_skill_stat_descriptions.lua" part="program"/>
-	<File sha1="5492efa0312ce060ae723b608b5752a7104c9846" name="Data/3_0/StatDescriptions/monster_stat_descriptions.lua" part="program"/>
-	<File sha1="2d4383b494b8affdec8d2fe494ed8e7a7c8b1126" name="Data/3_0/StatDescriptions/offering_skill_stat_descriptions.lua" part="program"/>
-	<File sha1="9c8f6b6a02736e4e800b50f772d4a75e50426d72" name="Data/3_0/StatDescriptions/skill_stat_descriptions.lua" part="program"/>
-	<File sha1="ad5375f3183145e0ec72730d0e8c74fb1b2c590c" name="Data/3_0/StatDescriptions/stat_descriptions.lua" part="program"/>
-	<File sha1="c10e87b9b02f65dac7ea0e533115e1ada7c198d8" name="Data/3_0/StatDescriptions/variable_duration_skill_stat_descriptions.lua" part="program"/>
-	<File platform="win32" sha1="7e5a3242c9a4296dc8377feb4c9d824f3f0a3cc1" name="Path of Building.exe" part="runtime"/>
-	<File platform="win32" sha1="7a973d3c0b5121e6aad0dcb9323be5b432fc63e7" name="lua51.dll" part="runtime"/>
-	<File platform="win32" sha1="d852ae6eafc9be62aa41d3cb74fb986d0e5b40e5" name="SimpleGraphic.dll" part="runtime"/>
-	<File platform="win32" sha1="5f68674e22a389dddeb72078b7d9d69d29881bdd" name="libcurl.dll" part="runtime"/>
-	<File platform="win32" sha1="fe399dbe89c02c597bbad8323ef5c29b24af4870" name="lcurl.dll" part="runtime"/>
-	<File platform="win32" sha1="fe73e74330bf2943036139c32a5c773558fc62a5" name="lzip.dll" part="runtime"/>
-	<File sha1="74cc6c47e7cda18211e57b9e062368eab3c26bab" name="SimpleGraphic/Fonts/Bitstream Vera Sans Mono.10.tga" part="runtime"/>
-	<File sha1="1977206f0efc5035834ecbf93ca7d046010d8aab" name="SimpleGraphic/Fonts/Bitstream Vera Sans Mono.12.tga" part="runtime"/>
-	<File sha1="93a4309dc814914be7d2dee708e3821494f145a2" name="SimpleGraphic/Fonts/Bitstream Vera Sans Mono.14.tga" part="runtime"/>
-	<File sha1="274665d752f1637c7e2be215c5ca7ea43df7d5e0" name="SimpleGraphic/Fonts/Bitstream Vera Sans Mono.16.tga" part="runtime"/>
-	<File sha1="3cd1d874cf6f75b4fd2d67e3060f9a7dbd89c9d1" name="SimpleGraphic/Fonts/Bitstream Vera Sans Mono.18.tga" part="runtime"/>
-	<File sha1="2411cf67aa67efede08830d350b1b08c94d6ea7b" name="SimpleGraphic/Fonts/Bitstream Vera Sans Mono.20.tga" part="runtime"/>
-	<File sha1="730fbfe488f47c0da6711f0e20c23e0c005148b0" name="SimpleGraphic/Fonts/Bitstream Vera Sans Mono.24.tga" part="runtime"/>
-	<File sha1="b6d5cc14c7336366b2b6036f781ca1c2ae00b638" name="SimpleGraphic/Fonts/Bitstream Vera Sans Mono.28.tga" part="runtime"/>
-	<File sha1="8c339846aac3a4c739750efe722816d86c56571a" name="SimpleGraphic/Fonts/Bitstream Vera Sans Mono.32.tga" part="runtime"/>
-	<File sha1="3a92b9f013871dc92211c7bba78a1c9669b443d4" name="SimpleGraphic/Fonts/Bitstream Vera Sans Mono.tgf" part="runtime"/>
-	<File sha1="88809ae34ea7d14500e1ad9bb17e74f6bd50f72e" name="SimpleGraphic/Fonts/Liberation Sans Bold.10.tga" part="runtime"/>
-	<File sha1="a42436255ca10b47934ad428c60d209da2c77f41" name="SimpleGraphic/Fonts/Liberation Sans Bold.12.tga" part="runtime"/>
-	<File sha1="d720f0c0c3c6d2bea38d52edb7ba73bff71eb501" name="SimpleGraphic/Fonts/Liberation Sans Bold.14.tga" part="runtime"/>
-	<File sha1="68ea1a3846198aae66f63a70abcf9b023b3c469f" name="SimpleGraphic/Fonts/Liberation Sans Bold.16.tga" part="runtime"/>
-	<File sha1="d9abed6557034288442ba1f6ee557ab8ac616a85" name="SimpleGraphic/Fonts/Liberation Sans Bold.18.tga" part="runtime"/>
-	<File sha1="cd39f6277e61c3e6bae24ffca3db64ade0cdb385" name="SimpleGraphic/Fonts/Liberation Sans Bold.20.tga" part="runtime"/>
-	<File sha1="909ed51261062dcc236a5d8f098d0b27defa9c48" name="SimpleGraphic/Fonts/Liberation Sans Bold.24.tga" part="runtime"/>
-	<File sha1="9c492dab86435d5afc634485d7ed3a7989cd4c08" name="SimpleGraphic/Fonts/Liberation Sans Bold.28.tga" part="runtime"/>
-	<File sha1="e8927530dc94099ce5d5f92568d29b1e3dc1dc7f" name="SimpleGraphic/Fonts/Liberation Sans Bold.32.tga" part="runtime"/>
-	<File sha1="704c68c7f87906e7b2159a0f0e0cb7160861178e" name="SimpleGraphic/Fonts/Liberation Sans Bold.tgf" part="runtime"/>
-	<File sha1="24b476e990fe5804df7264f225b6db63ad956907" name="SimpleGraphic/Fonts/Liberation Sans.10.tga" part="runtime"/>
-	<File sha1="ec96b2a3d13ea40ac5a9cdcb1a1bf9702461a2df" name="SimpleGraphic/Fonts/Liberation Sans.12.tga" part="runtime"/>
-	<File sha1="8e698d7b5701d0fff9594394eb789526ba65547e" name="SimpleGraphic/Fonts/Liberation Sans.14.tga" part="runtime"/>
-	<File sha1="37e84115416caeb52e6e65b37e0f378bcfe14447" name="SimpleGraphic/Fonts/Liberation Sans.16.tga" part="runtime"/>
-	<File sha1="3db0c18bc2333570598381aff2a103fc786d27db" name="SimpleGraphic/Fonts/Liberation Sans.18.tga" part="runtime"/>
-	<File sha1="f2f757885b1359164c78b11108a7d2f1beb0a706" name="SimpleGraphic/Fonts/Liberation Sans.20.tga" part="runtime"/>
-	<File sha1="6a5e5a131dd6ec31304d3889c1dacb326ccf0a03" name="SimpleGraphic/Fonts/Liberation Sans.24.tga" part="runtime"/>
-	<File sha1="3175f25ff2ba00f95f10078bea790ff591943c46" name="SimpleGraphic/Fonts/Liberation Sans.28.tga" part="runtime"/>
-	<File sha1="526edb97597a06ed0d9689107a4e130a22faf810" name="SimpleGraphic/Fonts/Liberation Sans.32.tga" part="runtime"/>
-	<File sha1="31fdef9c0e2ad46df47123e7d81f5e8d4fe399ed" name="SimpleGraphic/Fonts/Liberation Sans.tgf" part="runtime"/>
-	<File sha1="18629865eb351e483178b6524fb3935cbc9b8297" name="lua/base64.lua" part="runtime"/>
-	<File sha1="16cbc26080996d9da827df42cb0844a25518eeb3" name="lua/dkjson.lua" part="runtime"/>
-	<File sha1="31e325cd40a9c0234c6265689cf70b97ef676f20" name="lua/sha1.lua" part="runtime"/>
-	<File sha1="859e09104842f91a4aaa9a4d9fadf667535877e2" name="lua/xml.lua" part="runtime"/>
-	<File sha1="77e4564761c38c755bee821f512e574d62b3a3b7" name="TreeData/Background1.png" part="tree"/>
-	<File sha1="11ac1fcb1bd0ffef54dc478e1e6b3e23823bfb18" name="TreeData/BackgroundDex.png" part="tree"/>
-	<File sha1="424f67c77c905291f140074f790ebfbd3a7b9a9b" name="TreeData/BackgroundDexInt.png" part="tree"/>
-	<File sha1="b9871a87c189bcc55b4b76c9e1b341f6d3099deb" name="TreeData/BackgroundInt.png" part="tree"/>
-	<File sha1="6d81b45041b510b0162d1c32c0c358627972c507" name="TreeData/BackgroundStr.png" part="tree"/>
-	<File sha1="81f57fc4c4138b922c9c45d7ef3af9c2643063d8" name="TreeData/BackgroundStrDex.png" part="tree"/>
-	<File sha1="1b02b0aec15ede4761a7fae1a9a108e8f958d13e" name="TreeData/BackgroundStrInt.png" part="tree"/>
-	<File sha1="8f37a253911a0019cfdea301075f28dee41ae675" name="TreeData/BlightedNotableFrameAllocated.png" part="tree"/>
-	<File sha1="955d47ef4f110d059b2d691b57f370a580d7f805" name="TreeData/BlightedNotableFrameCanAllocate.png" part="tree"/>
-	<File sha1="5e36a22cd35dcf53871b6302e78c18a677baeda2" name="TreeData/BlightedNotableFrameUnallocated.png" part="tree"/>
-	<File sha1="fe8783affb4fd5c43c3e18a74da279ecc38e6f28" name="TreeData/centerduelist.png" part="tree"/>
-	<File sha1="d5fa638543829b404228d9023f1cb17405664799" name="TreeData/centermarauder.png" part="tree"/>
-	<File sha1="6adabfadc5a17886e07bea0db6d665540dc73823" name="TreeData/centerranger.png" part="tree"/>
-	<File sha1="e9cfae2dda31986f7124dd1c8658651589c10976" name="TreeData/centerscion.png" part="tree"/>
-	<File sha1="04e5beade48d335c770c47eae1725ff245492e2e" name="TreeData/centershadow.png" part="tree"/>
-	<File sha1="72a4bc7d712aff2776abd98331baee0c57aa758a" name="TreeData/centertemplar.png" part="tree"/>
-	<File sha1="9fb9158a7bc51ed9391752b4322c88752d37ce95" name="TreeData/centerwitch.png" part="tree"/>
-	<File sha1="4a1be6448348a41089cf4ff1fa35111313853133" name="TreeData/ClassesAscendant.png" part="tree"/>
-	<File sha1="fd748fbcf0c29924f5818a32322e1d1134828f9f" name="TreeData/ClassesAssassin.png" part="tree"/>
-	<File sha1="2ea6be9c3cc3f2d5dbc65fbb5b0d51dfe2ae0240" name="TreeData/ClassesBerserker.png" part="tree"/>
-	<File sha1="1bb449a170f751dc282896595f0ac6d0a8238bef" name="TreeData/ClassesChampion.png" part="tree"/>
-	<File sha1="27f73668926bc3fc92ae21869f1b637682559092" name="TreeData/ClassesChieftain.png" part="tree"/>
-	<File sha1="b2c9e23636098604fd0d4016f11b5155d33d300b" name="TreeData/ClassesDeadeye.png" part="tree"/>
-	<File sha1="2c57055fdb673274ca39ecb7435af9b234c87b87" name="TreeData/ClassesElementalist.png" part="tree"/>
-	<File sha1="cf2ec8605adc294ffb4f332cae3399d68bf15688" name="TreeData/ClassesGladiator.png" part="tree"/>
-	<File sha1="294a825b73db5d6e134b103581bad1e64029317b" name="TreeData/ClassesGuardian.png" part="tree"/>
-	<File sha1="2885e12eeddf92ebe7f625338368b825f050f156" name="TreeData/ClassesHierophant.png" part="tree"/>
-	<File sha1="d18bd9060e56213215e3c759d707bd668ed8a74d" name="TreeData/ClassesInquisitor.png" part="tree"/>
-	<File sha1="3a0f2eb93b911bd53989db10c1ba3f57b7a79437" name="TreeData/ClassesJuggernaut.png" part="tree"/>
-	<File sha1="cb80494666cd105dbb6d15b4f01bc23626f50e18" name="TreeData/ClassesNecromancer.png" part="tree"/>
-	<File sha1="9d7a219a17c67f0e5db1d50e6c6e9cc80cbee1d6" name="TreeData/ClassesOccultist.png" part="tree"/>
-	<File sha1="325f836cdca0439869e8c37a677f13ee59bfb56c" name="TreeData/ClassesPathfinder.png" part="tree"/>
-	<File sha1="7b949b22e66d8b656788b0477297b0e3d9506982" name="TreeData/ClassesRaider.png" part="tree"/>
-	<File sha1="42cc31a1d98987a17303aecf8622644a6d3af857" name="TreeData/ClassesSaboteur.png" part="tree"/>
-	<File sha1="9aef4e2aca1fdd23e4912e88879fbab997156ffd" name="TreeData/ClassesSlayer.png" part="tree"/>
-	<File sha1="0aada4f66055e25842de241d428b49df3ced2abb" name="TreeData/ClassesTrickster.png" part="tree"/>
-	<File sha1="bcfa9be1d6cdbaf9f0b926fbb3c7025b7a777cd2" name="TreeData/imgPSFadeCorner.png" part="tree"/>
-	<File sha1="f3ff70a3288d63d0807a13b947cc96e87105bf7c" name="TreeData/imgPSFadeSide.png" part="tree"/>
-	<File sha1="354ceefdbbba413cb120ee65c823b2ec8cf498b7" name="TreeData/JewelFrameAllocated.png" part="tree"/>
-	<File sha1="b7902f15c86ff6bc55f8b61a3c5068b62d131b27" name="TreeData/JewelFrameCanAllocate.png" part="tree"/>
-	<File sha1="ae859797fd7741fa4b8a80c1e924eb7c696f2ca8" name="TreeData/JewelFrameUnallocated.png" part="tree"/>
-	<File sha1="4f675d3e44ee8f989fb0164a3c6e87c580374c45" name="TreeData/JewelSocketActiveAbyss.png" part="tree"/>
-	<File sha1="39796196dc48f0a5cfd648d6b87631960c165891" name="TreeData/JewelSocketActiveBlue.png" part="tree"/>
-	<File sha1="c0e4c8192a0593e2174152412c1744897c4dc79b" name="TreeData/JewelSocketActiveGreen.png" part="tree"/>
-	<File sha1="333bbd5ec8e58dbc37958fb5c5cb4cbc70df1cb8" name="TreeData/JewelSocketActivePrismatic.png" part="tree"/>
-	<File sha1="32487978b9c0ec456b8a4b8f189c84d3c86ae21c" name="TreeData/JewelSocketActiveRed.png" part="tree"/>
-	<File sha1="5245118418a446ff8bcdfcf821136c6fbc0522b9" name="TreeData/KeystoneFrameAllocated.png" part="tree"/>
-	<File sha1="44b9d99ec9f3cc21d6ad9c14a3dff547f89641f7" name="TreeData/KeystoneFrameCanAllocate.png" part="tree"/>
-	<File sha1="0630de48ca2f34cdad37076673691f626936b6ba" name="TreeData/KeystoneFrameUnallocated.png" part="tree"/>
-	<File sha1="13ba1f39278e7ab1819dad356dfe82fcda9e5bd1" name="TreeData/LineConnectorActive.png" part="tree"/>
-	<File sha1="e22fe9245c8b97b58a1b85764f417ac3dfce95fa" name="TreeData/LineConnectorIntermediate.png" part="tree"/>
-	<File sha1="3398fb895afa45f6f120cf99ca3c710b34cfabbb" name="TreeData/LineConnectorNormal.png" part="tree"/>
-	<File sha1="e0c01cd83cc50dd333d11299b29ddc02ff8c20aa" name="TreeData/NotableFrameAllocated.png" part="tree"/>
-	<File sha1="87973c184c904a4f7655d12cfd695d13c4108ab0" name="TreeData/NotableFrameCanAllocate.png" part="tree"/>
-	<File sha1="b897b879edcb1f0f73ff8609926fc9ff0fa2da5f" name="TreeData/NotableFrameUnallocated.png" part="tree"/>
-	<File sha1="6ce274dd7ad17e94dfb00104e46bcb4e49a29302" name="TreeData/Orbit1Active.png" part="tree"/>
-	<File sha1="507046732f1bc04035243d14a51817125840df37" name="TreeData/Orbit1Intermediate.png" part="tree"/>
-	<File sha1="ec90b5d35db1f413c2c1a50f59892ce44ff53e64" name="TreeData/Orbit1Normal.png" part="tree"/>
-	<File sha1="6c9fbaac3854b46eba138b5895d88a98b4f96776" name="TreeData/Orbit2Active.png" part="tree"/>
-	<File sha1="d000a4a423bd5ebd2d413a3b937f468536112dd8" name="TreeData/Orbit2Intermediate.png" part="tree"/>
-	<File sha1="cfa18119d7276877bc34b26ff74264a9a7f6ffe5" name="TreeData/Orbit2Normal.png" part="tree"/>
-	<File sha1="c785c16a77434ad5ca196b0ee5139e38c6bb6d02" name="TreeData/Orbit3Active.png" part="tree"/>
-	<File sha1="8e9814aec5a004c587979764528a29a3dcab21f4" name="TreeData/Orbit3Intermediate.png" part="tree"/>
-	<File sha1="07bbd0b5e75aec3a9c87b5b753314e6cb8f8221e" name="TreeData/Orbit3Normal.png" part="tree"/>
-	<File sha1="4a3784eb7fa4f4dd818b6f84d8e9348d58d4b64f" name="TreeData/Orbit4Active.png" part="tree"/>
-	<File sha1="7dc05d9788078fed0f09de81c3c3baa336618c8d" name="TreeData/Orbit4Intermediate.png" part="tree"/>
-	<File sha1="1f374dbe1ad23ef2863158280659f46c0625b05f" name="TreeData/Orbit4Normal.png" part="tree"/>
-	<File sha1="570f34a29da650e6d6781890db7ff5d5a8dd18be" name="TreeData/PassiveSkillScreenAscendancyButton.png" part="tree"/>
-	<File sha1="862acbe013c081126e7477d827647c02cc67205b" name="TreeData/PassiveSkillScreenAscendancyButtonHighlight.png" part="tree"/>
-	<File sha1="bfdf7398d89e94ade00ee3a35e12827f2933465b" name="TreeData/PassiveSkillScreenAscendancyButtonPressed.png" part="tree"/>
-	<File sha1="43327a0658f14291c2d6d17a48d3b6a798a013dc" name="TreeData/PassiveSkillScreenAscendancyFrameLargeAllocated.png" part="tree"/>
-	<File sha1="e7cad0dede1afdf3e84259f54e6d6dcc0920eb39" name="TreeData/PassiveSkillScreenAscendancyFrameLargeCanAllocate.png" part="tree"/>
-	<File sha1="f19d1c23f892931132d781cc26010cbd200bd3bf" name="TreeData/PassiveSkillScreenAscendancyFrameLargeNormal.png" part="tree"/>
-	<File sha1="ebf837e2e27ba7e5c85d1410f8cec3fa4ea3eb3a" name="TreeData/PassiveSkillScreenAscendancyFrameSmallAllocated.png" part="tree"/>
-	<File sha1="b009e1d2b8ed65f6752c0011ff48d0a6b7387727" name="TreeData/PassiveSkillScreenAscendancyFrameSmallCanAllocate.png" part="tree"/>
-	<File sha1="430317839843c64f4bd6ee92406e425027156654" name="TreeData/PassiveSkillScreenAscendancyFrameSmallNormal.png" part="tree"/>
-	<File sha1="7bad658a6a0140d747c7f403d73b1fe6b8b3939e" name="TreeData/PassiveSkillScreenAscendancyMiddle.png" part="tree"/>
-	<File sha1="b2cd3358201b40b6810459d4dcb29ceca237bb5d" name="TreeData/PassiveSkillScreenEternalEmpireJewelCircle1.png" part="tree"/>
-	<File sha1="f33ccfa1f043028f2b4fbad14e6b7b48c7da259c" name="TreeData/PassiveSkillScreenEternalEmpireJewelCircle2.png" part="tree"/>
-	<File sha1="797ed1d1308d9d892a08022515f9521f3a74b341" name="TreeData/PassiveSkillScreenJewelCircle1.png" part="tree"/>
-	<File sha1="1da79ad9b413f7ba830558aca4fffe59ec79bd05" name="TreeData/PassiveSkillScreenKaruiJewelCircle1.png" part="tree"/>
-	<File sha1="88e0408c45d27d7ba772b631048519e47b52c59e" name="TreeData/PassiveSkillScreenKaruiJewelCircle2.png" part="tree"/>
-	<File sha1="ec6aea0cbe5139b382136ecd91afcb655169a706" name="TreeData/PassiveSkillScreenMarakethJewelCircle1.png" part="tree"/>
-	<File sha1="c0e133ff7b4a560517767d3ec39744f9fe4a92de" name="TreeData/PassiveSkillScreenMarakethJewelCircle2.png" part="tree"/>
-	<File sha1="9799e6eda8fdd0caa9787900611eeeee1205c7b4" name="TreeData/PassiveSkillScreenTemplarJewelCircle1.png" part="tree"/>
-	<File sha1="298351ab5fd1117d7b09f9a8be11f037f3dcc1b2" name="TreeData/PassiveSkillScreenTemplarJewelCircle2.png" part="tree"/>
-	<File sha1="2a07b25f44b3873bba55028098634a04ac128d96" name="TreeData/PassiveSkillScreenVaalJewelCircle1.png" part="tree"/>
-	<File sha1="974339171737e0a725a69f13298382e5a9e4a517" name="TreeData/PassiveSkillScreenVaalJewelCircle2.png" part="tree"/>
-	<File sha1="5b7773d80cbebaf8e0a459524da1543763e632e1" name="TreeData/PSGroupBackground1.png" part="tree"/>
-	<File sha1="41e363241cb2f923f78b101ea883e50148c594d3" name="TreeData/PSGroupBackground2.png" part="tree"/>
-	<File sha1="148fcef35603908cecaca2f3773020d05efcff45" name="TreeData/PSGroupBackground3.png" part="tree"/>
-	<File sha1="a690fb4c3f9910939e398daee5dd4b7427a8e5a1" name="TreeData/PSLineDeco.png" part="tree"/>
-	<File sha1="a23866124ce4353cfcdc2903b584a4b527f375c1" name="TreeData/PSLineDecoHighlighted.png" part="tree"/>
-	<File sha1="6e10d16cb9a4070c84f935d97064a2c05381c63b" name="TreeData/PSPointsFrame.png" part="tree"/>
-	<File sha1="82fbfcd4d9c7b61464614f69aeeb6912712b7dde" name="TreeData/PSSkillFrame.png" part="tree"/>
-	<File sha1="e820f2fd0187c7fb5e255b89a53115fd25847831" name="TreeData/PSSkillFrameActive.png" part="tree"/>
-	<File sha1="876508200ac2043ec9af17cc0d34382b990480e9" name="TreeData/PSSkillFrameHighlighted.png" part="tree"/>
-	<File sha1="3f9173651fd88f8c9ed0ddf2c939a15e4767b973" name="TreeData/PSStartNodeBackgroundInactive.png" part="tree"/>
-	<File sha1="ee02b7e6e521896c498d8b222b1efab04538eaa7" name="TreeData/2_6/tree.lua" part="tree-2_6"/>
-	<File sha1="abf59db207e4256edd4d67a73e8ae2821418ca84" name="TreeData/2_6/skill_sprite-3-32f639bbfc42783ca7ec218a787dd918.jpg" part="tree-2_6"/>
-	<File sha1="8f8a0c2f6792a505dbc7b66570f28d409d8ad4af" name="TreeData/2_6/skill_sprite-active-3-3e73c4c4534433ecfc340c7287093bd5.png" part="tree-2_6"/>
-	<File sha1="5a1693ea2e3f4f46c4e7988edb58e2405ecf63a4" name="TreeData/2_6/skill_sprite-active-3-7798fabab8a21829831293c20ac9c414.jpg" part="tree-2_6"/>
-	<File sha1="9c28311886cf10799b745e843c3b06b1c40f0c24" name="TreeData/3_6/tree.lua" part="tree-3_6"/>
-	<File sha1="275e7066b61a7ad12ee59d34cd5a405d2d71a9d6" name="TreeData/3_6/groups-3.png" part="tree-3_6"/>
-	<File sha1="ebc0c5c46007ec625ee2bf6bd65317be4bce088e" name="TreeData/3_6/skills-3.jpg" part="tree-3_6"/>
-	<File sha1="e69a47709256d27e5529051522f018f3380fc457" name="TreeData/3_6/skills-disabled-3.jpg" part="tree-3_6"/>
-	<File sha1="2c73d57dabd0054b884b2a63b8af9948592fd6ef" name="TreeData/3_7/tree.lua" part="tree-3_7"/>
-	<File sha1="dff51e75f0aafdae5118167c66b1cec360ff4b00" name="TreeData/3_7/groups-3.png" part="tree-3_7"/>
-	<File sha1="0c82fd04e6afd6cacd35208cf499a35155ea4cda" name="TreeData/3_7/skills-3.jpg" part="tree-3_7"/>
-	<File sha1="2930d625d1422d24c7d6ccaaacf0ed00e97e7391" name="TreeData/3_7/skills-disabled-3.jpg" part="tree-3_7"/>
-	<File sha1="27af0a1cc95e2f4cf303849aeac7f474c34a5546" name="TreeData/3_8/tree.lua" part="tree-3_8"/>
-	<File sha1="f5ef46af99150b25e44babac41c96ee58c87b44d" name="TreeData/3_8/groups-3.png" part="tree-3_8"/>
-	<File sha1="e2ba51c375dd1c6e105303f296bfae966c495f6d" name="TreeData/3_8/skills-3.jpg" part="tree-3_8"/>
-	<File sha1="43c308d6949611832b3f0e84da4acde45bfcfd32" name="TreeData/3_8/skills-disabled-3.jpg" part="tree-3_8"/>
+	<Version branch="master" number="1.4.152 (LocalIdentity fork)" />
+	<Source part="program" url="https://raw.githubusercontent.com/edmundsmith/PathOfBuilding/{branch}/" />
+	<Source part="tree" url="https://raw.githubusercontent.com/Openarl/PathOfBuilding/{branch}/" />
+	<Source part="tree-2_6" url="https://raw.githubusercontent.com/Openarl/PathOfBuilding/{branch}/tree-2_6.zip" />
+	<Source part="tree-3_6" url="https://raw.githubusercontent.com/Openarl/PathOfBuilding/{branch}/tree-3_6.zip" />
+	<Source part="tree-3_7" url="https://raw.githubusercontent.com/Openarl/PathOfBuilding/{branch}/tree-3_7.zip" />
+	<Source part="tree-3_8" url="https://raw.githubusercontent.com/Openarl/PathOfBuilding/{branch}/tree-3_8.zip" />
+	<Source part="runtime" platform="win32" url="https://raw.githubusercontent.com/Openarl/PathOfBuilding/{branch}/runtime-win32.zip" />
+	<File name="Launch.lua" part="program" sha1="74cd89091c4db01f0673217a5bd0927f232391e2" />
+	<File name="UpdateCheck.lua" part="program" sha1="72b9bea1871e94a643e4471fd84bbedbc7810336" />
+	<File name="UpdateApply.lua" part="program" sha1="4f17937f2b37784e169a3792b235f2a0a3961e61" />
+	<File name="GameVersions.lua" part="program" sha1="4be21620b1c7149c7dca35c883bd8b7dd2c5eea9" />
+	<File name="changelog.txt" part="program" sha1="309dabf6c0322c4f972b565d9e198f8d2cb7a8b6" />
+	<File name="Classes/BuildListControl.lua" part="program" sha1="b093a2709f30c1f83ce5ba9df88c80f22c1beb4a" />
+	<File name="Classes/ButtonControl.lua" part="program" sha1="16fc5eaa04cc14b2022f6705a12717935454dab0" />
+	<File name="Classes/CalcBreakdownControl.lua" part="program" sha1="7bc27fdc1e178e5d6932996f8d10da89552d0986" />
+	<File name="Classes/CalcSectionControl.lua" part="program" sha1="7f3747edd121907622e075ce3fd0a2abf1577c3f" />
+	<File name="Classes/CalcsTab.lua" part="program" sha1="85280ec71e86e92b2d62af5856cfb7944a35beb2" />
+	<File name="Classes/CheckBoxControl.lua" part="program" sha1="d2e5a1d2717da6853a9c5e788bc45c309d925e77" />
+	<File name="Classes/ConfigTab.lua" part="program" sha1="ab06b5a5717be18b05b7aea5ba8d0439c3370205" />
+	<File name="Classes/Control.lua" part="program" sha1="64fc5fd8e3d4ade976f51c4a28d782b9b2ad31ac" />
+	<File name="Classes/ControlHost.lua" part="program" sha1="8bc9c45c9223fb0d51e67cde556849678862817a" />
+	<File name="Classes/DropDownControl.lua" part="program" sha1="5efd9a36853d6fb5214a9e4b88a5ca94d470b44f" />
+	<File name="Classes/EditControl.lua" part="program" sha1="8e8340df34a9a27374fe48e0ebcb633ef03af550" />
+	<File name="Classes/FolderListControl.lua" part="program" sha1="bcb52d02b8ca9288be255219956d6f0bc4efeedd" />
+	<File name="Classes/GemSelectControl.lua" part="program" sha1="d64d726b51a5d25dcfcccd674722e88dae60b76e" />
+	<File name="Classes/ImportTab.lua" part="program" sha1="3f894501b2b59276c010b78e8f8ccfccc61f9bcc" />
+	<File name="Classes/Item.lua" part="program" sha1="1b1f5fd0b52706597f8d42286f4e45b60b23c797" />
+	<File name="Classes/ItemDBControl.lua" part="program" sha1="4d272598d19ac2642391facb507fc99cf457a812" />
+	<File name="Classes/ItemListControl.lua" part="program" sha1="8298506b88cea37e78c1c5faebc05335b3ace240" />
+	<File name="Classes/ItemSetListControl.lua" part="program" sha1="7ecee459d3c477b46c6b6115bfeb2480995e17ed" />
+	<File name="Classes/ItemSlotControl.lua" part="program" sha1="ce1f69ab2716013511aeca61fb4e9867c77abb3a" />
+	<File name="Classes/ItemsTab.lua" part="program" sha1="24acd5cd21cb8baa0b3f7d1c99801e02d084d4d0" />
+	<File name="Classes/LabelControl.lua" part="program" sha1="d2ffe0071641c07b63d152c0f48b691eba0cffb0" />
+	<File name="Classes/ListControl.lua" part="program" sha1="45ec0b7e2345533caca3f4eb6575298bc280d6a2" />
+	<File name="Classes/MinionListControl.lua" part="program" sha1="f7281f889c87c8de45d5af4243c49d9998d4a272" />
+	<File name="Classes/ModDB.lua" part="program" sha1="b67204a03fc51b91cb3e73c398e57ebc50dd9df1" />
+	<File name="Classes/ModList.lua" part="program" sha1="2fa5f20b12a4b366dc4b28a2a873699b834766d6" />
+	<File name="Classes/ModStore.lua" part="program" sha1="dcd61c9b14509a09554f109602f5c0e797374f27" />
+	<File name="Classes/NotesTab.lua" part="program" sha1="cc7c5eff58c2868cdc7d4c1bf9a967aa8c448c9e" />
+	<File name="Classes/PassiveSpec.lua" part="program" sha1="85735f795096fff6ddbb6551be397d409e5a4f5b" />
+	<File name="Classes/PassiveSpecListControl.lua" part="program" sha1="d449391ea879a20728f7e9a0345398c0141a45f6" />
+	<File name="Classes/PassiveTree.lua" part="program" sha1="251d4315696c0c540a56fad32f0931312aefd37e" />
+	<File name="Classes/PassiveTreeView.lua" part="program" sha1="72c79652b48b45ad5bf050ad260f5a458fb1e494" />
+	<File name="Classes/PathControl.lua" part="program" sha1="3acd77612e658766260129ffab70373d8ee60c59" />
+	<File name="Classes/PopupDialog.lua" part="program" sha1="2bfb5bb91475432d23a29c1eb36daec2d76914f0" />
+	<File name="Classes/ScrollBarControl.lua" part="program" sha1="0690e86bb59d80be8ec3cbd0c902d54850338371" />
+	<File name="Classes/SectionControl.lua" part="program" sha1="35e760f9dd2a5fc51ab9e5ba7f0e9e37eaad1c5a" />
+	<File name="Classes/SharedItemListControl.lua" part="program" sha1="917978ae386092c1d37b2bf121fbc9107e4d2b6b" />
+	<File name="Classes/SharedItemSetListControl.lua" part="program" sha1="441ad6269d2992ee1de9e249ecbb4638653bcbde" />
+	<File name="Classes/SkillListControl.lua" part="program" sha1="c3ac5329ade721b25e7ae38563368d6e71791f5a" />
+	<File name="Classes/SkillsTab.lua" part="program" sha1="5931dadab66caaee0d070a59f2acde839d5ef6d7" />
+	<File name="Classes/SliderControl.lua" part="program" sha1="c6dea22945dcfa8b2a681468ed8dab16eeae7929" />
+	<File name="Classes/TextListControl.lua" part="program" sha1="bb62a34443d64f21c5f0e3e00cae736a8eb6bd87" />
+	<File name="Classes/Tooltip.lua" part="program" sha1="a9c6a1965fb2d7b7435bd635cd4241ee6e771ec9" />
+	<File name="Classes/TooltipHost.lua" part="program" sha1="23274906162877c09d2119237414b6747a0e6cea" />
+	<File name="Classes/TreeTab.lua" part="program" sha1="cd59df8b175db763863a9039a13f9e9008c4a38f" />
+	<File name="Classes/UndoHandler.lua" part="program" sha1="ce4835c384c834da0de47b0302b1e774c8300c6b" />
+	<File name="Modules/Build.lua" part="program" sha1="4a4b8001e6187caa671ca38e81cf04abb9aef99a" />
+	<File name="Modules/BuildList.lua" part="program" sha1="bcda0c5148b9e40274acd13702896cc430c89eba" />
+	<File name="Modules/CalcActiveSkill.lua" part="program" sha1="af0c71e966bcf55ab39f66790532bad7d5a323a7" />
+	<File name="Modules/CalcBreakdown.lua" part="program" sha1="2408b55c894b81fbcd0456a3540cdb07c5a7c4a1" />
+	<File name="Modules/CalcDefence-2_6.lua" part="program" sha1="f49b47b90a18902c30db9693a7949172c72944e7" />
+	<File name="Modules/CalcDefence-3_0.lua" part="program" sha1="62f0fafbec4dd52394cfa27e23e320f5ea8cdf7f" />
+	<File name="Modules/CalcOffence-2_6.lua" part="program" sha1="fdfcb2daf9f582e3d2fa065c4b61ecfe66d8ba4f" />
+	<File name="Modules/CalcOffence-3_0.lua" part="program" sha1="79b259069df09986db35a858200910d48310d4d7" />
+	<File name="Modules/CalcPerform.lua" part="program" sha1="ba73bfc23205c34ad6cf28cd6a3d0be7f23ea652" />
+	<File name="Modules/Calcs.lua" part="program" sha1="582806808b1646f18bfde93db45658d66c4569d8" />
+	<File name="Modules/CalcSections-2_6.lua" part="program" sha1="32da2a949a5fe0ab10d54078a96caff0dccb5f3f" />
+	<File name="Modules/CalcSections-3_0.lua" part="program" sha1="d6b29d219274bf263ebf947dc6cfe42f09779f81" />
+	<File name="Modules/CalcSetup.lua" part="program" sha1="af72b6a9c9d3dbebb08b0a0f1ff1f1628d39d43a" />
+	<File name="Modules/CalcTools.lua" part="program" sha1="3c92a7629f7e3a5b7eafae6ee4a0b03ae86420b8" />
+	<File name="Modules/Common.lua" part="program" sha1="fef899d2413e9fa67df808e4f6de533b263ddcd7" />
+	<File name="Modules/ConfigOptions.lua" part="program" sha1="5604c21b0ae935d78f89a66015e57ebdecbf8917" />
+	<File name="Modules/Data.lua" part="program" sha1="ee0ae56a5739ac6df980d27f91dd98aad2332526" />
+	<File name="Modules/ItemTools.lua" part="program" sha1="d74918586d5ae396fc9bea4c4b6e4aa6bfad8d3e" />
+	<File name="Modules/Main.lua" part="program" sha1="a56579dd70e73a2cc537748a5d04d02f5bbf2f08" />
+	<File name="Modules/ModParser-2_6.lua" part="program" sha1="fc2d3bdf7a4e57894b3d04beb83485cc6dcc5e26" />
+	<File name="Modules/ModParser-3_0.lua" part="program" sha1="cd0dc6f662f845f9ae6ceadcb7636eac4e4f531d" />
+	<File name="Modules/ModTools.lua" part="program" sha1="2ce4f3b83db992a286bd92f3849d037d6dcc8db2" />
+	<File name="Modules/StatDescriber.lua" part="program" sha1="6b0b5ac8fdb764b47fd7a1657bd470bd275f9069" />
+	<File name="Modules/PantheonTools.lua" part="program" sha1="ebe91a7d8f8444a6061acf4758da0e775cc8c314" />
+	<File name="Assets/game_ui_small.png" part="program" sha1="c345cdcf374d271411aa424ab150c0edbb5a362d" />
+	<File name="Assets/patreon_logo.png" part="program" sha1="97b020d8213e09c313536a91528ba5d5ebc4ca0a" />
+	<File name="Assets/range_guide.png" part="program" sha1="4ebea5031fd03771a9b637a3fdccf394344e4782" />
+	<File name="Assets/ring.png" part="program" sha1="e7ee7e5b6388facb7bf568517ecc401590757df7" />
+	<File name="Assets/small_ring.png" part="program" sha1="9a320bfe629b1cf3f14fc77fbbf2508d0a5b2841" />
+	<File name="Data/Global.lua" part="program" sha1="31557624a3065d2f6ea1f8a22f4867cce8904d02" />
+	<File name="Data/New.lua" part="program" sha1="566dcff7e8120354eae68eccf8c7641aaa75d9c0" />
+	<File name="Data/Uniques/amulet.lua" part="program" sha1="3e07bab63bcee57af50552445cefef637f8e01f2" />
+	<File name="Data/Uniques/axe.lua" part="program" sha1="68ddb940c438ff8ec096056599c08a122cf2d7a6" />
+	<File name="Data/Uniques/belt.lua" part="program" sha1="967fcb4328461798da9b0f99a8c28ee90d70dcb7" />
+	<File name="Data/Uniques/body.lua" part="program" sha1="dee747b456463c8ccb79a02e02d62235d003e51c" />
+	<File name="Data/Uniques/boots.lua" part="program" sha1="2eb51da615f7ce0c911134688ba6eee5987204e9" />
+	<File name="Data/Uniques/bow.lua" part="program" sha1="52b9681de2b976af6afcc664962583207c53677c" />
+	<File name="Data/Uniques/claw.lua" part="program" sha1="70dec1ca1ff574abb3e98547364cd6c6107a88ed" />
+	<File name="Data/Uniques/dagger.lua" part="program" sha1="a454337540ba275b7451134a6838f03e69f2484b" />
+	<File name="Data/Uniques/flask.lua" part="program" sha1="d6cb43e2a263bd29f87bf9d9ed9e2817423523a3" />
+	<File name="Data/Uniques/gloves.lua" part="program" sha1="c6c1aaff321551e9f80ea015ca9572e1d01af995" />
+	<File name="Data/Uniques/helmet.lua" part="program" sha1="218e4eafc473708824ae7bdca2b49b80fca27f57" />
+	<File name="Data/Uniques/jewel.lua" part="program" sha1="92aeec484074c36582a858fba3f2c03c6f38644e" />
+	<File name="Data/Uniques/mace.lua" part="program" sha1="5fd320762aa17813725731338b242dacb74ff65c" />
+	<File name="Data/Uniques/quiver.lua" part="program" sha1="d874470df955e4ee24e8ef347c39f57b6fbd7b77" />
+	<File name="Data/Uniques/ring.lua" part="program" sha1="4fde19b9aeda9055bb676be7ab55d74ce3f7e944" />
+	<File name="Data/Uniques/shield.lua" part="program" sha1="e7b8e7f5199e7008b3a6a7efe0d8a41cba75e5b9" />
+	<File name="Data/Uniques/staff.lua" part="program" sha1="9657037ec1bbca246d613b272cd6c6636de94fe0" />
+	<File name="Data/Uniques/sword.lua" part="program" sha1="4157c6cb6ef087358e6d3ac7aa51f61bd4df1702" />
+	<File name="Data/Uniques/wand.lua" part="program" sha1="5c977bfb8cee5cfab3ff37b500d48632b8f34ec4" />
+	<File name="Data/2_6/EnchantmentBoots.lua" part="program" sha1="4a2651bfcb3beb6fe8b9acab18a6792072f7e9b4" />
+	<File name="Data/2_6/EnchantmentGloves.lua" part="program" sha1="cc36a59b04a69c76ef76f5b6bc6899fd0ee1666e" />
+	<File name="Data/2_6/EnchantmentHelmet.lua" part="program" sha1="b305198cafc6800aa5556da07a5eea699c718d3b" />
+	<File name="Data/2_6/Essence.lua" part="program" sha1="170d14d9176a1d7425d4bfa1b3bcc08c5f4fe73c" />
+	<File name="Data/2_6/Gems.lua" part="program" sha1="0d124348e8ec0aa3944c68e2789aea2e82dbd740" />
+	<File name="Data/2_6/Minions.lua" part="program" sha1="2fbdc82acb8016c40d91ae77a8a8cee914b85d81" />
+	<File name="Data/2_6/Misc.lua" part="program" sha1="9a5c9b0a3f75ba2c573376d53a8cf87a54ac8a96" />
+	<File name="Data/2_6/ModCache.lua" part="program" sha1="31396cc76162aa98fe06a39bc149c09c45200040" />
+	<File name="Data/2_6/ModFlask.lua" part="program" sha1="d96fc1e31349cb8aba1336c1f356b69ff436269b" />
+	<File name="Data/2_6/ModItem.lua" part="program" sha1="19036f1ef6a61d5cb673ef1fd4eef1ddb8bed1e3" />
+	<File name="Data/2_6/ModJewel.lua" part="program" sha1="0671f7f062f06c68ec6c659d2121620a1782fecf" />
+	<File name="Data/2_6/ModMaster.lua" part="program" sha1="6bf966e95660cd986c2a94cfb730a426a0964781" />
+	<File name="Data/2_6/Rares.lua" part="program" sha1="8ac06e060e843345ad8b3fd14e9cc262ead9cd69" />
+	<File name="Data/2_6/SkillStatMap.lua" part="program" sha1="842ba7e78b399a9c943bb5f9002cf4d60748ae05" />
+	<File name="Data/2_6/Spectres.lua" part="program" sha1="7ba7a3bc11cb3dbbb269d2efcca06cc740254f4f" />
+	<File name="Data/2_6/Bases/amulet.lua" part="program" sha1="4538254d9b6867e463d0c95022cd574c9a89c783" />
+	<File name="Data/2_6/Bases/axe.lua" part="program" sha1="3ae2b135f2081039ac5917a20e39de000e01000e" />
+	<File name="Data/2_6/Bases/belt.lua" part="program" sha1="4f9d73ef3f59866a64cbc5836b9bc5210c619224" />
+	<File name="Data/2_6/Bases/body.lua" part="program" sha1="f70b2fe71f7787b1f4a3c364ba0d359f21221a8d" />
+	<File name="Data/2_6/Bases/boots.lua" part="program" sha1="df8d1ed2298d203caeff6d55553b996f9375b679" />
+	<File name="Data/2_6/Bases/bow.lua" part="program" sha1="01b66c55d9722b39b584880efa0347696c7f47c2" />
+	<File name="Data/2_6/Bases/claw.lua" part="program" sha1="55cd289d21bba64ee017770278a0beb9ade08854" />
+	<File name="Data/2_6/Bases/dagger.lua" part="program" sha1="1ea544481024738aadd42e80864cf19dbe640580" />
+	<File name="Data/2_6/Bases/flask.lua" part="program" sha1="2b0612f9de80f97c168919a2b91bb4d01af97123" />
+	<File name="Data/2_6/Bases/gloves.lua" part="program" sha1="cc9865d7d4fe62bd6005d0d8ac34602616cad975" />
+	<File name="Data/2_6/Bases/helmet.lua" part="program" sha1="5637471b83bc5d7e374f2af4d635c0e4a9b9d4fd" />
+	<File name="Data/2_6/Bases/jewel.lua" part="program" sha1="768eea50f8995473c66d39b507f3f3d9a8d9a75a" />
+	<File name="Data/2_6/Bases/mace.lua" part="program" sha1="0886861547b564906c0d29eedd662172e4fdaadd" />
+	<File name="Data/2_6/Bases/quiver.lua" part="program" sha1="19523099a7ec81317c6cd8e14366d6b85a3599ab" />
+	<File name="Data/2_6/Bases/ring.lua" part="program" sha1="9291f3eafc2749b7d1cd4732406d6bcc5b6f2abe" />
+	<File name="Data/2_6/Bases/shield.lua" part="program" sha1="5c3c81c17d4c1d1481f0d0cf45267185632d31fe" />
+	<File name="Data/2_6/Bases/staff.lua" part="program" sha1="d86048fae69d25db4d20ef6aaa867e769bc1626e" />
+	<File name="Data/2_6/Bases/sword.lua" part="program" sha1="6e894851b10cafbdd00d8ce5eaa44a25bd712d71" />
+	<File name="Data/2_6/Bases/wand.lua" part="program" sha1="c8d18eddf62b1b3ba22fb3233da329a29a200f4b" />
+	<File name="Data/2_6/Skills/act_dex.lua" part="program" sha1="ec37909b9d4bba33d68d2ab91744956b835d27b1" />
+	<File name="Data/2_6/Skills/act_int.lua" part="program" sha1="9114076b8a213fdda01a4307fff031e3c77e15fe" />
+	<File name="Data/2_6/Skills/act_str.lua" part="program" sha1="fbb92d3cf35261e9b1a90ad4090ec7dce70b7785" />
+	<File name="Data/2_6/Skills/glove.lua" part="program" sha1="a7b57aa42617334e532173d9ee275d9633628f36" />
+	<File name="Data/2_6/Skills/minion.lua" part="program" sha1="cfa3597b4aceff8e519f0bd04a685b1dfe716eba" />
+	<File name="Data/2_6/Skills/other.lua" part="program" sha1="aa58c860e606ac3f99151f597376f4a1f930eed6" />
+	<File name="Data/2_6/Skills/spectre.lua" part="program" sha1="679a20a3f7ab566ccc5d4095844b29a88e88b929" />
+	<File name="Data/2_6/Skills/sup_dex.lua" part="program" sha1="497ff50f4ec90ce331b431598bdf5b142d2858a9" />
+	<File name="Data/2_6/Skills/sup_int.lua" part="program" sha1="f1376f24e3efb1359fe636fd22d64fe6fc61aa43" />
+	<File name="Data/2_6/Skills/sup_str.lua" part="program" sha1="7b2113799018833a76908d024c8b5aa937324483" />
+	<File name="Data/3_0/EnchantmentBoots.lua" part="program" sha1="94b77c91487b78185ff26605c5fc4e41ce6c7f8b" />
+	<File name="Data/3_0/EnchantmentGloves.lua" part="program" sha1="1fcdacb6f5e454b41163c0ddef1e4aa3444fe0fb" />
+	<File name="Data/3_0/EnchantmentHelmet.lua" part="program" sha1="e9c8a9cb77a4b3335036bce6374cfe1a82eb302c" />
+	<File name="Data/3_0/Essence.lua" part="program" sha1="05bf7be7aa8219e16fba64aca2cdb7bd262c4339" />
+	<File name="Data/3_0/Gems.lua" part="program" sha1="7a678a4d874cecc2b31e06e0549df1d49f6656ff" />
+	<File name="Data/3_0/Minions.lua" part="program" sha1="adb21034a36b059f54363b9995d790c8d6b7f39c" />
+	<File name="Data/3_0/Misc.lua" part="program" sha1="ae310ea401f6ad8a10e048d57cbc10178d1f4da3" />
+	<File name="Data/3_0/ModCache.lua" part="program" sha1="81858ca1f06ce05c174219c8519dd4f1c3578825" />
+	<File name="Data/3_0/ModFlask.lua" part="program" sha1="4d63f91c23e7a4ac481b8ad7bae9e70bb46200c6" />
+	<File name="Data/3_0/ModItem.lua" part="program" sha1="8e58cec44fb8d139e386996b793069eda6e74fef" />
+	<File name="Data/3_0/ModJewel.lua" part="program" sha1="a976b5e81ef3d0842f2185ecc744a8847c93202f" />
+	<File name="Data/3_0/ModJewelAbyss.lua" part="program" sha1="f7fd342a037dda7612c15f1d8ee52bb114012c01" />
+	<File name="Data/3_0/ModMaster.lua" part="program" sha1="3239982439814f451aa948167f1cc4845be95b3c" />
+	<File name="Data/3_0/Rares.lua" part="program" sha1="f1a52475b331c1c644145760342017a65f8d40fc" />
+	<File name="Data/3_0/SkillStatMap.lua" part="program" sha1="f01e648a0cea9bd7b791f9bfa777ae9b81eebd17" />
+	<File name="Data/3_0/Spectres.lua" part="program" sha1="54ba5008fd8cb1a88aa3c04e92721e30c116ef54" />
+	<File name="Data/3_0/Bases/amulet.lua" part="program" sha1="95dfa07c930fd5178baaac5d8a23dfbaeaa56edf" />
+	<File name="Data/3_0/Bases/axe.lua" part="program" sha1="9292f38aa5c33e044e775a1df62d60cfc48e4e66" />
+	<File name="Data/3_0/Bases/belt.lua" part="program" sha1="c69a5cce068314f65bb9f5f0fd2577be7ac0f1cd" />
+	<File name="Data/3_0/Bases/body.lua" part="program" sha1="5a9238d084698a2d36bd73d6d042493c4949b71f" />
+	<File name="Data/3_0/Bases/boots.lua" part="program" sha1="2ae3b0d76c7fb5840befefa2664831c659707b3c" />
+	<File name="Data/3_0/Bases/bow.lua" part="program" sha1="939580b5c10f21e4d9cde26929bb9955e22f13fc" />
+	<File name="Data/3_0/Bases/claw.lua" part="program" sha1="feec29f491d2ff239d6441543375ff7f80ff3a4c" />
+	<File name="Data/3_0/Bases/dagger.lua" part="program" sha1="7b9415341e8b254bc30d05ced401073657f69ac9" />
+	<File name="Data/3_0/Bases/flask.lua" part="program" sha1="057772b3b2e3525f2caeaf7a9732eaab5b055bd4" />
+	<File name="Data/3_0/Bases/gloves.lua" part="program" sha1="1486365549d7ddd029c09da5cf36080fc7d9189e" />
+	<File name="Data/3_0/Bases/helmet.lua" part="program" sha1="4cd0c68aefcae4fe93a082af20ebccf25f3600dd" />
+	<File name="Data/3_0/Bases/jewel.lua" part="program" sha1="6be39acaa983a3f5e454d6f84991d3089a5ff82c" />
+	<File name="Data/3_0/Bases/mace.lua" part="program" sha1="2928471a828e4e32604f0153ff74bf2ec6ae9ae2" />
+	<File name="Data/3_0/Bases/quiver.lua" part="program" sha1="5982f667bfeccd7e2b978f3955a5b96fe88aba93" />
+	<File name="Data/3_0/Bases/ring.lua" part="program" sha1="d7b43fd70235a7ac9010ed265a12d4b1e7182b77" />
+	<File name="Data/3_0/Bases/shield.lua" part="program" sha1="eb0485638eb1f1632c5b7e414ff9c4a0c99d12e5" />
+	<File name="Data/3_0/Bases/staff.lua" part="program" sha1="439c3c038cdbc6133367fecfe119dd13d8248775" />
+	<File name="Data/3_0/Bases/sword.lua" part="program" sha1="2c0bb96c9310711060beb010b282018bc1425cbd" />
+	<File name="Data/3_0/Bases/wand.lua" part="program" sha1="5ee7725728e14929c4339eded5e19aa15f55e803" />
+	<File name="Data/3_0/Pantheons.lua" part="program" sha1="bbd02226a334e18ab5d276ff82a4f412929f8770" />
+	<File name="Data/3_0/Skills/act_dex.lua" part="program" sha1="b94ccee3abf90551c66e3520d11f8ae7499a2911" />
+	<File name="Data/3_0/Skills/act_int.lua" part="program" sha1="cc01d4a65e5ff0e193c6cd957a0d73080ac3ee8e" />
+	<File name="Data/3_0/Skills/act_str.lua" part="program" sha1="3055adf7b9612a394a9d00501e9860d2dac8375b" />
+	<File name="Data/3_0/Skills/glove.lua" part="program" sha1="5588b65dd69431c775af937d9db59e242ce23647" />
+	<File name="Data/3_0/Skills/minion.lua" part="program" sha1="3095c366f6b672ff209cbc1fa66440b8249ca42b" />
+	<File name="Data/3_0/Skills/other.lua" part="program" sha1="d0940c85ab07c8d1ab1fe35f61da68430465ef00" />
+	<File name="Data/3_0/Skills/spectre.lua" part="program" sha1="3d236ea161a34bdc440fb07d9d371b7a0fc567e1" />
+	<File name="Data/3_0/Skills/sup_dex.lua" part="program" sha1="1b35429171184006feae22e26c012367ccb0809a" />
+	<File name="Data/3_0/Skills/sup_int.lua" part="program" sha1="beae2cee21cef4da714c8a554de372ff28918a92" />
+	<File name="Data/3_0/Skills/sup_str.lua" part="program" sha1="4718c2b9c54f60be38ce94a1a7784b32a0c4c251" />
+	<File name="Data/3_0/StatDescriptions/active_skill_gem_stat_descriptions.lua" part="program" sha1="35cc503815893143504a9109191f6469e3a0e902" />
+	<File name="Data/3_0/StatDescriptions/aura_skill_stat_descriptions.lua" part="program" sha1="3c86e0db7e27e95d1ceebd3beeed89e8248f9250" />
+	<File name="Data/3_0/StatDescriptions/banner_aura_skill_stat_descriptions.lua" part="program" sha1="eeb9f2acc81f104b066a5c7c1a7c8e37d1c48b36" />
+	<File name="Data/3_0/StatDescriptions/beam_skill_stat_descriptions.lua" part="program" sha1="37462abd0417b82b89e30ab36191b32869c18aa1" />
+	<File name="Data/3_0/StatDescriptions/brand_skill_stat_descriptions.lua" part="program" sha1="9f7429786065be0619854ebe5541490fb13e938f" />
+	<File name="Data/3_0/StatDescriptions/buff_skill_stat_descriptions.lua" part="program" sha1="f110532addb4086bca044933c6a83f2b18af155f" />
+	<File name="Data/3_0/StatDescriptions/curse_skill_stat_descriptions.lua" part="program" sha1="c5e6249c1bcd49b2f36ddd36fb1e407308220461" />
+	<File name="Data/3_0/StatDescriptions/debuff_skill_stat_descriptions.lua" part="program" sha1="c36a4a5102dfafb468758999cd5e19c3014e2a8d" />
+	<File name="Data/3_0/StatDescriptions/gem_stat_descriptions.lua" part="program" sha1="b603ec84e05e5fad7fb1c868362edcaedf60a26b" />
+	<File name="Data/3_0/StatDescriptions/minion_attack_skill_stat_descriptions.lua" part="program" sha1="bd2824418e3c6d346e2bd292f9b7e7eecd473fc3" />
+	<File name="Data/3_0/StatDescriptions/minion_skill_stat_descriptions.lua" part="program" sha1="8794bbba79e883e00f88d265624f6f897b5b6803" />
+	<File name="Data/3_0/StatDescriptions/minion_spell_skill_stat_descriptions.lua" part="program" sha1="0e63b7f3c04f944d38077d4680dcad51512fffac" />
+	<File name="Data/3_0/StatDescriptions/monster_stat_descriptions.lua" part="program" sha1="5492efa0312ce060ae723b608b5752a7104c9846" />
+	<File name="Data/3_0/StatDescriptions/offering_skill_stat_descriptions.lua" part="program" sha1="2d4383b494b8affdec8d2fe494ed8e7a7c8b1126" />
+	<File name="Data/3_0/StatDescriptions/skill_stat_descriptions.lua" part="program" sha1="9c8f6b6a02736e4e800b50f772d4a75e50426d72" />
+	<File name="Data/3_0/StatDescriptions/stat_descriptions.lua" part="program" sha1="ad5375f3183145e0ec72730d0e8c74fb1b2c590c" />
+	<File name="Data/3_0/StatDescriptions/variable_duration_skill_stat_descriptions.lua" part="program" sha1="c10e87b9b02f65dac7ea0e533115e1ada7c198d8" />
+	<File name="Path of Building.exe" part="runtime" platform="win32" sha1="7e5a3242c9a4296dc8377feb4c9d824f3f0a3cc1" />
+	<File name="lua51.dll" part="runtime" platform="win32" sha1="7a973d3c0b5121e6aad0dcb9323be5b432fc63e7" />
+	<File name="SimpleGraphic.dll" part="runtime" platform="win32" sha1="d852ae6eafc9be62aa41d3cb74fb986d0e5b40e5" />
+	<File name="libcurl.dll" part="runtime" platform="win32" sha1="5f68674e22a389dddeb72078b7d9d69d29881bdd" />
+	<File name="lcurl.dll" part="runtime" platform="win32" sha1="fe399dbe89c02c597bbad8323ef5c29b24af4870" />
+	<File name="lzip.dll" part="runtime" platform="win32" sha1="fe73e74330bf2943036139c32a5c773558fc62a5" />
+	<File name="SimpleGraphic/Fonts/Bitstream Vera Sans Mono.10.tga" part="runtime" sha1="74cc6c47e7cda18211e57b9e062368eab3c26bab" />
+	<File name="SimpleGraphic/Fonts/Bitstream Vera Sans Mono.12.tga" part="runtime" sha1="1977206f0efc5035834ecbf93ca7d046010d8aab" />
+	<File name="SimpleGraphic/Fonts/Bitstream Vera Sans Mono.14.tga" part="runtime" sha1="93a4309dc814914be7d2dee708e3821494f145a2" />
+	<File name="SimpleGraphic/Fonts/Bitstream Vera Sans Mono.16.tga" part="runtime" sha1="274665d752f1637c7e2be215c5ca7ea43df7d5e0" />
+	<File name="SimpleGraphic/Fonts/Bitstream Vera Sans Mono.18.tga" part="runtime" sha1="3cd1d874cf6f75b4fd2d67e3060f9a7dbd89c9d1" />
+	<File name="SimpleGraphic/Fonts/Bitstream Vera Sans Mono.20.tga" part="runtime" sha1="2411cf67aa67efede08830d350b1b08c94d6ea7b" />
+	<File name="SimpleGraphic/Fonts/Bitstream Vera Sans Mono.24.tga" part="runtime" sha1="730fbfe488f47c0da6711f0e20c23e0c005148b0" />
+	<File name="SimpleGraphic/Fonts/Bitstream Vera Sans Mono.28.tga" part="runtime" sha1="b6d5cc14c7336366b2b6036f781ca1c2ae00b638" />
+	<File name="SimpleGraphic/Fonts/Bitstream Vera Sans Mono.32.tga" part="runtime" sha1="8c339846aac3a4c739750efe722816d86c56571a" />
+	<File name="SimpleGraphic/Fonts/Bitstream Vera Sans Mono.tgf" part="runtime" sha1="3a92b9f013871dc92211c7bba78a1c9669b443d4" />
+	<File name="SimpleGraphic/Fonts/Liberation Sans Bold.10.tga" part="runtime" sha1="88809ae34ea7d14500e1ad9bb17e74f6bd50f72e" />
+	<File name="SimpleGraphic/Fonts/Liberation Sans Bold.12.tga" part="runtime" sha1="a42436255ca10b47934ad428c60d209da2c77f41" />
+	<File name="SimpleGraphic/Fonts/Liberation Sans Bold.14.tga" part="runtime" sha1="d720f0c0c3c6d2bea38d52edb7ba73bff71eb501" />
+	<File name="SimpleGraphic/Fonts/Liberation Sans Bold.16.tga" part="runtime" sha1="68ea1a3846198aae66f63a70abcf9b023b3c469f" />
+	<File name="SimpleGraphic/Fonts/Liberation Sans Bold.18.tga" part="runtime" sha1="d9abed6557034288442ba1f6ee557ab8ac616a85" />
+	<File name="SimpleGraphic/Fonts/Liberation Sans Bold.20.tga" part="runtime" sha1="cd39f6277e61c3e6bae24ffca3db64ade0cdb385" />
+	<File name="SimpleGraphic/Fonts/Liberation Sans Bold.24.tga" part="runtime" sha1="909ed51261062dcc236a5d8f098d0b27defa9c48" />
+	<File name="SimpleGraphic/Fonts/Liberation Sans Bold.28.tga" part="runtime" sha1="9c492dab86435d5afc634485d7ed3a7989cd4c08" />
+	<File name="SimpleGraphic/Fonts/Liberation Sans Bold.32.tga" part="runtime" sha1="e8927530dc94099ce5d5f92568d29b1e3dc1dc7f" />
+	<File name="SimpleGraphic/Fonts/Liberation Sans Bold.tgf" part="runtime" sha1="704c68c7f87906e7b2159a0f0e0cb7160861178e" />
+	<File name="SimpleGraphic/Fonts/Liberation Sans.10.tga" part="runtime" sha1="24b476e990fe5804df7264f225b6db63ad956907" />
+	<File name="SimpleGraphic/Fonts/Liberation Sans.12.tga" part="runtime" sha1="ec96b2a3d13ea40ac5a9cdcb1a1bf9702461a2df" />
+	<File name="SimpleGraphic/Fonts/Liberation Sans.14.tga" part="runtime" sha1="8e698d7b5701d0fff9594394eb789526ba65547e" />
+	<File name="SimpleGraphic/Fonts/Liberation Sans.16.tga" part="runtime" sha1="37e84115416caeb52e6e65b37e0f378bcfe14447" />
+	<File name="SimpleGraphic/Fonts/Liberation Sans.18.tga" part="runtime" sha1="3db0c18bc2333570598381aff2a103fc786d27db" />
+	<File name="SimpleGraphic/Fonts/Liberation Sans.20.tga" part="runtime" sha1="f2f757885b1359164c78b11108a7d2f1beb0a706" />
+	<File name="SimpleGraphic/Fonts/Liberation Sans.24.tga" part="runtime" sha1="6a5e5a131dd6ec31304d3889c1dacb326ccf0a03" />
+	<File name="SimpleGraphic/Fonts/Liberation Sans.28.tga" part="runtime" sha1="3175f25ff2ba00f95f10078bea790ff591943c46" />
+	<File name="SimpleGraphic/Fonts/Liberation Sans.32.tga" part="runtime" sha1="526edb97597a06ed0d9689107a4e130a22faf810" />
+	<File name="SimpleGraphic/Fonts/Liberation Sans.tgf" part="runtime" sha1="31fdef9c0e2ad46df47123e7d81f5e8d4fe399ed" />
+	<File name="lua/base64.lua" part="runtime" sha1="18629865eb351e483178b6524fb3935cbc9b8297" />
+	<File name="lua/dkjson.lua" part="runtime" sha1="16cbc26080996d9da827df42cb0844a25518eeb3" />
+	<File name="lua/sha1.lua" part="runtime" sha1="31e325cd40a9c0234c6265689cf70b97ef676f20" />
+	<File name="lua/xml.lua" part="runtime" sha1="859e09104842f91a4aaa9a4d9fadf667535877e2" />
+	<File name="TreeData/Background1.png" part="tree" sha1="77e4564761c38c755bee821f512e574d62b3a3b7" />
+	<File name="TreeData/BackgroundDex.png" part="tree" sha1="11ac1fcb1bd0ffef54dc478e1e6b3e23823bfb18" />
+	<File name="TreeData/BackgroundDexInt.png" part="tree" sha1="424f67c77c905291f140074f790ebfbd3a7b9a9b" />
+	<File name="TreeData/BackgroundInt.png" part="tree" sha1="b9871a87c189bcc55b4b76c9e1b341f6d3099deb" />
+	<File name="TreeData/BackgroundStr.png" part="tree" sha1="6d81b45041b510b0162d1c32c0c358627972c507" />
+	<File name="TreeData/BackgroundStrDex.png" part="tree" sha1="81f57fc4c4138b922c9c45d7ef3af9c2643063d8" />
+	<File name="TreeData/BackgroundStrInt.png" part="tree" sha1="1b02b0aec15ede4761a7fae1a9a108e8f958d13e" />
+	<File name="TreeData/BlightedNotableFrameAllocated.png" part="tree" sha1="8f37a253911a0019cfdea301075f28dee41ae675" />
+	<File name="TreeData/BlightedNotableFrameCanAllocate.png" part="tree" sha1="955d47ef4f110d059b2d691b57f370a580d7f805" />
+	<File name="TreeData/BlightedNotableFrameUnallocated.png" part="tree" sha1="5e36a22cd35dcf53871b6302e78c18a677baeda2" />
+	<File name="TreeData/centerduelist.png" part="tree" sha1="fe8783affb4fd5c43c3e18a74da279ecc38e6f28" />
+	<File name="TreeData/centermarauder.png" part="tree" sha1="d5fa638543829b404228d9023f1cb17405664799" />
+	<File name="TreeData/centerranger.png" part="tree" sha1="6adabfadc5a17886e07bea0db6d665540dc73823" />
+	<File name="TreeData/centerscion.png" part="tree" sha1="e9cfae2dda31986f7124dd1c8658651589c10976" />
+	<File name="TreeData/centershadow.png" part="tree" sha1="04e5beade48d335c770c47eae1725ff245492e2e" />
+	<File name="TreeData/centertemplar.png" part="tree" sha1="72a4bc7d712aff2776abd98331baee0c57aa758a" />
+	<File name="TreeData/centerwitch.png" part="tree" sha1="9fb9158a7bc51ed9391752b4322c88752d37ce95" />
+	<File name="TreeData/ClassesAscendant.png" part="tree" sha1="4a1be6448348a41089cf4ff1fa35111313853133" />
+	<File name="TreeData/ClassesAssassin.png" part="tree" sha1="fd748fbcf0c29924f5818a32322e1d1134828f9f" />
+	<File name="TreeData/ClassesBerserker.png" part="tree" sha1="2ea6be9c3cc3f2d5dbc65fbb5b0d51dfe2ae0240" />
+	<File name="TreeData/ClassesChampion.png" part="tree" sha1="1bb449a170f751dc282896595f0ac6d0a8238bef" />
+	<File name="TreeData/ClassesChieftain.png" part="tree" sha1="27f73668926bc3fc92ae21869f1b637682559092" />
+	<File name="TreeData/ClassesDeadeye.png" part="tree" sha1="b2c9e23636098604fd0d4016f11b5155d33d300b" />
+	<File name="TreeData/ClassesElementalist.png" part="tree" sha1="2c57055fdb673274ca39ecb7435af9b234c87b87" />
+	<File name="TreeData/ClassesGladiator.png" part="tree" sha1="cf2ec8605adc294ffb4f332cae3399d68bf15688" />
+	<File name="TreeData/ClassesGuardian.png" part="tree" sha1="294a825b73db5d6e134b103581bad1e64029317b" />
+	<File name="TreeData/ClassesHierophant.png" part="tree" sha1="2885e12eeddf92ebe7f625338368b825f050f156" />
+	<File name="TreeData/ClassesInquisitor.png" part="tree" sha1="d18bd9060e56213215e3c759d707bd668ed8a74d" />
+	<File name="TreeData/ClassesJuggernaut.png" part="tree" sha1="3a0f2eb93b911bd53989db10c1ba3f57b7a79437" />
+	<File name="TreeData/ClassesNecromancer.png" part="tree" sha1="cb80494666cd105dbb6d15b4f01bc23626f50e18" />
+	<File name="TreeData/ClassesOccultist.png" part="tree" sha1="9d7a219a17c67f0e5db1d50e6c6e9cc80cbee1d6" />
+	<File name="TreeData/ClassesPathfinder.png" part="tree" sha1="325f836cdca0439869e8c37a677f13ee59bfb56c" />
+	<File name="TreeData/ClassesRaider.png" part="tree" sha1="7b949b22e66d8b656788b0477297b0e3d9506982" />
+	<File name="TreeData/ClassesSaboteur.png" part="tree" sha1="42cc31a1d98987a17303aecf8622644a6d3af857" />
+	<File name="TreeData/ClassesSlayer.png" part="tree" sha1="9aef4e2aca1fdd23e4912e88879fbab997156ffd" />
+	<File name="TreeData/ClassesTrickster.png" part="tree" sha1="0aada4f66055e25842de241d428b49df3ced2abb" />
+	<File name="TreeData/imgPSFadeCorner.png" part="tree" sha1="bcfa9be1d6cdbaf9f0b926fbb3c7025b7a777cd2" />
+	<File name="TreeData/imgPSFadeSide.png" part="tree" sha1="f3ff70a3288d63d0807a13b947cc96e87105bf7c" />
+	<File name="TreeData/JewelFrameAllocated.png" part="tree" sha1="354ceefdbbba413cb120ee65c823b2ec8cf498b7" />
+	<File name="TreeData/JewelFrameCanAllocate.png" part="tree" sha1="b7902f15c86ff6bc55f8b61a3c5068b62d131b27" />
+	<File name="TreeData/JewelFrameUnallocated.png" part="tree" sha1="ae859797fd7741fa4b8a80c1e924eb7c696f2ca8" />
+	<File name="TreeData/JewelSocketActiveAbyss.png" part="tree" sha1="4f675d3e44ee8f989fb0164a3c6e87c580374c45" />
+	<File name="TreeData/JewelSocketActiveBlue.png" part="tree" sha1="39796196dc48f0a5cfd648d6b87631960c165891" />
+	<File name="TreeData/JewelSocketActiveGreen.png" part="tree" sha1="c0e4c8192a0593e2174152412c1744897c4dc79b" />
+	<File name="TreeData/JewelSocketActivePrismatic.png" part="tree" sha1="333bbd5ec8e58dbc37958fb5c5cb4cbc70df1cb8" />
+	<File name="TreeData/JewelSocketActiveRed.png" part="tree" sha1="32487978b9c0ec456b8a4b8f189c84d3c86ae21c" />
+	<File name="TreeData/KeystoneFrameAllocated.png" part="tree" sha1="5245118418a446ff8bcdfcf821136c6fbc0522b9" />
+	<File name="TreeData/KeystoneFrameCanAllocate.png" part="tree" sha1="44b9d99ec9f3cc21d6ad9c14a3dff547f89641f7" />
+	<File name="TreeData/KeystoneFrameUnallocated.png" part="tree" sha1="0630de48ca2f34cdad37076673691f626936b6ba" />
+	<File name="TreeData/LineConnectorActive.png" part="tree" sha1="13ba1f39278e7ab1819dad356dfe82fcda9e5bd1" />
+	<File name="TreeData/LineConnectorIntermediate.png" part="tree" sha1="e22fe9245c8b97b58a1b85764f417ac3dfce95fa" />
+	<File name="TreeData/LineConnectorNormal.png" part="tree" sha1="3398fb895afa45f6f120cf99ca3c710b34cfabbb" />
+	<File name="TreeData/NotableFrameAllocated.png" part="tree" sha1="e0c01cd83cc50dd333d11299b29ddc02ff8c20aa" />
+	<File name="TreeData/NotableFrameCanAllocate.png" part="tree" sha1="87973c184c904a4f7655d12cfd695d13c4108ab0" />
+	<File name="TreeData/NotableFrameUnallocated.png" part="tree" sha1="b897b879edcb1f0f73ff8609926fc9ff0fa2da5f" />
+	<File name="TreeData/Orbit1Active.png" part="tree" sha1="6ce274dd7ad17e94dfb00104e46bcb4e49a29302" />
+	<File name="TreeData/Orbit1Intermediate.png" part="tree" sha1="507046732f1bc04035243d14a51817125840df37" />
+	<File name="TreeData/Orbit1Normal.png" part="tree" sha1="ec90b5d35db1f413c2c1a50f59892ce44ff53e64" />
+	<File name="TreeData/Orbit2Active.png" part="tree" sha1="6c9fbaac3854b46eba138b5895d88a98b4f96776" />
+	<File name="TreeData/Orbit2Intermediate.png" part="tree" sha1="d000a4a423bd5ebd2d413a3b937f468536112dd8" />
+	<File name="TreeData/Orbit2Normal.png" part="tree" sha1="cfa18119d7276877bc34b26ff74264a9a7f6ffe5" />
+	<File name="TreeData/Orbit3Active.png" part="tree" sha1="c785c16a77434ad5ca196b0ee5139e38c6bb6d02" />
+	<File name="TreeData/Orbit3Intermediate.png" part="tree" sha1="8e9814aec5a004c587979764528a29a3dcab21f4" />
+	<File name="TreeData/Orbit3Normal.png" part="tree" sha1="07bbd0b5e75aec3a9c87b5b753314e6cb8f8221e" />
+	<File name="TreeData/Orbit4Active.png" part="tree" sha1="4a3784eb7fa4f4dd818b6f84d8e9348d58d4b64f" />
+	<File name="TreeData/Orbit4Intermediate.png" part="tree" sha1="7dc05d9788078fed0f09de81c3c3baa336618c8d" />
+	<File name="TreeData/Orbit4Normal.png" part="tree" sha1="1f374dbe1ad23ef2863158280659f46c0625b05f" />
+	<File name="TreeData/PassiveSkillScreenAscendancyButton.png" part="tree" sha1="570f34a29da650e6d6781890db7ff5d5a8dd18be" />
+	<File name="TreeData/PassiveSkillScreenAscendancyButtonHighlight.png" part="tree" sha1="862acbe013c081126e7477d827647c02cc67205b" />
+	<File name="TreeData/PassiveSkillScreenAscendancyButtonPressed.png" part="tree" sha1="bfdf7398d89e94ade00ee3a35e12827f2933465b" />
+	<File name="TreeData/PassiveSkillScreenAscendancyFrameLargeAllocated.png" part="tree" sha1="43327a0658f14291c2d6d17a48d3b6a798a013dc" />
+	<File name="TreeData/PassiveSkillScreenAscendancyFrameLargeCanAllocate.png" part="tree" sha1="e7cad0dede1afdf3e84259f54e6d6dcc0920eb39" />
+	<File name="TreeData/PassiveSkillScreenAscendancyFrameLargeNormal.png" part="tree" sha1="f19d1c23f892931132d781cc26010cbd200bd3bf" />
+	<File name="TreeData/PassiveSkillScreenAscendancyFrameSmallAllocated.png" part="tree" sha1="ebf837e2e27ba7e5c85d1410f8cec3fa4ea3eb3a" />
+	<File name="TreeData/PassiveSkillScreenAscendancyFrameSmallCanAllocate.png" part="tree" sha1="b009e1d2b8ed65f6752c0011ff48d0a6b7387727" />
+	<File name="TreeData/PassiveSkillScreenAscendancyFrameSmallNormal.png" part="tree" sha1="430317839843c64f4bd6ee92406e425027156654" />
+	<File name="TreeData/PassiveSkillScreenAscendancyMiddle.png" part="tree" sha1="7bad658a6a0140d747c7f403d73b1fe6b8b3939e" />
+	<File name="TreeData/PassiveSkillScreenEternalEmpireJewelCircle1.png" part="tree" sha1="b2cd3358201b40b6810459d4dcb29ceca237bb5d" />
+	<File name="TreeData/PassiveSkillScreenEternalEmpireJewelCircle2.png" part="tree" sha1="f33ccfa1f043028f2b4fbad14e6b7b48c7da259c" />
+	<File name="TreeData/PassiveSkillScreenJewelCircle1.png" part="tree" sha1="797ed1d1308d9d892a08022515f9521f3a74b341" />
+	<File name="TreeData/PassiveSkillScreenKaruiJewelCircle1.png" part="tree" sha1="1da79ad9b413f7ba830558aca4fffe59ec79bd05" />
+	<File name="TreeData/PassiveSkillScreenKaruiJewelCircle2.png" part="tree" sha1="88e0408c45d27d7ba772b631048519e47b52c59e" />
+	<File name="TreeData/PassiveSkillScreenMarakethJewelCircle1.png" part="tree" sha1="ec6aea0cbe5139b382136ecd91afcb655169a706" />
+	<File name="TreeData/PassiveSkillScreenMarakethJewelCircle2.png" part="tree" sha1="c0e133ff7b4a560517767d3ec39744f9fe4a92de" />
+	<File name="TreeData/PassiveSkillScreenTemplarJewelCircle1.png" part="tree" sha1="9799e6eda8fdd0caa9787900611eeeee1205c7b4" />
+	<File name="TreeData/PassiveSkillScreenTemplarJewelCircle2.png" part="tree" sha1="298351ab5fd1117d7b09f9a8be11f037f3dcc1b2" />
+	<File name="TreeData/PassiveSkillScreenVaalJewelCircle1.png" part="tree" sha1="2a07b25f44b3873bba55028098634a04ac128d96" />
+	<File name="TreeData/PassiveSkillScreenVaalJewelCircle2.png" part="tree" sha1="974339171737e0a725a69f13298382e5a9e4a517" />
+	<File name="TreeData/PSGroupBackground1.png" part="tree" sha1="5b7773d80cbebaf8e0a459524da1543763e632e1" />
+	<File name="TreeData/PSGroupBackground2.png" part="tree" sha1="41e363241cb2f923f78b101ea883e50148c594d3" />
+	<File name="TreeData/PSGroupBackground3.png" part="tree" sha1="148fcef35603908cecaca2f3773020d05efcff45" />
+	<File name="TreeData/PSLineDeco.png" part="tree" sha1="a690fb4c3f9910939e398daee5dd4b7427a8e5a1" />
+	<File name="TreeData/PSLineDecoHighlighted.png" part="tree" sha1="a23866124ce4353cfcdc2903b584a4b527f375c1" />
+	<File name="TreeData/PSPointsFrame.png" part="tree" sha1="6e10d16cb9a4070c84f935d97064a2c05381c63b" />
+	<File name="TreeData/PSSkillFrame.png" part="tree" sha1="82fbfcd4d9c7b61464614f69aeeb6912712b7dde" />
+	<File name="TreeData/PSSkillFrameActive.png" part="tree" sha1="e820f2fd0187c7fb5e255b89a53115fd25847831" />
+	<File name="TreeData/PSSkillFrameHighlighted.png" part="tree" sha1="876508200ac2043ec9af17cc0d34382b990480e9" />
+	<File name="TreeData/PSStartNodeBackgroundInactive.png" part="tree" sha1="3f9173651fd88f8c9ed0ddf2c939a15e4767b973" />
+	<File name="TreeData/2_6/tree.lua" part="tree-2_6" sha1="ee02b7e6e521896c498d8b222b1efab04538eaa7" />
+	<File name="TreeData/2_6/skill_sprite-3-32f639bbfc42783ca7ec218a787dd918.jpg" part="tree-2_6" sha1="abf59db207e4256edd4d67a73e8ae2821418ca84" />
+	<File name="TreeData/2_6/skill_sprite-active-3-3e73c4c4534433ecfc340c7287093bd5.png" part="tree-2_6" sha1="8f8a0c2f6792a505dbc7b66570f28d409d8ad4af" />
+	<File name="TreeData/2_6/skill_sprite-active-3-7798fabab8a21829831293c20ac9c414.jpg" part="tree-2_6" sha1="5a1693ea2e3f4f46c4e7988edb58e2405ecf63a4" />
+	<File name="TreeData/3_6/tree.lua" part="program" sha1="9c28311886cf10799b745e843c3b06b1c40f0c24" />
+	<File name="TreeData/3_6/groups-3.png" part="tree-3_6" sha1="275e7066b61a7ad12ee59d34cd5a405d2d71a9d6" />
+	<File name="TreeData/3_6/skills-3.jpg" part="tree-3_6" sha1="ebc0c5c46007ec625ee2bf6bd65317be4bce088e" />
+	<File name="TreeData/3_6/skills-disabled-3.jpg" part="tree-3_6" sha1="e69a47709256d27e5529051522f018f3380fc457" />
+	<File name="TreeData/3_7/tree.lua" part="program" sha1="2c73d57dabd0054b884b2a63b8af9948592fd6ef" />
+	<File name="TreeData/3_7/groups-3.png" part="tree-3_7" sha1="dff51e75f0aafdae5118167c66b1cec360ff4b00" />
+	<File name="TreeData/3_7/skills-3.jpg" part="tree-3_7" sha1="0c82fd04e6afd6cacd35208cf499a35155ea4cda" />
+	<File name="TreeData/3_7/skills-disabled-3.jpg" part="tree-3_7" sha1="2930d625d1422d24c7d6ccaaacf0ed00e97e7391" />
+	<File name="TreeData/3_8/tree.lua" part="program" sha1="3472bc1eb7916dbee91fe4526462eec5316859ca" />
+	<File name="TreeData/3_8/groups-3.png" part="tree-3_8" sha1="f5ef46af99150b25e44babac41c96ee58c87b44d" />
+	<File name="TreeData/3_8/skills-3.jpg" part="tree-3_8" sha1="e2ba51c375dd1c6e105303f296bfae966c495f6d" />
+	<File name="TreeData/3_8/skills-disabled-3.jpg" part="tree-3_8" sha1="43c308d6949611832b3f0e84da4acde45bfcfd32" />
 </PoBVersion>

--- a/patch_fork.ps1
+++ b/patch_fork.ps1
@@ -1,0 +1,8 @@
+$fork = "edmundsmith";
+Write-Output "Patching to use the $fork fork...";
+$source = "https://raw.githubusercontent.com/$fork/PathOfBuilding/master/manifest.xml";
+$dest = "$env:ProgramData\Path of Building\manifest.xml";
+
+$cli = New-Object System.Net.WebClient;
+$cli.Headers['User-Agent'] = 'Mozilla/5.0 Powershell';
+$cli.DownloadFile($source, $dest)

--- a/updatemanifest.py
+++ b/updatemanifest.py
@@ -1,0 +1,20 @@
+import xml.etree.ElementTree
+import hashlib
+
+manifest = xml.etree.ElementTree.parse("manifest.xml")
+root = manifest.getroot()
+
+for file in root.iter("File"):
+	path = file.get('name')	
+	if path[-4:] != ".lua":
+		print("Skipping file type {}".format(path[-4:]))
+		continue
+	try:
+		hash = hashlib.sha1(open(path, 'rb').read()).hexdigest()
+		file.set("sha1", hash)
+		print("path {} hash {}".format(path,hash))
+	except FileNotFoundError:
+		print("file not found, skipping: {}".format(path))
+		continue
+		
+manifest.write("manifest-updated.xml")


### PR DESCRIPTION
Hi,
I've been using/tweaking PoB for a while now, and I was getting frustrated at some of the slowdown in being kept up to date or reviewing pull reqs on the master repo combined with the inability for a non-technical user to use a fork repo. As Openarl appears to be the only person with the sources to SimpleGraphics engine, installer, etc., while PoB's core was open source, if he didn't have time to make a public release then nobody else could make an easy-to-use public release either.
I saw that a few people had made efforts to re-create SimpleGraphics to allow for users to install their forks without needing dev mode/git, but these had stagnated. I started looking into how to make my own release packages, and after finding the graphics re-impls and skipping over install wizards to auto-install forks into dev mode I looked into how the `manifest.xml` and update system works.
From this, I created a python script to allow devs to make compatible `manifest.xml` files for their forks so that PoB can auto-update from the new forks, and I added a small PowerShell script for end users to use to switch their update sources from the Openarl repo to an updater-compatible fork.
The python script will only need to be run by the dev, so a Python dependency there is ok, while I used PowerShell for the end-user manifest-patcher script as Powershell 2.0 and higher should already be installed on every Windows 7 and higher machine (this is also why I used WebClient objects instead of the newer Invoke-RestMethod/WebRequest commands not included in PowerShell 2.0, the Windows 7 default version).

To use, `updatemanifest.py` will read the existing `manifest.xml` and output `manifest-updated.xml`, which can then be checked over/version incremented before replacing the old manifest. To add a new source file to the update system, it will need a <File> entry in the manifest, then have `updatemanifest.py` run again.
Once the remote repo contains the appropriate updated manifest file, end users can then run `patch_fork.ps1` to replace their installed PoB's manifest with this fork's updated manifest file. The next time PoB checks for an update, it will update itself from the fork's repo instead, using the fork's manifest.xml to check for which files to download and replace.
Once this is done, PoB will auto-update from the fork's repo as per usual (keeping the `manifest.xml` updated is therefore important, hence having the `updatemanifest` script).

You will want to change the `$fork` variable in `patch_forks.ps1` to point to your repo.

## TL;DR

These scripts allow a dev to make their repo PoB-update compatible (`updatemanifest.py`) and allow an end user to switch their regular, installed PoB's update channel from Openarl to any compatible fork (just edit the `$fork` variable in patch_fork.ps1`) and then PoB-update Just Works