### PR TITLE
 Added support for deterministic passive modifications from Timeless jewels.

### DIFF
--- a/Data/Uniques/jewel.lua
+++ b/Data/Uniques/jewel.lua
@@ -1246,9 +1246,14 @@ League: Legion
 Source: Drops from Maraketh Legion
 Requires Level: 20
 Limited to: 1 Historic
+Variant: Asenath
+Variant: Deshret
+Variant: Nasima
 Radius: Large
 Implicits: 0
-Denoted service of (500-8000) dekhara in the akhara of Deshret
+{variant:1}Denoted service of (500-8000) dekhara in the akhara of Asenath
+{variant:2}Denoted service of (500-8000) dekhara in the akhara of Deshret
+{variant:3}Denoted service of (500-8000) dekhara in the akhara of Nasima
 Passives in radius are Conquered by the Maraketh
 Historic
 ]],[[
@@ -1258,9 +1263,14 @@ League: Legion
 Source: Drops from Eternal Legion
 Requires Level: 20
 Limited to: 1 Historic
+Variant: Cadiro
+Variant: Chitus
+Variant: Victario
 Radius: Large
 Implicits: 0
-Commissioned (2000-160000) coins to commemorate Cadiro
+{variant:1}Commissioned (2000-160000) coins to commemorate Cadiro
+{variant:2}Commissioned (2000-160000) coins to commemorate Chitus
+{variant:3}Commissioned (2000-160000) coins to commemorate Victario
 Passives in radius are Conquered by the Eternal Empire
 Historic
 ]],[[
@@ -1270,9 +1280,14 @@ League: Legion
 Source: Drops from Vaal Legion
 Requires Level: 20
 Limited to: 1 Historic
+Variant: Doryani
+Variant: Xibaqua
+Variant: Zerphi
 Radius: Large
 Implicits: 0
-Bathed in the blood of (100-8000) sacrificed in the name of Doryani
+{variant:1}Bathed in the blood of (100-8000) sacrificed in the name of Doryani
+{variant:2}Bathed in the blood of (100-8000) sacrificed in the name of Xibaqua
+{variant:3}Bathed in the blood of (100-8000) sacrificed in the name of Zerphi
 Passives in radius are Conquered by the Vaal
 Historic
 ]],[[
@@ -1282,9 +1297,14 @@ League: Legion
 Source: Drops from Karui Legion
 Requires Level: 20
 Limited to: 1 Historic
+Variant: Kaom
+Variant: Kiloava
+Variant: Rakiata
 Radius: Large
 Implicits: 0
-Commanded leadership over (10000-18000) warriors under Kaom
+{variant:1}Commanded leadership over (10000-18000) warriors under Kaom
+{variant:2}Commanded leadership over (10000-18000) warriors under Kiloava
+{variant:3}Commanded leadership over (10000-18000) warriors under Rakiata
 Passives in radius are Conquered by the Karui
 Historic
 ]],[[
@@ -1294,9 +1314,14 @@ League: Legion
 Source: Drops from Templar Legion
 Requires Level: 20
 Limited to: 1 Historic
+Variant: Avarius
+Variant: Dominus
+Variant: Venarius
 Radius: Large
 Implicits: 0
-Carved to glorify (2000-10000) new faithful converted by High Templar Venarius
+{variant:1}Carved to glorify (2000-10000) new faithful converted by High Templar Avarius
+{variant:2}Carved to glorify (2000-10000) new faithful converted by High Templar Dominus
+{variant:3}Carved to glorify (2000-10000) new faithful converted by High Templar Venarius
 Passives in radius are Conquered by the Templars
 Historic
 ]],

