### PR TITLE
make deep copy of skill stats so they can have distinct sources

### DIFF
--- a/Modules/Data.lua
+++ b/Modules/Data.lua
@@ -236,7 +236,8 @@ for _, targetVersion in ipairs(targetVersionList) do
 		__index = function(t, key)
 			local map = verData.skillStatMap[key]
 			if map then
-				t[key] = copyTable(map, true)
+				map = copyTable(map)
+				t[key] = map
 				for _, mod in ipairs(map) do
 					processMod(t._grantedEffect, mod)
 				end


### PR DESCRIPTION
mods are given source values in 
`processMod(t._grantedEffect, mod)`
however since `verData.skillStatMap` is a shared table containing mods that are also meant to be shared between skills no skill specific source should be written to those instances.
the already present 
`copyTable(map, true)` did only do a shallow copy. So changing it to `copyTable(map)` will do a recursive copy and allow us to set skill specific stuff down the road.

Another subtile bug was doing the shallow copy, setting it to `t[key]` but later on returning the unmodified `map`. That is why `map` gets overwritten here, so we can use it as iterator for the deeply copied mods, that got now relevant, and as the proper return value that it always should have been

