### PR TITLE
Add a few new spectres

### DIFF
--- a/Data/3_0/Skills/spectre.lua
+++ b/Data/3_0/Skills/spectre.lua
@@ -91,6 +91,17 @@ skills["BanditExplosiveArrow"] = {
 	},
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
+	statMap = {
+		["minimum_fire_damage_per_fuse_arrow_orb"] = {
+			skill("FireMin", nil, { type = "Multiplier", var = "ExplosiveArrowFuse" }),
+		},
+		["maximum_fire_damage_per_fuse_arrow_orb"] = {
+			skill("FireMax", nil, { type = "Multiplier", var = "ExplosiveArrowFuse" }),
+		},
+		["fuse_arrow_explosion_radius_+_per_fuse_arrow_orb"] = {
+			skill("radiusExtra", nil, { type = "Multiplier", var = "ExplosiveArrowFuse" }),
+		},
+	},
 	baseFlags = {
 		cast = true,
 		projectile = true,
@@ -98,7 +109,9 @@ skills["BanditExplosiveArrow"] = {
 		duration = true,
 	},
 	baseMods = {
+		skill("radius", 15),
 		skill("showAverage", true),
+		mod("Multiplier:ExplosiveArrowFuse", "BASE", 1, 0, 0),
 	},
 	qualityStats = {
 	},
@@ -116,6 +129,40 @@ skills["BanditExplosiveArrow"] = {
 		[2] = { 1000, 0.80000001192093, 1.2000000476837, 2, 0, 1, 1, critChance = 6, levelRequirement = 10, manaCost = 5, statInterpolation = { 1, 3, 3, 1, 1, 1, 1, }, },
 		[3] = { 1000, 0.80000001192093, 1.2000000476837, 2, 0, 1, 1, critChance = 6, levelRequirement = 20, manaCost = 4, statInterpolation = { 1, 3, 3, 1, 1, 1, 1, }, },
 		[4] = { 1000, 1.2000000476837, 1.7999999523163, 2, 0, 1, 1, critChance = 6, levelRequirement = 68, manaCost = 4, statInterpolation = { 1, 3, 3, 1, 1, 1, 1, }, },
+	},
+}
+skills["BanditChampionBlastRainSpectre"] = {
+	name = "Blast Rain",
+	hidden = true,
+	color = 2,
+	description = "Fires an arrow up in the air, which splits and rains down in a series of explosions over an area. The explosions will always overlap on the targeted area.",
+	skillTypes = { [SkillType.Attack] = true, [SkillType.Area] = true, [SkillType.ProjectileDamage] = true, [SkillType.SkillCanTotem] = true, [SkillType.SkillCanTrap] = true, [SkillType.SkillCanMine] = true, [SkillType.FireSkill] = true, [SkillType.ProjectileAttack] = true, [SkillType.SkillCanMirageArcher] = true, [SkillType.Triggerable] = true, [SkillType.Triggerable] = true, },
+	weaponTypes = {
+		["Bow"] = true,
+	},
+	statDescriptionScope = "skill_stat_descriptions",
+	castTime = 1,
+	baseFlags = {
+		attack = true,
+		projectile = true,
+		area = true,
+	},
+	baseMods = {
+		skill("radius", 24),
+		skill("dpsMultiplier", 4),
+	},
+	qualityStats = {
+	},
+	stats = {
+		"skill_physical_damage_%_to_convert_to_fire",
+		"active_skill_area_of_effect_radius_+%_final",
+		"blast_rain_number_of_blasts",
+		"blast_rain_arrow_delay_ms",
+		"base_is_projectile",
+		"is_area_damage",
+	},
+	levels = {
+		[1] = { 50, 0, 4, 80, damageEffectiveness = 0.5, baseMultiplier = 0.5, levelRequirement = 15, statInterpolation = { 1, 1, 1, 1, }, },
 	},
 }
 skills["BeastCleave"] = {
@@ -538,6 +585,47 @@ skills["DemonModularBladeVortexSpectre"] = {
 	},
 	levels = {
 		[1] = { 0.80000001192093, 1.2000000476837, 5000, 5, 0, 2, critChance = 6, levelRequirement = 3, statInterpolation = { 3, 3, 1, 1, 1, 1, }, },
+	},
+}
+skills["ElementalHitSkeletonKnight"] = {
+	name = "Elemental Hit Fire",
+	hidden = true,
+	color = 2,
+	baseEffectiveness = 1.1667000055313,
+	incrementalEffectiveness = 0.04280000180006,
+	description = "Each attack with this skill will choose an element at random, and will only be able to deal damage of that element. If the attack hits an enemy, it will also deal damage in an area around them, with the radius being larger if that enemy is suffering from an ailment of the chosen element. It will avoid choosing the same element twice in a row.",
+	skillTypes = { [SkillType.Attack] = true, [SkillType.Projectile] = true, [SkillType.SkillCanVolley] = true, [SkillType.SkillCanTotem] = true, [SkillType.SkillCanTrap] = true, [SkillType.SkillCanMine] = true, [SkillType.MeleeSingleTarget] = true, [SkillType.AttackCanRepeat] = true, [SkillType.Melee] = true, [SkillType.FireSkill] = true, [SkillType.ColdSkill] = true, [SkillType.LightningSkill] = true, [SkillType.ProjectileAttack] = true, [SkillType.SkillCanMirageArcher] = true, [SkillType.Area] = true, [SkillType.Triggerable] = true, },
+	statDescriptionScope = "skill_stat_descriptions",
+	castTime = 1,
+	baseFlags = {
+		attack = true,
+		projectile = true,
+		melee = true,
+	},
+	baseMods = {
+		flag("DealNoPhysical"),
+		flag("DealNoChaos"),
+		flag("DealNoCold"),
+		flag("DealNoLightning"),
+		mod("AreaOfEffect", "MORE", 80, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Ignited" }),
+		mod("Multiplier:ElementalHitAilmentOnEnemy", "BASE", 1, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Ignited" }),
+		mod("Multiplier:ElementalHitAilmentOnEnemy", "BASE", 1, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Chilled" }),
+		mod("Multiplier:ElementalHitAilmentOnEnemy", "BASE", 1, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Frozen" }),
+		mod("Multiplier:ElementalHitAilmentOnEnemy", "BASE", 1, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Shocked" }),
+		mod("Damage", "MORE", 10, 0, 0, { type = "Multiplier", var = "ElementalHitAilmentOnEnemy" }),
+	},
+	qualityStats = {
+	},
+	stats = {
+		"active_skill_damage_+%_final",
+		"chance_to_freeze_shock_ignite_%",
+		"is_area_damage",
+	},
+	levels = {
+		[1] = { 0, 25, baseMultiplier = 1.5, levelRequirement = 1, statInterpolation = { 2, 1, }, },
+		[2] = { 0, 25, baseMultiplier = 1.5, levelRequirement = 20, statInterpolation = { 2, 1, }, },
+		[3] = { 1, 25, baseMultiplier = 1.5, levelRequirement = 21, statInterpolation = { 2, 1, }, },
+		[4] = { 200, 25, baseMultiplier = 1.5, levelRequirement = 84, statInterpolation = { 2, 1, }, },
 	},
 }
 skills["ElementalHitSkeletonKnightIncursion"] = {
@@ -1093,7 +1181,7 @@ skills["HolyFireElementalFireball"] = {
 	},
 }
 skills["IguanaProjectile"] = {
-	name = "Ranged Attack",
+	name = "Barrage",
 	hidden = true,
 	color = 4,
 	skillTypes = { [SkillType.Attack] = true, [SkillType.ProjectileAttack] = true, [SkillType.SkillCanMirageArcher] = true, [SkillType.Projectile] = true, [SkillType.SkillCanVolley] = true, [SkillType.Hit] = true, [SkillType.Triggerable] = true, },
@@ -1117,6 +1205,34 @@ skills["IguanaProjectile"] = {
 	},
 	levels = {
 		[1] = { 4, 0, -60, -60, 30, cooldown = 3.5, levelRequirement = 1, statInterpolation = { 1, 1, 1, 1, 1, }, },
+	},
+}
+skills["IguanaProjectileChrome"] = {
+	name = "Barrage",
+	hidden = true,
+	color = 4,
+	skillTypes = { [SkillType.Attack] = true, [SkillType.ProjectileAttack] = true, [SkillType.SkillCanMirageArcher] = true, [SkillType.Projectile] = true, [SkillType.SkillCanVolley] = true, [SkillType.Hit] = true, [SkillType.Triggerable] = true, },
+	statDescriptionScope = "skill_stat_descriptions",
+	castTime = 1.5,
+	baseFlags = {
+		attack = true,
+		projectile = true,
+	},
+	baseMods = {
+	},
+	qualityStats = {
+	},
+	stats = {
+		"monster_projectile_variation",
+		"skill_repeat_count",
+		"spell_maximum_action_distance_+%",
+		"active_skill_damage_+%_final",
+		"monster_reverse_point_blank_damage_-%_at_minimum_range",
+		"skill_physical_damage_%_to_convert_to_cold",
+		"base_is_projectile",
+	},
+	levels = {
+		[1] = { 24, 0, -60, -30, 30, 50, cooldown = 3.5, levelRequirement = 1, statInterpolation = { 1, 1, 1, 1, 1, 1, }, },
 	},
 }
 skills["IncaMinionProjectile"] = {
@@ -1990,6 +2106,39 @@ skills["MonsterFlameRedCannibal"] = {
 	},
 	levels = {
 		[1] = { 0.80000001192093, 1.2000000476837, 8, 2, -75, 0, -25, 3, damageEffectiveness = 0.25, levelRequirement = 3, statInterpolation = { 3, 3, 1, 1, 1, 1, 1, 1, }, },
+	},
+}
+skills["MonsterIceShot"] = {
+	name = "Ice Shot",
+	hidden = true,
+	color = 2,
+	description = "Fires an arrow that converts some physical damage to cold on its target and converts all physical damage to cold in a cone behind that target. Creates a patch of ground ice under the target.",
+	skillTypes = { [SkillType.Attack] = true, [SkillType.ProjectileAttack] = true, [SkillType.SkillCanMirageArcher] = true, [SkillType.Projectile] = true, [SkillType.SkillCanVolley] = true, [SkillType.Area] = true, [SkillType.Duration] = true, [SkillType.SkillCanTotem] = true, [SkillType.SkillCanTrap] = true, [SkillType.SkillCanMine] = true, [SkillType.ColdSkill] = true, [SkillType.ChillingArea] = true, [SkillType.Triggerable] = true, },
+	weaponTypes = {
+		["Bow"] = true,
+	},
+	statDescriptionScope = "skill_stat_descriptions",
+	castTime = 1,
+	baseFlags = {
+		attack = true,
+		projectile = true,
+		area = true,
+		duration = true,
+	},
+	baseMods = {
+	},
+	qualityStats = {
+	},
+	stats = {
+		"skill_physical_damage_%_to_convert_to_cold",
+		"base_skill_effect_duration",
+		"physical_damage_+%",
+		"active_skill_damage_+%_final",
+		"skill_art_variation",
+		"skill_can_fire_arrows",
+	},
+	levels = {
+		[1] = { 50, 2500, 50, 0, 2, levelRequirement = 1, statInterpolation = { 1, 1, 1, 1, 1, }, },
 	},
 }
 skills["MountainGoatmanIceSpear"] = {
@@ -3142,6 +3291,41 @@ skills["SeaWitchWave"] = {
 		[2] = { 2.2400000095367, 3.3599998950958, 1, critChance = 5, levelRequirement = 68, manaCost = 6, statInterpolation = { 3, 3, 1, }, },
 	},
 }
+skills["SkeletonBlackAbyssBoneLance"] = {
+	name = "Unearth",
+	hidden = true,
+	color = 4,
+	baseEffectiveness = 1.5,
+	incrementalEffectiveness = 0.035000000149012,
+	description = "Fires a projectile that will pierce through enemies to impact the ground at the targeted location, creating a Bone Archer corpse where it lands.",
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.SkillCanVolley] = true, [SkillType.SkillCanTotem] = true, [SkillType.SkillCanMine] = true, [SkillType.SkillCanTrap] = true, [SkillType.Triggerable] = true, [SkillType.Hit] = true, [SkillType.SpellCanRepeat] = true, [SkillType.CanRapidFire] = true, [SkillType.Area] = true, [SkillType.AreaSpell] = true, [SkillType.PhysicalSkill] = true, },
+	statDescriptionScope = "skill_stat_descriptions",
+	castTime = 1.5,
+	baseFlags = {
+		spell = true,
+		projectile = true,
+		area = true,
+	},
+	baseMods = {
+	},
+	qualityStats = {
+	},
+	stats = {
+		"spell_minimum_base_physical_damage",
+		"spell_maximum_base_physical_damage",
+		"base_skill_effect_duration",
+		"alternate_minion",
+		"desecrate_maximum_number_of_corpses",
+		"base_projectile_speed_+%",
+		"base_is_projectile",
+		"always_pierce",
+		"projectile_uses_contact_position",
+	},
+	levels = {
+		[1] = { 0.80000001192093, 1.2000000476837, 6000, 0, 3, -35, cooldown = 6, levelRequirement = 1, statInterpolation = { 3, 3, 1, 1, 1, 1, }, },
+		[2] = { 0.80000001192093, 1.2000000476837, 6000, 0, 3, -35, cooldown = 6, levelRequirement = 82, statInterpolation = { 3, 3, 1, 1, 1, 1, }, },
+	},
+}
 skills["SkeletonCannonMortar"] = {
 	name = "Mortar",
 	hidden = true,
@@ -3294,6 +3478,38 @@ skills["SkeletonProjectileBlack"] = {
 		[1] = { 0.80000001192093, 1.2000000476837, 33, critChance = 5, levelRequirement = 1, statInterpolation = { 3, 3, 1, }, },
 	},
 }
+skills["SkeletonSoldierTornadoShot"] = {
+	name = "Tornado Shot",
+	hidden = true,
+	color = 2,
+	description = "Fires a piercing shot that travels until it reaches the targeted location. It will then fire projectiles out in all directions from that point.",
+	skillTypes = { [SkillType.Attack] = true, [SkillType.Projectile] = true, [SkillType.SkillCanVolley] = true, [SkillType.SkillCanTrap] = true, [SkillType.SkillCanMine] = true, [SkillType.SkillCanTotem] = true, [SkillType.ProjectileAttack] = true, [SkillType.SkillCanMirageArcher] = true, [SkillType.Triggerable] = true, },
+	weaponTypes = {
+		["Bow"] = true,
+	},
+	statDescriptionScope = "skill_stat_descriptions",
+	castTime = 1,
+	baseFlags = {
+		attack = true,
+		projectile = true,
+	},
+	baseMods = {
+	},
+	qualityStats = {
+	},
+	stats = {
+		"active_skill_damage_+%_final",
+		"number_of_additional_projectiles",
+		"tornado_shot_num_of_secondary_projectiles",
+		"base_is_projectile",
+		"skill_can_fire_arrows",
+	},
+	levels = {
+		[1] = { -30, 0, 3, levelRequirement = 2, statInterpolation = { 1, 1, 1, }, },
+		[2] = { -35, 0, 3, levelRequirement = 38, statInterpolation = { 1, 1, 1, }, },
+		[3] = { -40, 0, 3, levelRequirement = 54, statInterpolation = { 1, 1, 1, }, },
+	},
+}
 skills["SkeletonSpark"] = {
 	name = "Spark",
 	hidden = true,
@@ -3440,6 +3656,36 @@ skills["SlavedriverFlameWhip"] = {
 	},
 	levels = {
 		[1] = { 0.5, 1.5, 50, -65, critChance = 6, levelRequirement = 1, statInterpolation = { 3, 3, 1, 1, }, },
+	},
+}
+skills["KitavaSlavedriverFlameWhip"] = {
+	name = "Flame Surge",
+	hidden = true,
+	color = 3,
+	baseEffectiveness = 2.2000000476837,
+	incrementalEffectiveness = 0.027499999850988,
+	description = "Strikes enemies in front of you with a surge of flame. Burning enemies are dealt more damage.",
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Hit] = true, [SkillType.SkillCanTrap] = true, [SkillType.SkillCanTotem] = true, [SkillType.SkillCanMine] = true, [SkillType.SpellCanRepeat] = true, [SkillType.Triggerable] = true, [SkillType.Area] = true, [SkillType.FireSkill] = true, [SkillType.CanRapidFire] = true, [SkillType.AreaSpell] = true, },
+	statDescriptionScope = "skill_stat_descriptions",
+	castTime = 0.5,
+	baseFlags = {
+		spell = true,
+		area = true,
+	},
+	baseMods = {
+		skill("radius", 30),
+	},
+	qualityStats = {
+	},
+	stats = {
+		"spell_minimum_base_physical_damage",
+		"spell_maximum_base_physical_damage",
+		"active_skill_area_of_effect_radius_+%_final",
+		"base_cast_speed_+%",
+		"is_area_damage",
+	},
+	levels = {
+		[1] = { 0.80000001192093, 1.2000000476837, 50, -65, critChance = 6, levelRequirement = 1, statInterpolation = { 3, 3, 1, 1, }, },
 	},
 }
 skills["SnakeSpineProjectile"] = {

--- a/Data/3_0/Spectres.lua
+++ b/Data/3_0/Spectres.lua
@@ -273,6 +273,48 @@ minions["Metadata/Monsters/Bandit/DockworkerChampion_"] = {
 	modList = {
 	},
 }
+minions["Metadata/Monsters/Bandits/BanditBowChampion"] = {
+	name = "Kraityn's Sentry",
+	life = 1.57,
+	fireResist = 0,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 0.73,
+	damageSpread = 0.2,
+	attackTime = 1.995,
+	attackRange = 40,
+	accuracy = 1,
+	weaponType1 = "Bow",
+	skillList = {
+		"Melee",
+		"BanditExplosiveArrowChampion",
+		"BanditChampionBlastRain",
+		"BanditChampionBlastRainSpectre",
+	},
+	modList = {
+	},
+}
+minions["Metadata/Monsters/Bandits/BanditRangedTornadoShotPetrified"] = {
+	name = "Imperial Vanguard",
+	life = 0.96,
+	fireResist = 0,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 0.6,
+	damageSpread = 0.2,
+	attackTime = 1.995,
+	attackRange = 40,
+	accuracy = 1,
+	weaponType1 = "Bow",
+	skillList = {
+		"Melee",
+		"SkeletonSoldierTornadoShot",
+	},
+	modList = {
+	},
+}
 -- Beast
 minions["Metadata/Monsters/Beasts/BeastCaveDegenAura"] = {
 	name = "Shaggy Monstrosity",
@@ -809,6 +851,30 @@ minions["Metadata/Monsters/GemMonster/Iguana"] = {
 	modList = {
 		-- MonsterSuppressingFire [chance_to_apply_suppression_on_hit_% = 20]
 		-- DisplayMonsterSuppressingFire [display_monster_uses_suppressing_fire_text = 1]
+	},
+}
+minions["Metadata/Monsters/GemMonster/IguanaChrome"] = {
+	name = "Chrome-infused Chimeral",
+	life = 1.54,
+	energyShield = 0.2,
+	fireResist = 52,
+	coldResist = 52,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 1.12,
+	damageSpread = 0.2,
+	attackTime = 1.005,
+	attackRange = 9,
+	accuracy = 1,
+	skillList = {
+		"IguanaProjectileChrome",
+		"Melee",
+		"IguanaDoomArrow",
+	},
+	modList = {
+		-- MonsterSuppressingFire [chance_to_apply_suppression_on_hit_% = 20]
+		-- DisplayMonsterSuppressingFire [display_monster_uses_suppressing_fire_text = 1]
+		mod("PhysicalDamageGainAsCold", "BASE", 100), -- MonsterPhysicalAddedAsColdSkeletonMaps [physical_damage_%_to_add_as_cold = 100]
 	},
 }
 -- Ghost pirate
@@ -2248,6 +2314,53 @@ minions["Metadata/Monsters/Skeletons/SkeletonMeleeKnightElementalSwordIncursionC
 		-- MonsterCastsElementalHitText [monster_casts_elemental_hit_text = 1]
 	},
 }
+minions["Metadata/Monsters/Skeletons/SkeletonBowKnightElemental"] = {
+	name = "Vaal Slayer",
+	life = 0.96,
+	fireResist = 37,
+	coldResist = 37,
+	lightningResist = 37,
+	chaosResist = 0,
+	damage = 0.6,
+	damageSpread = 0.2,
+	attackTime = 1.995,
+	attackRange = 40,
+	accuracy = 1,
+	weaponType1 = "Bow",
+	skillList = {
+		"Melee",
+		"ElementalHitSkeletonKnight",
+	},
+	modList = {
+		-- MonsterCastsElementalHitText [monster_casts_elemental_hit_text = 1]
+	},
+}
+minions["Metadata/Monsters/Skeletons/SkeletonMeleeBlackAbyssBoneLance"] = {
+	name = "Primeval Hunter",
+	life = 1.7,
+	armour = 0.15,
+	fireResist = 0,
+	coldResist = 0,
+	lightningResist = 40,
+	chaosResist = 0,
+	damage = 1,
+	damageSpread = 0.3,
+	attackTime = 1.605,
+	attackRange = 14,
+	accuracy = 1,
+	weaponType1 = "Two Handed Mace",
+	skillList = {
+		"Melee",
+		"SkeletonBlackAbyssBoneLance",
+	},
+	modList = {
+		-- MonsterAbyssDropModifiers [monster_slain_experience_+% = 0] [monster_dropped_item_quantity_+% = 100] [monster_dropped_item_rarity_+% = 300] [monster_no_map_drops = 1]
+		-- VariableEmergeSpeedAbyss [emerge_speed_+% = 0]
+		-- CannotBeUsedAsMinion [cannot_be_used_as_minion = 1]
+		-- BreachReducedBeyondPortalChance [monster_beyond_portal_chance_+%_final = -66]
+		-- VariableEmergeSpeedAbyss [emerge_speed_+% = 0]
+	},
+}
 minions["Metadata/Monsters/SkeletonCannon/SkeletonCannon1"] = {
 	name = "Bone Husk",
 	life = 2.07,
@@ -2360,6 +2473,30 @@ minions["Metadata/Monsters/Statue/DaressoStatueLargeMaleSpear"] = {
 		-- MonsterCastsPunctureText [monster_casts_puncture_text = 1]
 	},
 }
+minions["Metadata/Monsters/Statue/StoneStatueMaleBow"] = {
+	name = "Archer Statue",
+	life = 2.46,
+	armour = 0.2,
+	fireResist = 0,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 0.72,
+	damageSpread = 0.2,
+	attackTime = 1.995,
+	attackRange = 40,
+	accuracy = 1,
+	damageFixup = 0.11,
+	weaponType1 = "Bow",
+	skillList = {
+		"Melee",
+		"MonsterIceShot",
+	},
+	modList = {
+		-- MonsterSpeedAndDamageFixupSmall [monster_base_type_attack_cast_speed_+%_and_damage_-%_final = 11]
+		-- MonsterFiresIceShotArrowsText [monster_fires_ice_shot_arrows_text = 1]
+	},
+}
 -- Ophidian
 minions["Metadata/Monsters/Taster/Taster"] = {
 	name = "Noisome Ophidian",
@@ -2402,6 +2539,30 @@ minions["Metadata/Monsters/TemplarSlaveDriver/TemplarSlaveDriver"] = {
 		"SlaverTaunt",
 		"Melee",
 		"SlavedriverFlameWhip",
+	},
+	modList = {
+		-- MonsterImplicitFastRun4 [base_movement_velocity_+% = 20]
+	},
+}
+minions["Metadata/Monsters/TemplarSlaveDriver/TemplarSlaveDriverKitava"] = {
+	name = "Crazed Driver",
+	life = 1,
+	armour = 0.25,
+	fireResist = 0,
+	coldResist = 40,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 1,
+	damageSpread = 0.2,
+	attackTime = 1.845,
+	attackRange = 8,
+	accuracy = 1,
+	weaponType1 = "One Handed Mace",
+	weaponType2 = "One Handed Mace",
+	skillList = {
+		"SlaverTaunt",
+		"Melee",
+		"KitavaSlavedriverFlameWhip",
 	},
 	modList = {
 		-- MonsterImplicitFastRun4 [base_movement_velocity_+% = 20]

--- a/Export/Minions/Spectres.txt
+++ b/Export/Minions/Spectres.txt
@@ -18,6 +18,8 @@ local minions, mod = ...
 #spectre Metadata/Monsters/Bandits/BanditBowPoisonArrow
 #spectre Metadata/Monsters/Bandits/BanditMeleeWarlordsMarkMaul
 #spectre Metadata/Monsters/Bandit/DockworkerChampion_
+#spectre Metadata/Monsters/Bandits/BanditBowChampion
+#spectre Metadata/Monsters/Bandits/BanditRangedTornadoShotPetrified
 -- Beast
 #spectre Metadata/Monsters/Beasts/BeastCaveDegenAura
 #spectre Metadata/Monsters/Beasts/BeastCleaveEnduringCry
@@ -51,6 +53,7 @@ local minions, mod = ...
 #spectre Metadata/Monsters/Frog/Frog2
 -- Chimeral
 #spectre Metadata/Monsters/GemMonster/Iguana
+#spectre Metadata/Monsters/GemMonster/IguanaChrome
 -- Ghost pirate
 #spectre Metadata/Monsters/GhostPirates/GhostPirateBlackBowMaps
 #spectre Metadata/Monsters/GhostPirates/GhostPirateBlackFlickerStrikeMaps
@@ -137,6 +140,8 @@ local minions, mod = ...
 #spectre Metadata/Monsters/Skeletons/SkeletonBlackCaster1_
 #spectre Metadata/Monsters/Skeletons/SkeletonBowProjectileWeaknessCurse
 #spectre Metadata/Monsters/Skeletons/SkeletonMeleeKnightElementalSwordIncursionChampionDelve
+#spectre Metadata/Monsters/Skeletons/SkeletonBowKnightElemental
+#spectre Metadata/Monsters/Skeletons/SkeletonMeleeBlackAbyssBoneLance
 #spectre Metadata/Monsters/SkeletonCannon/SkeletonCannon1
 -- Snake
 #spectre Metadata/Monsters/Snake/SnakeMeleeSpit
@@ -145,10 +150,12 @@ local minions, mod = ...
 #spectre Metadata/Monsters/Spiders/SpiderThornFlickerStrike
 -- Statue
 #spectre Metadata/Monsters/Statue/DaressoStatueLargeMaleSpear
+#spectre Metadata/Monsters/Statue/StoneStatueMaleBow
 -- Ophidian
 #spectre Metadata/Monsters/Taster/Taster
 -- Templar
 #spectre Metadata/Monsters/TemplarSlaveDriver/TemplarSlaveDriver
+#spectre Metadata/Monsters/TemplarSlaveDriver/TemplarSlaveDriverKitava
 -- Undying
 #spectre Metadata/Monsters/Undying/CityStalkerMaleCasterArmour
 #spectre Metadata/Monsters/Undying/UndyingOutcastPuncture

--- a/Export/Skills/spectre.txt
+++ b/Export/Skills/spectre.txt
@@ -17,7 +17,26 @@ local skills, mod, flag, skill = ...
 
 #skill BanditExplosiveArrow Explosive Arrow
 #flags cast projectile area duration
+	statMap = {
+		["minimum_fire_damage_per_fuse_arrow_orb"] = {
+			skill("FireMin", nil, { type = "Multiplier", var = "ExplosiveArrowFuse" }),
+		},
+		["maximum_fire_damage_per_fuse_arrow_orb"] = {
+			skill("FireMax", nil, { type = "Multiplier", var = "ExplosiveArrowFuse" }),
+		},
+		["fuse_arrow_explosion_radius_+_per_fuse_arrow_orb"] = {
+			skill("radiusExtra", nil, { type = "Multiplier", var = "ExplosiveArrowFuse" }),
+		},
+	},
+#baseMod skill("radius", 15)
 #baseMod skill("showAverage", true)
+#baseMod mod("Multiplier:ExplosiveArrowFuse", "BASE", 1, 0, 0)
+#mods
+
+#skill BanditChampionBlastRainSpectre Blast Rain
+#flags attack projectile area
+#baseMod skill("radius", 24)
+#baseMod skill("dpsMultiplier", 4)
 #mods
 
 #skill BeastCleave Cleave
@@ -75,6 +94,20 @@ local skills, mod, flag, skill = ...
 #skill DemonModularBladeVortexSpectre Blade Vortex
 #flags spell area duration
 #baseMod skill("hitTimeOverride", 1)
+#mods
+
+#skill ElementalHitSkeletonKnight Elemental Hit Fire
+#flags attack projectile melee
+#baseMod flag("DealNoPhysical")
+#baseMod flag("DealNoChaos")
+#baseMod flag("DealNoCold")
+#baseMod flag("DealNoLightning")
+#baseMod mod("AreaOfEffect", "MORE", 80, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Ignited" })
+#baseMod mod("Multiplier:ElementalHitAilmentOnEnemy", "BASE", 1, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Ignited" })
+#baseMod mod("Multiplier:ElementalHitAilmentOnEnemy", "BASE", 1, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Chilled" })
+#baseMod mod("Multiplier:ElementalHitAilmentOnEnemy", "BASE", 1, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Frozen" })
+#baseMod mod("Multiplier:ElementalHitAilmentOnEnemy", "BASE", 1, 0, 0, { type = "ActorCondition", actor = "enemy", var = "Shocked" })
+#baseMod mod("Damage", "MORE", 10, 0, 0, { type = "Multiplier", var = "ElementalHitAilmentOnEnemy" })
 #mods
 
 #skill ElementalHitSkeletonKnightIncursion
@@ -149,7 +182,11 @@ local skills, mod, flag, skill = ...
 #flags spell projectile area
 #mods
 
-#skill IguanaProjectile Ranged Attack
+#skill IguanaProjectile Barrage
+#flags attack projectile
+#mods
+
+#skill IguanaProjectileChrome Barrage
 #flags attack projectile
 #mods
 
@@ -267,6 +304,10 @@ local skills, mod, flag, skill = ...
 
 #skill MonsterFlameRedCannibal Incinerate
 #flags spell projectile
+#mods
+
+#skill MonsterIceShot Ice Shot
+#flags attack projectile area duration
 #mods
 
 #skill MountainGoatmanIceSpear
@@ -493,6 +534,10 @@ local skills, mod, flag, skill = ...
 #flags spell 
 #mods
 
+#skill SkeletonBlackAbyssBoneLance Unearth
+#flags spell projectile area
+#mods
+
 #skill SkeletonCannonMortar Mortar
 #flags spell projectile area
 #mods
@@ -512,6 +557,10 @@ local skills, mod, flag, skill = ...
 
 #skill SkeletonProjectileBlack
 #flags spell projectile
+#mods
+
+#skill SkeletonSoldierTornadoShot Tornado Shot
+#flags attack projectile
 #mods
 
 #skill SkeletonSpark Spark
@@ -547,6 +596,11 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SlavedriverFlameWhip
+#flags spell area
+#baseMod skill("radius", 30)
+#mods
+
+#skill KitavaSlavedriverFlameWhip
 #flags spell area
 #baseMod skill("radius", 30)
 #mods


### PR DESCRIPTION
This PR adds Crazed Driver and a bunch of bow-skill-using spectres.

I've made a best-effort with skills like Elemental Hit and Explosive Arrow that the UI doesn't support yet. Unfortunately the Export scripts *also* don't seem to play nice with multiple copies of a skill so this is the best option without deeper modifications. At least Explosive Arrow should be more straight-forward once the patch drops anyway.