### PR TITLE
Hotfix minion dps sorting

### DIFF
--- a/Classes/CalcsTab.lua
+++ b/Classes/CalcsTab.lua
@@ -496,6 +496,10 @@ function CalcsTabClass:PowerBuilder()
 end
 
 function CalcsTabClass:CalculatePowerStat(selection, original, modified)
+	if modified.Minion then
+		original = original.Minion
+		modified = modified.Minion
+	end
 	originalValue = original[selection.stat] or 0
 	modifiedValue = modified[selection.stat] or 0
 	if selection.transform then

--- a/Classes/ItemDBControl.lua
+++ b/Classes/ItemDBControl.lua
@@ -188,6 +188,9 @@ function ItemDBClass:ListBuilder()
 			for slotName, slot in pairs(self.itemsTab.slots) do
 				if self.itemsTab:IsItemValidForSlot(item, slotName) and not slot.inactive and (not slot.weaponSet or slot.weaponSet == (self.itemsTab.activeItemSet.useSecondWeaponSet and 2 or 1)) then
 					local output = calcFunc(item.base.flask and { toggleFlask = item } or { repSlotName = slotName, repItem = item })
+					if calcBase.Minion and output.Minion then
+						output = output.Minion
+					end
 					item.measuredPower = output[self.sortMode] or 0
 					if self.sortDetail.transform then
 						item.measuredPower = self.sortDetail.transform(item.measuredPower)

--- a/Classes/ItemDBControl.lua
+++ b/Classes/ItemDBControl.lua
@@ -182,19 +182,16 @@ function ItemDBClass:ListBuilder()
 	if self.sortDetail and self.sortDetail.stat then -- stat-based
 		local start = GetTime()
 		local calcFunc, calcBase = self.itemsTab.build.calcsTab:GetMiscCalculator(self.build)
-		local originalValue = calcBase[self.sortMode]
 		for itemIndex, item in ipairs(list) do
 			item.measuredPower = 0
 			for slotName, slot in pairs(self.itemsTab.slots) do
 				if self.itemsTab:IsItemValidForSlot(item, slotName) and not slot.inactive and (not slot.weaponSet or slot.weaponSet == (self.itemsTab.activeItemSet.useSecondWeaponSet and 2 or 1)) then
 					local output = calcFunc(item.base.flask and { toggleFlask = item } or { repSlotName = slotName, repItem = item })
-					if calcBase.Minion and output.Minion then
-						output = output.Minion
-					end
-					item.measuredPower = output[self.sortMode] or 0
+					local measuredPower = output.Minion and output.Minion[self.sortMode] or output[self.sortMode] or 0
 					if self.sortDetail.transform then
-						item.measuredPower = self.sortDetail.transform(item.measuredPower)
-					end			
+						measuredPower = self.sortDetail.transform(measuredPower)
+					end
+					item.measuredPower = m_max(item.measuredPower, measuredPower)
 				end
 			end
 			local now = GetTime()


### PR DESCRIPTION
* Use minion stats for item sorting and tree highlighting if a minion skill is selected, player stats otherwise. Should solve Issue #5 
* Items are now sorted by the highest bonus they can provide given all possible slots that the item can be equipped in.