### PR TITLE
Triple watchers eye

### DIFF
--- a/Classes/Item.lua
+++ b/Classes/Item.lua
@@ -157,7 +157,7 @@ function ItemClass:ParseRaw(raw)
 		else
 			local specName, specVal = line:match("^([%a ]+): (%x+)$")
 			if not specName then
-				specName, specVal = line:match("^([%a ]+): %+?([%d%-%.]+)")
+				specName, specVal = line:match("^([%a ]+): %+?([%d+%-%.,]+)")
 				if not tonumber(specVal) then
 					specName = nil
 				end
@@ -213,12 +213,24 @@ function ItemClass:ParseRaw(raw)
 					importedLevelReq = tonumber(specVal)
 				elseif specName == "LevelReq" then
 					self.requirements.level = tonumber(specVal)
+					-- Backward compatibility
 				elseif specName == "Has Alt Variant" then
-					self.hasAltVariant = true
+					self.hasAltVariant = true -- <
 				elseif specName == "Selected Variant" then
-					self.variant = tonumber(specVal)
+					self.variant = tonumber(specVal) -- <
 				elseif specName == "Selected Alt Variant" then
-					self.variantAlt = tonumber(specVal)
+					self.variantAlt = tonumber(specVal) -- <
+				elseif specName == "Has Variants" then
+					self.hasVariants = tonumber(specVal)
+					if self.hasVariants > 1 then self.hasAltVariant = true end -- <
+				elseif specName == "Selected Variants" then
+					self.variants = {}
+					for val in specVal:gmatch("(%d+)") do
+						t_insert(self.variants, tonumber(val))
+					end
+					self.variant = self.variants[1] -- <
+					if #self.variants > 1 then self.variantAlt = self.variants[2] end -- <
+					-- ^
 				elseif specName == "League" then
 					self.league = specVal
 				elseif specName == "Crafted" then
@@ -381,10 +393,28 @@ function ItemClass:ParseRaw(raw)
 	end
 	self.abyssalSocketCount = 0
 	if self.variantList then
