### PR TITLE
Add breakdown for "Base from Armours" row for ES/Armour/Evasion

### DIFF
--- a/Classes/CalcBreakdownControl.lua
+++ b/Classes/CalcBreakdownControl.lua
@@ -181,17 +181,39 @@ function CalcBreakdownClass:AddBreakdownSection(sectionData)
 
 	if breakdown.slots and #breakdown.slots > 0 then
 		-- Slots table, used for armour/evasion/ES total breakdowns
-		local section = { 
-			type = "TABLE",
-			rowList = breakdown.slots,
-			colList = { 
+		local colList
+		local rowList
+		if (sectionData.gearOnly) then
+			-- Only show basic table for gear and base ES/Armour/Evasion value
+			colList = {
+				{ label = "Value", key = "base", right = true },
+				{ label = "Source", key = "source" },
+				{ label = "Name", key = "sourceLabel" },
+			}
+
+			rowList = {}
+			for _, row in pairs(breakdown.slots) do
+				if (row.item and row.item.armourData) then
+					table.insert(rowList, row)
+				end
+			end
+		else
+			colList = {
 				{ label = "Base", key = "base", right = true },
 				{ label = "Inc/red", key = "inc" },
 				{ label = "More/less", key = "more" },
 				{ label = "Total", key = "total", right = true },
 				{ label = "Source", key = "source" },
 				{ label = "Name", key = "sourceLabel" },
-			},
+			}
+
+			rowList = breakdown.slots
+		end
+
+		local section = { 
+			type = "TABLE",
+			rowList = rowList,
+			colList = colList,
 		}
 		t_insert(self.sectionList, section)
 		for _, row in pairs(section.rowList) do

--- a/Modules/CalcSections-3_0.lua
+++ b/Modules/CalcSections-3_0.lua
@@ -916,7 +916,7 @@ return {
 } },
 { 1, "EnergyShield", 2, "Energy Shield", colorCodes.DEFENCE, {
 	extra = "{0:output:EnergyShield}",
-	{ label = "Base from Armours", { format = "{0:output:Gear:EnergyShield}", }, },
+	{ label = "Base from Armours", { format = "{0:output:Gear:EnergyShield}", { breakdown = "EnergyShield", gearOnly = true }, }, },
 	{ label = "Global Base", { format = "{0:mod:1}", { modName = "EnergyShield", modType = "BASE" }, }, },
 	{ label = "Inc. from Tree", { format = "{0:mod:1}%", { modName = "EnergyShield", modType = "INC", modSource = "Tree" }, }, },
 	{ label = "Total Increased", { format = "{0:mod:1}%", { modName = { "EnergyShield", "Defences" }, modType = "INC" }, }, },
@@ -937,7 +937,7 @@ return {
 } },
 { 1, "Armour", 3, "Armour", colorCodes.DEFENCE, {
 	extra = "{0:output:Armour}",
-	{ label = "Base from Armours", { format = "{0:output:Gear:Armour}" }, },
+	{ label = "Base from Armours", { format = "{0:output:Gear:Armour}", { breakdown = "Armour", gearOnly = true }, }, },
 	{ label = "Global Base", { format = "{0:mod:1}", { modName = "Armour", modType = "BASE" }, }, },
 	{ label = "Inc. from Tree", { format = "{0:mod:1}%", { modName = { "Armour", "ArmourAndEvasion" }, modType = "INC", modSource = "Tree", }, }, },
 	{ label = "Total Increased", { format = "{0:mod:1}%", { modName = { "Armour", "ArmourAndEvasion", "Defences" }, modType = "INC" }, }, },
@@ -950,7 +950,7 @@ return {
 } },
 { 1, "Evasion", 3, "Evasion", colorCodes.DEFENCE, {
 	extra = "{0:output:Evasion}",
-	{ label = "Base from Armours", { format = "{0:output:Gear:Evasion}", }, },
+	{ label = "Base from Armours", { format = "{0:output:Gear:Evasion}", { breakdown = "Evasion", gearOnly = true }, }, },
 	{ label = "Global Base", { format = "{0:mod:1}", { modName = "Evasion", modType = "BASE" }, }, },
 	{ label = "Inc. from Tree", { format = "{0:mod:1}%", { modName = { "Evasion", "ArmourAndEvasion" }, modType = "INC", modSource = "Tree" }, }, },
 	{ label = "Total Increased", { format = "{0:mod:1}%", { modName = { "Evasion", "ArmourAndEvasion", "Defences" }, modType = "INC" }, }, },


### PR DESCRIPTION
Currently there is no breakdown for the row "Base from Armours" for ES/Armour/Evasion in the Calc tab. This commit adds that.

![image](https://user-images.githubusercontent.com/1388219/72682820-4a5c5e80-3a9f-11ea-9407-b38c8e30ab48.png)

![image](https://user-images.githubusercontent.com/1388219/72682828-6102b580-3a9f-11ea-9322-15a3f139b033.png)

![image](https://user-images.githubusercontent.com/1388219/72682841-711a9500-3a9f-11ea-8e83-5a775363c7e6.png)
