### PR TITLE
for EditControls, remove any illegal chars from the "text" variable, …

### DIFF
--- a/Classes/EditControl.lua
+++ b/Classes/EditControl.lua
@@ -130,6 +130,8 @@ end
 
 function EditClass:Insert(text)
 	text = text:gsub("\r","")
+	-- Remove any illegal chars from the "text" variable, to stop resulting in no text when an illegal character is found.
+	text = text:gsub(self.filterPattern,"")
 	if text:match(self.filterPattern) then
 		return
 	end

--- a/Classes/EditControl.lua
+++ b/Classes/EditControl.lua
@@ -132,9 +132,6 @@ function EditClass:Insert(text)
 	text = text:gsub("\r","")
 	-- Remove any illegal chars from the "text" variable, to stop resulting in no text when an illegal character is found.
 	text = text:gsub(self.filterPattern,"")
-	if text:match(self.filterPattern) then
-		return
-	end
 	local newBuf = self.buf:sub(1, self.caret - 1) .. text .. self.buf:sub(self.caret)
 	if self.limit and #newBuf > self.limit then
 		return


### PR DESCRIPTION
…to stop resulting in no text when an illegal character is found.

Another QoL PR.
This is for stopping zero text being returned, when pasting (or typing) text into a field with illegal characters in it (what forms an illegal character differs depending on the control).

This PR mainly focuses on the pasting of a build name into the Build SaveAs control. Currently if I was to copy the name of a build from a youtube build like "Fantastic Poison build using: Bane/Wither", the result would be a blank field. Using this PR, the result would be "Fantastic Poison build using BaneWither".

Currently I remove all illegal chars, but welcome feedback on if it should be replaced with another character (eg: underscore -> "Fantastic Poison build using_ Bane_Wither"), though I'd like to note this will break more things than it fixes (ie: number fields)

Testing on the following edit controls types:
counters/number fields (eg: Corpse Life/Skill level) - Test Text : 0/0
text fields  (eg:names of builds and folders / equipment sets / Tree search) - Test Text : "Fred / Fred" 
notes tab - Test Text (any - all printable characters are permitted).

So positive and negative testing was performed.

P