--- a/Data/Uniques/jewel.lua
+++ b/Data/Uniques/jewel.lua
@@ -1,4 +1,4 @@
-﻿-- Item data (c) Grinding Gear Games
+-- Item data (c) Grinding Gear Games
 
 return {
 -- Jewel: Drop
@@ -163,6 +163,7 @@ Cobalt Jewel
 Limited to: 1
 Variant: Pre 3.8.0
 Variant: Current
+Implicits: 0
 {variant:1}Summon 2 additional Skeleton Warriors with Summon Skeleton
 {variant:2}Summon 4 additional Skeleton Warriors with Summon Skeleton
 +1 second to Summon Skeleton Cooldown
@@ -256,6 +257,7 @@ Dexterity from Passives in Radius is Transformed to Strength
 Inspired Learning
 Crimson Jewel
 Radius: Small
+Implicits: 0
 If 4 Notables are Allocated in Radius, When you Kill a Rare monster, you gain 1
 of its mods for 20 seconds
 ]],[[
@@ -357,8 +359,7 @@ Minions have (12-16)% increased Attack Speed
 Minions have (12-16)% increased Cast Speed
 Minions have (10-12)% chance to Dodge Attack Hits
 Minions have (10-12)% chance to Dodge Spell Hits
-Notable Passive Skills in Radius are Transformed to
-instead grant: Minions have 25% reduced Movement Speed
+Notable Passive Skills in Radius are Transformed to instead grant: Minions have 25% reduced Movement Speed
 ]],[[
 Rain of Splinters
 Crimson Jewel
@@ -770,7 +771,6 @@ Radius: Medium
 With 40 total Dexterity and Strength in Radius, Spectral Shield Throw Chains +4 times
 With 40 total Dexterity and Strength in Radius, Spectral Shield Throw fires Shard Projectiles when Chaining
 With 40 total Dexterity and Strength in Radius, Spectral Shield Throw fires 75% less Shard Projectiles
-Historic
 ]],[[
 Fight for Survival
 Viridian Jewel
@@ -1076,6 +1076,7 @@ Corrupted
 ]],[[
 Corrupted Energy
 Cobalt Jewel
+Implicits: 0
 With 5 Corrupted Items Equipped: 50% of Chaos Damage does not bypass Energy Shield and 50% of Physical Damage bypasses Energy Shield
 Corrupted
 ]],[[
@@ -1246,6 +1247,7 @@ Source: Drops from Maraketh Legion
 Requires Level: 20
 Limited to: 1 Historic
 Radius: Large
+Implicits: 0
 Denoted service of (500-8000) dekhara in the akhara of Deshret
 Passives in radius are Conquered by the Maraketh
 Historic
@@ -1257,6 +1259,7 @@ Source: Drops from Eternal Legion
 Requires Level: 20
 Limited to: 1 Historic
 Radius: Large
+Implicits: 0
 Commissioned (2000-160000) coins to commemorate Cadiro
 Passives in radius are Conquered by the Eternal
 Historic
@@ -1268,6 +1271,7 @@ Source: Drops from Vaal Legion
 Requires Level: 20
 Limited to: 1 Historic
 Radius: Large
+Implicits: 0
 Bathed in the blood of (100-8000) sacrificed in the name of Doryani
 Passives in radius are Conquered by the Vaal
 Historic
@@ -1279,6 +1283,7 @@ Source: Drops from Karui Legion
 Requires Level: 20
 Limited to: 1 Historic
 Radius: Large
+Implicits: 0
 Commanded leadership over (10000-18000) warriors under Kaom
 Passives in radius are Conquered by the Karui
 Historic
@@ -1290,6 +1295,7 @@ Source: Drops from Templar Legion
 Requires Level: 20
 Limited to: 1 Historic
 Radius: Large
+Implicits: 0
 Carved to glorify (2000-10000) new faithful converted by High Templar Venarius
 Passives in radius are Conquered by the Templars
 Historic

--- a/Data/Uniques/jewel.lua
+++ b/Data/Uniques/jewel.lua
@@ -1,4 +1,4 @@
--- Item data (c) Grinding Gear Games
+﻿-- Item data (c) Grinding Gear Games
 
 return {
 -- Jewel: Drop
@@ -1261,7 +1261,7 @@ Limited to: 1 Historic
 Radius: Large
 Implicits: 0
 Commissioned (2000-160000) coins to commemorate Cadiro
-Passives in radius are Conquered by the Eternal
+Passives in radius are Conquered by the Eternal Empire
 Historic
 ]],[[
 Glorious Vanity

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -1998,6 +1998,31 @@ local jewelOtherFuncs = {
 			end
 		end
 	end,
+	["Passives in radius are Conquered by the Eternal Empire"] = function(node, out, data)
+		if node and node.type == "Normal" then
+			out:NewMod("PassiveSkillHasNoEffect", "FLAG", true, data.modSource)
+		end
+	end,
+	["Passives in radius are Conquered by the Karui"] = function(node, out, data)
+		local attributes = { "Dexterity", "Intelligence", "Strength" }
+		if node and node.type == "Normal" then
+			if isValueInArray(attributes, node.dn) then
+				out:NewMod("Str", "BASE", 2, data.modSource)
+			else
+				out:NewMod("Str", "BASE", 4, data.modSource)
+			end
+		end
+	end,
+	["Passives in radius are Conquered by the Maraketh"] = function(node, out, data)
+		local attributes = { "Dexterity", "Intelligence", "Strength" }
+		if node and node.type == "Normal" then
+			if isValueInArray(attributes, node.dn) then
+				out:NewMod("Dex", "BASE", 2, data.modSource)
+			else
+				out:NewMod("Dex", "BASE", 4, data.modSource)
+			end
+		end
+	end,
 }
 
 -- Radius jewels that modify the jewel itself based on nearby allocated nodes
@@ -2163,7 +2188,6 @@ end
 local function parseMod(line, order)
 	-- Check if this is a special modifier
 	local lineLower = line:lower()
-	local bestVal, _, bestCaps = scan(line, jewelFuncList)
 	for pattern, patternVal in pairs(jewelFuncList) do
 		local _, _, cap1, cap2, cap3, cap4, cap5 = lineLower:find(pattern, 1)
 		if cap1 then


### PR DESCRIPTION
Karui and Maraketh Timeless jewels will now add extra attributes to passives in radius.
Eternal Timeless jewels will now remove all normal passive modifiers in radius.
Keystones are still not supported.

Also fixed some jewels not displaying correctly, including Timeless jewels.