### PR TITLE
Ryslatha's coil support - currently blocked on a parsing bug

### DIFF
--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -1031,8 +1031,8 @@ function calcs.offence(env, actor, activeSkill)
 						-- Apply crit multiplier
 						allMult = allMult * output.CritMultiplier
 					end				
-					min = min * allMult
-					max = max * allMult
+					min = min * allMult * skillModList:More(cfg, "Minimum"..damageType.."Damage")
+					max = max * allMult * skillModList:More(cfg, "Maximum"..damageType.."Damage")
 					if (min ~= 0 or max ~= 0) and env.mode_effective then
 						-- Apply enemy resistances and damage taken modifiers
 						local resist = 0

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -367,6 +367,8 @@ local modNameList = {
 	["non-chaos damage"] = "NonChaosDamage",
 	["elemental damage"] = "ElementalDamage",
 	-- Other damage forms
+	["maximum physical attack damage"] = { "MaximumPhysicalDamage", flags = ModFlag.Attack },
+	["minimum physical attack damage"] = { "MinimumPhysicalDamage", flags = ModFlag.Attack },
 	["attack damage"] = { "Damage", flags = ModFlag.Attack },
 	["attack physical damage"] = { "PhysicalDamage", flags = ModFlag.Attack },
 	["physical attack damage"] = { "PhysicalDamage", flags = ModFlag.Attack },


### PR DESCRIPTION
This adds everything needed for supporting Ryslatha's Coil, excepting a spacing bug in the parser elsewhere: a leading 'M' will not be detected (?). The following work:

    40% moreMaximum ...
    40% more  Maximum ...
    40% more maximum ...
    40% more pMaximum ... (with "pmaximum..." in the modNameList)
and yet the parseMods won't accept

    40% more Maximum ... (the version on the item)

The `parseMods` function likely has some problem causing the <space>M to bug out, but I can't find it yet.