### PR TITLE
Fixed incorrect calculations of Active Totem Limit

### DIFF
--- a/Modules/CalcPerform.lua
+++ b/Modules/CalcPerform.lua
@@ -523,7 +523,7 @@ function calcs.perform(env)
 			output.ActiveGolemLimit = m_max(limit, output.ActiveGolemLimit or 0)
 		end
 		if activeSkill.skillFlags.totem then
-			local limit = activeSkill.skillModList:Sum("BASE", nil, "ActiveTotemLimit")
+			local limit = env.player.mainSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "ActiveTotemLimit")
 			output.ActiveTotemLimit = m_max(limit, output.ActiveTotemLimit or 0)
 		end
 	end


### PR DESCRIPTION
Fixes #165, but found 2 bugs overall with the calculations.

- Active totem limit was only calculated based off one skill, meaning that if you had multiple skills with different active totem limits, only one of the skills with have the correct value.
- Increases to maximum number of ballista totem were ignored