### PR TITLE
Add Skitterbot minions

### DIFF
--- a/Export/Minions/Minions.txt
+++ b/Export/Minions/Minions.txt
@@ -110,3 +110,9 @@ local minions, mod = ...
 #monster Metadata/Monsters/BoneGolem/BoneGolem SummonedCarrionGolem
 #limit ActiveGolemLimit
 #emit
+
+#monster Metadata/Monsters/Skitterbot/SkitterbotCold SkitterbotCold
+#emit
+
+#monster Metadata/Monsters/Skitterbot/SkitterbotLightning SkitterbotLightning
+#emit

--- a/Export/Skills/act_int.txt
+++ b/Export/Skills/act_int.txt
@@ -1169,7 +1169,11 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill Skitterbots
-#flags spell
+#flags spell minion
+	minionList = {
+		"SkitterbotCold",
+		"SkitterbotLightning",
+	},
 	statMap = {
 		["skitterbots_trap_mine_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Mine, KeywordFlag.Trap), { type = "GlobalEffect", effectType = "Buff" }),

--- a/Export/Skills/minion.txt
+++ b/Export/Skills/minion.txt
@@ -175,6 +175,10 @@ local skills, mod, flag, skill = ...
 #flags attack melee area
 #mods
 
+#skill SkitterbotWait Skitterbot Wait
+#flags duration
+#mods
+
 skills["MinionInstability"] = {
 	name = "Minion Instability",
 	hidden = true,


### PR DESCRIPTION
This adds skitterbot minions and fixes #108 . They don't do anything but can be supported by Infernal Legion. I also added the Skitterbot Wait skill because they get a Default Attack if no other skills are present. I thought that might be misleading as they cannot attack.