### PR TITLE
Crazed Driver Spectre

### DIFF
--- a/Data/3_0/Skills/spectre.lua
+++ b/Data/3_0/Skills/spectre.lua
@@ -1499,6 +1499,36 @@ skills["KitavaDemonXMortar"] = {
 		[2] = { 2, 500, 0.54000002145767, 0.80000001192093, 10, 0, 125, cooldown = 3, levelRequirement = 68, statInterpolation = { 1, 1, 3, 3, 1, 1, 1, }, },
 	},
 }
+skills["KitavaSlavedriverFlameWhip"] = {
+	name = "Flame Surge",
+	hidden = true,
+	color = 3,
+	baseEffectiveness = 2.5,
+	incrementalEffectiveness = 0.045000001788139,
+	description = "Strikes enemies in front of you with a surge of flame. Burning enemies are dealt more damage.",
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Hit] = true, [SkillType.SkillCanTrap] = true, [SkillType.SkillCanTotem] = true, [SkillType.SkillCanMine] = true, [SkillType.SpellCanRepeat] = true, [SkillType.Triggerable] = true, [SkillType.Area] = true, [SkillType.FireSkill] = true, [SkillType.CanRapidFire] = true, [SkillType.AreaSpell] = true, },
+	statDescriptionScope = "skill_stat_descriptions",
+	castTime = 0.5,
+	baseFlags = {
+		spell = true,
+		area = true,
+	},
+	baseMods = {
+		skill("radius", 30),
+	},
+	qualityStats = {
+	},
+	stats = {
+		"spell_minimum_base_physical_damage",
+		"spell_maximum_base_physical_damage",
+		"active_skill_area_of_effect_radius_+%_final",
+		"base_cast_speed_+%",
+		"is_area_damage",
+	},
+	levels = {
+		[1] = { 0.30896384046, 0.46337742297, 50, -65, critChance = 6, levelRequirement = 1, statInterpolation = { 3, 3, 1, 1, }, },
+	},
+}
 skills["MassFrenzy"] = {
 	name = "Mass Frenzy",
 	hidden = true,

--- a/Data/3_0/Spectres.lua
+++ b/Data/3_0/Spectres.lua
@@ -2383,6 +2383,30 @@ minions["Metadata/Monsters/Taster/Taster"] = {
 	},
 }
 -- Templar
+minions["Metadata/Monsters/TemplarCrazedDriver/TemplarCrazedDriver"] = {
+	name = "Crazed Driver",
+	life = 1,
+	armour = 0.25,
+	fireResist = 0,
+	coldResist = 40,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 1,
+	damageSpread = 0.2,
+	attackTime = 1.845,
+	attackRange = 8,
+	accuracy = 1,
+	weaponType1 = "One Handed Mace",
+	weaponType2 = "One Handed Mace",
+	skillList = {
+		"SlaverTaunt",
+		"Melee",
+		"KitavaSlavedriverFlameWhip",
+	},
+	modList = {
+		-- MonsterImplicitFastRun4 [base_movement_velocity_+% = 20]
+	},
+}
 minions["Metadata/Monsters/TemplarSlaveDriver/TemplarSlaveDriver"] = {
 	name = "Slave Driver",
 	life = 1,


### PR DESCRIPTION
As noted in their individual commits, these may not be exact. I've populated the values manually with poedb as a reference so if nothing else it should be good enough for an approximation (experience in-game in the previous league suggests that that's true).

Because these files are generated this certainly isn't the *best* option. I'll see if I can't figure that out going forward. This may lead to rebase/back-merge conflicts when the Openarl trunk is updated, so I absolutely understand if this isn't something worth merging as-is.