### PR TITLE
Fix default gem level for gems with a max level below 20

### DIFF
--- a/Classes/GemSelectControl.lua
+++ b/Classes/GemSelectControl.lua
@@ -145,11 +145,11 @@ function GemSelectClass:UpdateSortCache()
 			if gemList[self.index] then
 				oldGem = copyTable(gemList[self.index], true)
 			else
-				gemList[self.index] = { level = self.skillsTab.defaultGemLevel or 20, quality = self.skillsTab.defaultGemQuality or 0, enabled = true, enableGlobal1 = true }
+				gemList[self.index] = { level = self.skillsTab.defaultGemLevel or gemData.defaultLevel, quality = self.skillsTab.defaultGemQuality or 0, enabled = true, enableGlobal1 = true }
 			end
 			local gemInstance = gemList[self.index]
 			if gemInstance.gemData and gemInstance.gemData.defaultLevel ~= gemData.defaultLevel then
-				gemInstance.level = self.skillsTab.defaultGemLevel or 20
+				gemInstance.level = self.skillsTab.defaultGemLevel or gemData.defaultLevel
 			end
 			gemInstance.gemData = gemData
 			if not gemData.grantedEffect.levels[gemInstance.level] then

--- a/Classes/GemSelectControl.lua
+++ b/Classes/GemSelectControl.lua
@@ -307,11 +307,11 @@ function GemSelectClass:Draw(viewPort)
 				if gemList[self.index] then
 					oldGem = copyTable(gemList[self.index], true)
 				else
-					gemList[self.index] = { level = self.skillsTab.defaultGemLevel or 20, quality = self.skillsTab.defaultGemQuality or 0, enabled = true, enableGlobal1 = true }
+					gemList[self.index] = { level = self.skillsTab.defaultGemLevel or gemData.defaultLevel, quality = self.skillsTab.defaultGemQuality or 0, enabled = true, enableGlobal1 = true }
 				end
 				local gemInstance = gemList[self.index]
 				if gemInstance.gemData and gemInstance.gemData.defaultLevel ~= gemData.defaultLevel then
-					gemData.level = self.skillsTab.defaultGemLevel or 20
+					gemData.level = self.skillsTab.defaultGemLevel or gemData.defaultLevel
 				end
 				gemInstance.gemData = gemData
 				if not gemData.grantedEffect.levels[gemInstance.level] then


### PR DESCRIPTION
Fixes a bug where when searching for gems, it would assume all gems had a max level of 20, which meant that things like awakened gems and Blood and Sand were previewing as way more damage than they actually give. Now it uses the gem's set defaultLevel.