### PR TITLE
Fix Elemental Focus Support and Chilll

### DIFF
--- a/Modules/CalcOffence-3_0.lua
+++ b/Modules/CalcOffence-3_0.lua
@@ -1587,8 +1587,6 @@ function calcs.offence(env, actor, activeSkill)
 			local freezeMult = (1 - enemyDB:Sum("BASE", nil, "AvoidFreeze") / 100)
 			output.FreezeChanceOnHit = output.FreezeChanceOnHit * freezeMult
 			output.FreezeChanceOnCrit = output.FreezeChanceOnCrit * freezeMult
-			output.ChillChanceOnHit = 100
-			output.ChillChanceOnCrit = 100
 		end
 	
 		local function calcAilmentDamage(type, sourceHitDmg, sourceCritDmg)


### PR DESCRIPTION
When I added in the new elemental ailments stuff a while ago I left in two lines that set your "chill chance", a non-existent stat, to 100%. This is leftover from the first way I tried implementing the Calcs tab stuff where I basically just copy and pasted the Freeze calcs and changed them to say Chill instead, but the final implementation doesn't need these lines.

ANYWAY, these lines come after the parts that check for whether you can apply each ailment, so even if you can't chill like when you're using Elemental Focus, the Calcs tab would show you could chill. This fixes that.