### PR TITLE
Fix for skills with 'cannot_pierce' stat

### DIFF
--- a/Data/3_0/SkillStatMap.lua
+++ b/Data/3_0/SkillStatMap.lua
@@ -720,6 +720,9 @@ return {
 ["always_pierce"] = {
 	flag("PierceAllTargets"),
 },
+["cannot_pierce"] = {
+	flag("CannotPierce"),
+},
 ["base_number_of_additional_arrows"] = {
 	mod("ProjectileCount", "BASE", nil),
 },


### PR DESCRIPTION
Toxic Rain and (Vaal) Rain of Arrows
Should solve #31.