### PR TITLE
Fixed Shockwave Support quality stats not included in damage calculation

### DIFF
--- a/Data/3_0/SkillStatMap.lua
+++ b/Data/3_0/SkillStatMap.lua
@@ -432,6 +432,9 @@ return {
 ["active_skill_damage_+%_final"] = {
 	mod("Damage", "MORE", nil),
 },
+["melee_damage_+%"] = {
+	mod("Damage", "INC", nil, ModFlag.Melee),
+},
 ["melee_physical_damage_+%"] = {
 	mod("PhysicalDamage", "INC", nil, ModFlag.Melee),
 },


### PR DESCRIPTION
Fixes bug under https://github.com/Openarl/PathOfBuilding/issues/1848

Increased melee damage quality stat missing in SkikllStatMap. Only affected gem was Shockwave Support.