### PR TITLE
Add ctrl-right and ctrl-left to edit control - skip word

### DIFF
--- a/Classes/EditControl.lua
+++ b/Classes/EditControl.lua
@@ -447,7 +447,17 @@ function EditClass:OnKeyDown(key, doubleClick)
 	elseif key == "LEFT" then
 		self.sel = shift and (self.sel or self.caret) or nil
 		if self.caret > 1 then
-			self.caret = self.caret - 1
+			if ctrl then
+			-- Skip leading space, then jump word
+				while self.buf:sub(self.caret-1, self.caret-1):match("[%s%p]") do
+					if self.caret > 1 then self.caret = self.caret - 1 end
+				end
+				while self.buf:sub(self.caret-1, self.caret-1):match("%w") do
+					if self.caret > 1 then self.caret = self.caret - 1 end
+				end
+			else
+				self.caret = self.caret - 1
+			end
 			self.lastUndoState.caret = self.caret
 			self:ScrollCaretIntoView()
 			self.blinkStart = GetTime()
@@ -455,7 +465,17 @@ function EditClass:OnKeyDown(key, doubleClick)
 	elseif key == "RIGHT" then
 		self.sel = shift and (self.sel or self.caret) or nil
 		if self.caret <= #self.buf then
-			self.caret = self.caret + 1
+			if ctrl then
+			-- Jump word, then skip trailing space, 
+				while self.buf:sub(self.caret, self.caret):match("%w") do
+					if self.caret <= #self.buf then self.caret = self.caret + 1 end
+				end
+				while self.buf:sub(self.caret, self.caret):match("[%s%p]") do
+					if self.caret <= #self.buf then self.caret = self.caret + 1 end
+				end
+			else
+				self.caret = self.caret + 1
+			end
 			self.lastUndoState.caret = self.caret
 			self:ScrollCaretIntoView()
 			self.blinkStart = GetTime()


### PR DESCRIPTION
Added ctrl-right and ctrl-left to edit control, mainly for notes tab.
tested on text "The quick'tab'brown'space''space''space''space'fox, is silly." , along with other random text supplied by build builders.

Tests include have the cursor start in the middle of the four spaces.
Integrates with selecting text.