+		if self.hasVariants then
+			if not self.variants then self.variants = {} end
+			for i = 1, self.hasVariants do
+				self.variants[i] = m_min(#self.variantList, self.variants[i] or self.defaultVariant or #self.variantList)
+			end
+		end
+		-- Backward compatibility
 		self.variant = m_min(#self.variantList, self.variant or self.defaultVariant or #self.variantList)
 		if self.hasAltVariant then
 			self.variantAlt = m_min(#self.variantList, self.variantAlt or self.defaultVariant or #self.variantList)
 		end
+
+		if not self.hasVariants then
+			self.variants = {}
+			self.hasVariants = 1
+			self.variants[1] = self.variant
+			if self.hasVariantAlt then
+				self.hasVariants = 2
+				self.variants[2] = self.variantAlt
+			end
+		end
+		-- ^
 	end
 	if not self.quality then
 		self:NormaliseQuality()
@@ -453,10 +483,17 @@ function ItemClass:BuildRaw()
 		for _, variantName in ipairs(self.variantList) do
 			t_insert(rawLines, "Variant: "..variantName)
 		end
+		-- Backward compatibility
 		t_insert(rawLines, "Selected Variant: "..self.variant)
+
 		if self.hasAltVariant then
 			t_insert(rawLines, "Has Alt Variant: true")
 			t_insert(rawLines, "Selected Alt Variant: "..self.variantAlt)
+		end
+		-- ^
+		if self.hasVariants then
+			t_insert(rawLines, "Has Variants: "..self.hasVariants)
+			t_insert(rawLines, "Selected Variants: "..table.concat(self.variants, ","))
 		end
 	end
 	if self.quality then
@@ -578,9 +615,18 @@ function ItemClass:Craft()
 end
 
 function ItemClass:CheckModLineVariant(modLine)
-	return not modLine.variantList 
-		or modLine.variantList[self.variant]
-		or (self.hasAltVariant and modLine.variantList[self.variantAlt])
+	if modLine.variantList then
+		if self.hasVariants then
+			for _, v in pairs(self.variants) do
+				if modLine.variantList[v] then
+					return true
+				end
+			end
+		end
+	end
+	return not modLine.variantList
+		--or modLine.variantList[self.variant]
+		--or (self.hasAltVariant and modLine.variantList[self.variantAlt])
 end
 
 -- Return the name of the slot this item is equipped in

--- a/Classes/Item.lua
+++ b/Classes/Item.lua
@@ -409,7 +409,7 @@ function ItemClass:ParseRaw(raw)
 			self.variants = {}
 			self.hasVariants = 1
 			self.variants[1] = self.variant
-			if self.hasVariantAlt then
+			if self.hasAltVariant then
 				self.hasVariants = 2
 				self.variants[2] = self.variantAlt
 			end

--- a/Classes/ItemsTab.lua
+++ b/Classes/ItemsTab.lua
@@ -243,9 +243,24 @@ If there's 2 slots an item can go in, holding Shift will put it in the second.]]
 	end)
 
 	-- Section: Variant(s)
+
 	self.controls.displayItemSectionVariant = new("Control", {"TOPLEFT",self.controls.addDisplayItem,"BOTTOMLEFT"}, 0, 8, 0, function()
 		return (self.displayItem.variantList and #self.displayItem.variantList > 1) and 28 or 0
 	end)
+
+	for i = 1, 3 do -- TODO: replace '3' with something good. '3'/*
+		-- TODO: smart? positioning for small screen resolutions
+		self.controls["displayItemVariant"..i] = new("DropDownControl", {"TOPLEFT", self.controls.displayItemSectionVariant,"TOPLEFT"}, (i < 3 and i or 2) * 232 - 232, (i > 2 and i or 0) * 9.5, 224, 20, nil, function(index, value)
+			self.displayItem.variants[i] = index
+			self.displayItem:BuildAndParseRaw()
+			self:UpdateDisplayItemTooltip()
+			self:UpdateDisplayItemRangeLines()
+		end)
+		self.controls["displayItemVariant"..i].shown = function()
+			return self.displayItem.variantList and #self.displayItem.variantList > 1 and #self.displayItem.variants >= i
+		end
+	end
+	--[[
 	self.controls.displayItemVariant = new("DropDownControl", {"TOPLEFT", self.controls.displayItemSectionVariant,"TOPLEFT"}, 0, 0, 224, 20, nil, function(index, value)
 		self.displayItem.variant = index
 		self.displayItem:BuildAndParseRaw()
@@ -264,6 +279,7 @@ If there's 2 slots an item can go in, holding Shift will put it in the second.]]
 	self.controls.displayItemAltVariant.shown = function()
 		return self.displayItem.hasAltVariant
 	end
+	]]
 
 	-- Section: Sockets and Links
 	self.controls.displayItemSectionSockets = new("Control", {"TOPLEFT",self.controls.displayItemSectionVariant,"BOTTOMLEFT"}, 0, 0, 0, function()
@@ -989,12 +1005,21 @@ function ItemsTabClass:SetDisplayItem(item)
 		-- Update the display item controls
 		self:UpdateDisplayItemTooltip()
 		self.snapHScroll = "RIGHT"
+
+		if item.hasVariants then
+			for i, variant in ipairs(item.variants) do
+				self.controls["displayItemVariant"..i].list = item.variantList
+				self.controls["displayItemVariant"..i].selIndex = variant
+			end
+		end
+		--[[
 		self.controls.displayItemVariant.list = item.variantList
 		self.controls.displayItemVariant.selIndex = item.variant
 		if item.hasAltVariant then
 			self.controls.displayItemAltVariant.list = item.variantList
 			self.controls.displayItemAltVariant.selIndex = item.variantAlt
 		end
+		]]
 		self:UpdateSocketControls()
 		if item.crafted then
 			self:UpdateAffixControls()
@@ -1727,7 +1752,7 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 			if #item.variantList == 1 then
 				tooltip:AddLine(16, "^xFFFF30Variant: "..item.variantList[1])
 			else
-				tooltip:AddLine(16, "^xFFFF30Variant: "..item.variantList[item.variant].." ("..#item.variantList.." variants)")
+				tooltip:AddLine(16, "^xFFFF30Variant: ".. item.variantList[item.variant or item.variants[1]] .." ("..#item.variantList.." variants)")
 			end
 		end
 		if item.league then

--- a/Data/Uniques/jewel.lua
+++ b/Data/Uniques/jewel.lua
@@ -507,6 +507,7 @@ Watcher's Eye
 Prismatic Jewel
 Source: Drops from unique{The Elder}
 Has Alt Variant: true
+Has Variants: 3
 Variant: Anger: Fire Damage Leeched as Life
 Variant: Anger: Fire Pen
 Variant: Anger: Crit Multi


### PR DESCRIPTION
And new tag for items: `Has Variants: x` where x is a number of... interchangeable mods or even mod sets?.. For ordinary uniques it is 1 -- legacy variants, for Synthesis Rings and Eyes of Greatwolf (things with 'Has Alt Variant' tag) it is 2, and Watcher's Eye is 2 or 3. Items with x less than 3 should be working as is, so there (probably) no need to set it explicitly for everything in Uniques/*.txt.
However, it probably shouldn't be in next release because I didn't properly tested it, especially compatibility with builds and items created in non-fork pob.