### PR TITLE
Copied items will now retain quality if above 20%

### DIFF
--- a/Classes/Item.lua
+++ b/Classes/Item.lua
@@ -474,7 +474,7 @@ function ItemClass:NormaliseQuality()
 	if self.base and (self.base.armour or self.base.weapon or self.base.flask) then
 		if not self.quality then
 			self.quality = self.corrupted and 0 or 20 
-		elseif not self.uniqueID and not self.corrupted then
+		elseif not self.uniqueID and not self.corrupted and self.quality < 20 then
 			self.quality = 20
 		end
 	end	


### PR DESCRIPTION
Items copied into the items page will keep their quality unless the item has less than 20% quality.
This adds support for quality mods on items that have had a perfect fossil used on them to raise their base quality above 20% or has a quality enhancing mod as an affix.
Previously, items would import as 20% no matter what