### PR TITLE
Added support for 'per minion' modifiers for Necromancer Bone Barrier notable

### DIFF
--- a/Data/3_0/ModCache.lua
+++ b/Data/3_0/ModCache.lua
@@ -398,7 +398,6 @@ c["+96 to maximum Energy Shield"]={{[1]={flags=0,keywordFlags=0,name="EnergyShie
 c["50% increased Life Recovery Rate if you've taken Fire Damage from an Enemy Hit Recently Unaffected by Ignite"]={{[1]={flags=0,keywordFlags=0,name="LifeRecoveryRate",type="INC",value=50}},"  if you've taken Fire Damage from an Enemy Hit Recently Unaffected by Ignite "}
 c["Your Chaos Damage can Shock"]={{[1]={flags=0,keywordFlags=0,name="ChaosCanShock",type="FLAG",value=true}},nil}
 c["Vaal Skills used during effect do not apply Soul Gain Prevention"]={nil,"Vaal Skills used during effect do not apply Soul Gain Prevention "}
-c["3% increased Recovery Rate of Life and Energy Shield per Minion, up to 30% Minions have 20% more Maximum Life"]={{[1]={flags=0,keywordFlags=0,name="FlaskRecoveryRate",type="INC",value=3}},"  of Life and Energy Shield per Minion, up to 30% Minions have 20% more Maximum Life "}
 c["1% chance to deal Double Damage per 4 Rage"]={{[1]={[1]={div=4,type="Multiplier",var="Rage"},flags=0,keywordFlags=0,name="DoubleDamageChance",type="BASE",value=1}},nil}
 c["200% increased Evasion and Energy Shield"]={{[1]={flags=0,keywordFlags=0,name="EvasionAndEnergyShield",type="INC",value=200}},nil}
 c["30% increased Area of Effect of Aura Skills"]={{[1]={[1]={skillType=44,type="SkillType"},flags=0,keywordFlags=0,name="AreaOfEffect",type="INC",value=30}},nil}
@@ -684,7 +683,7 @@ c["200% of Life Leech applies to enemies as Chaos Damage"]={{[1]={flags=0,keywor
 c["Energy Shield protects Mana instead of Life"]={{[1]={flags=0,keywordFlags=0,name="EnergyShieldProtectsMana",type="FLAG",value=true}},nil}
 c["50% increased Physical Damage taken"]={{[1]={flags=0,keywordFlags=0,name="PhysicalDamageTaken",type="INC",value=50}},nil}
 c["Adds 24 to 45 Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalMin",type="BASE",value=24},[2]={flags=0,keywordFlags=0,name="PhysicalMax",type="BASE",value=45}},nil}
-c["1% additional Physical Damage Reduction per Minion, up to 10%"]={{[1]={flags=0,keywordFlags=0,name="PhysicalDamageReduction",type="BASE",value=1}},"  per Minion, up to 10% "}
+c["1% additional Physical Damage Reduction per Minion, up to 10%"]={{[1]={[1]={limit=10,limitTotal=true,type="Multiplier",var="SummonedMinion"},flags=0,keywordFlags=0,name="PhysicalDamageReduction",type="BASE",value=1}},nil}
 c["34% increased Elemental Damage with Attack Skills"]={{[1]={flags=0,keywordFlags=65536,name="ElementalDamage",type="INC",value=34}},nil}
 c["+111 to Accuracy Rating"]={{[1]={flags=0,keywordFlags=0,name="Accuracy",type="BASE",value=111}},nil}
 c["Regenerate 40 Energy Shield per second"]={{[1]={flags=0,keywordFlags=0,name="EnergyShieldRegen",type="BASE",value=40}},nil}
@@ -960,7 +959,6 @@ c["Enemies Become Chilled as they Unfreeze 10% chance to Freeze Enemies which ar
 c["Minions have 10% increased Movement Speed"]={{[1]={flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="MovementSpeed",type="INC",value=10}}}},nil}
 c["100% chance on Block to create Consecrated Ground"]={{}," on Block to create Consecrated Ground "}
 c["20% increased Damage with Ailments from Attack Skills while wielding a Claw"]={{[1]={[1]={type="Condition",var="UsingClaw"},flags=2048,keywordFlags=65536,name="Damage",type="INC",value=20}},nil}
-c["1% additional Physical Damage Reduction per Minion, up to 10% +3% to all Elemental Resistances per Minion, up to 30%"]={{[1]={flags=0,keywordFlags=0,name="PhysicalDamageReduction",type="BASE",value=1}},"  per Minion, up to 10% +3% to all Elemental Resistances per Minion, up to 30% "}
 c["5% increased Fire Damage per Endurance Charge"]={{[1]={[1]={type="Multiplier",var="EnduranceCharge"},flags=0,keywordFlags=0,name="FireDamage",type="INC",value=5}},nil}
 c["+16% to Fire and Lightning Resistances"]={{[1]={flags=0,keywordFlags=0,name="FireResist",type="BASE",value=16},[2]={flags=0,keywordFlags=0,name="LightningResist",type="BASE",value=16}},nil}
 c["Attack Skills deal 30% increased Damage with Ailments while holding a Shield"]={{[1]={[1]={type="Condition",var="UsingShield"},flags=2048,keywordFlags=65536,name="Damage",type="INC",value=30}},nil}
@@ -1004,7 +1002,6 @@ c["6% increased Area of Effect per Endurance Charge"]={{[1]={[1]={type="Multipli
 c["+40% to Critical Strike Multiplier against Enemies that are on Full Life"]={{[1]={[1]={actor="enemy",type="ActorCondition",var="FullLife"},flags=0,keywordFlags=262144,name="CritMultiplier",type="BASE",value=40}},nil}
 c["13% increased Movement Speed"]={{[1]={flags=0,keywordFlags=0,name="MovementSpeed",type="INC",value=13}},nil}
 c["+80 to maximum Life"]={{[1]={flags=0,keywordFlags=0,name="Life",type="BASE",value=80}},nil}
-c["1% additional Physical Damage Reduction per Minion, up to 10% +3% to all Elemental Resistances per Minion, up to 30% 3% increased Recovery Rate of Life and Energy Shield per Minion, up to 30% Minions have 20% more Maximum Life"]={{[1]={flags=0,keywordFlags=0,name="PhysicalDamageReduction",type="BASE",value=1}},"  per Minion, up to 10% +3% to all Elemental Resistances per Minion, up to 30% 3% increased Recovery Rate of Life and Energy Shield per Minion, up to 30% Minions have 20% more Maximum Life "}
 c["5% increased Area of Effect"]={{[1]={flags=0,keywordFlags=0,name="AreaOfEffect",type="INC",value=5}},nil}
 c["+8 to Armour"]={{[1]={flags=0,keywordFlags=0,name="Armour",type="BASE",value=8}},nil}
 c["30% increased Projectile Speed"]={{[1]={flags=0,keywordFlags=0,name="ProjectileSpeed",type="INC",value=30}},nil}
@@ -1133,7 +1130,6 @@ c["538% increased Energy Shield"]={{[1]={flags=0,keywordFlags=0,name="EnergyShie
 c["1% increased Spell Damage per 10 Intelligence"]={{[1]={[1]={div=10,stat="Int",type="PerStat"},flags=2,keywordFlags=0,name="Damage",type="INC",value=1}},nil}
 c["10% chance to Freeze"]={{[1]={flags=0,keywordFlags=0,name="EnemyFreezeChance",type="BASE",value=10}},nil}
 c["Adds 39 to 60 Cold Damage to Spells"]={{[1]={flags=0,keywordFlags=131072,name="ColdMin",type="BASE",value=39},[2]={flags=0,keywordFlags=131072,name="ColdMax",type="BASE",value=60}},nil}
-c["Grants Level 20 Bone Armour Skill 1% additional Physical Damage Reduction per Minion, up to 10% +3% to all Elemental Resistances per Minion, up to 30% 3% increased Recovery Rate of Life and Energy Shield per Minion, up to 30% Minions have 20% more Maximum Life"]={nil,nil}
 c["+15 to Evasion Rating"]={{[1]={flags=0,keywordFlags=0,name="Evasion",type="BASE",value=15}},nil}
 c["12% increased Accuracy Rating with Axes"]={{[1]={flags=65536,keywordFlags=0,name="Accuracy",type="INC",value=12}},nil}
 c["Nearby Allies' Action Speed cannot be modified to below base value Nearby Enemies cannot deal Critical Strikes"]={nil,"Nearby Allies' Action Speed cannot be modified to below base value Nearby Enemies cannot deal Critical Strikes "}
@@ -2860,7 +2856,6 @@ c["Adds 31 to 100 Lightning Damage to Spells"]={{[1]={flags=0,keywordFlags=13107
 c["Energy Shield Recharge is not interrupted by Damage if"]={nil,"Energy Shield Recharge is not interrupted by Damage if "}
 c["1% of Energy Shield Regenerated per second for each"]={{[1]={flags=0,keywordFlags=0,name="EnergyShieldRegenPercent",type="BASE",value=1}}," for each "}
 c["Arrows Pierce an additional Target"]={{[1]={flags=1,keywordFlags=0,name="PierceCount",type="BASE",value=1}},nil}
-c["Grants Level 20 Bone Armour Skill 1% additional Physical Damage Reduction per Minion, up to 10% +3% to all Elemental Resistances per Minion, up to 30%"]={nil,nil}
 c["Gain 25% of Physical Damage as Extra Lightning Damage while affected by Wrath"]={{[1]={[1]={type="Condition",var="AffectedByWrath"},flags=0,keywordFlags=0,name="PhysicalDamageGainAsLightning",type="BASE",value=25}},nil}
 c["Minions deal 51 to 78 additional Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="PhysicalMin",type="BASE",value=51}}},[2]={flags=0,keywordFlags=0,name="MinionModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="PhysicalMax",type="BASE",value=78}}}},nil}
 c["400 Lightning Damage taken per second per Power Charge if you've dealt a Critical Strike Recently"]={{[1]={[1]={type="Multiplier",var="PowerCharge"},[2]={type="Condition",var="CritRecently"},flags=0,keywordFlags=0,name="LightningDegen",type="BASE",value=400}},nil}
@@ -3674,7 +3669,7 @@ c["30% reduced Chance to Block Attacks and Spells"]={{[1]={flags=0,keywordFlags=
 c["You have Fortify during Effect of any Life Flask"]={nil,"You have Fortify during Effect of any Life Flask "}
 c["Projectiles Pierce all nearby Targets"]={{[1]={flags=0,keywordFlags=0,name="PierceAllTargets",type="FLAG",value=true}},nil}
 c["Left ring slot: 40% reduced Reflected Elemental Damage taken"]={{[1]={[1]={num=1,type="SlotNumber"},flags=0,keywordFlags=0,name="ElementalDamageTaken",type="INC",value=-40}}," Reflected  "}
-c["3% increased Recovery Rate of Life and Energy Shield per Minion, up to 30%"]={{[1]={flags=0,keywordFlags=0,name="FlaskRecoveryRate",type="INC",value=3}},"  of Life and Energy Shield per Minion, up to 30% "}
+c["3% increased Recovery Rate of Life and Energy Shield per Minion, up to 30%"]={{[1]={[1]={limit=30,limitTotal=true,type="Multiplier",var="SummonedMinion"},flags=0,keywordFlags=0,name="LifeRecoveryRate",type="INC",value=3},[2]={[1]={limit=30,limitTotal=true,type="Multiplier",var="SummonedMinion"},flags=0,keywordFlags=0,name="EnergyShieldRecoveryRate",type="INC",value=3}},nil}
 c["Replenishes Energy Shield by 4% of Armour when you Block"]={nil,"Replenishes Energy Shield by 4% of Armour when you Block "}
 c["Adds 15 to 28 Fire Damage to Attacks"]={{[1]={flags=0,keywordFlags=65536,name="FireMin",type="BASE",value=15},[2]={flags=0,keywordFlags=65536,name="FireMax",type="BASE",value=28}},nil}
 c["30% chance to cause Bleeding on Hit"]={{[1]={flags=0,keywordFlags=0,name="BleedChance",type="BASE",value=30}},nil}
@@ -3960,7 +3955,6 @@ c["Adds 110 to 170 Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="Physica
 c["175% increased Armour"]={{[1]={flags=0,keywordFlags=0,name="Armour",type="INC",value=175}},nil}
 c["40% of Lightning Damage Converted to Cold Damage"]={{[1]={flags=0,keywordFlags=0,name="LightningDamageConvertToCold",type="BASE",value=40}},nil}
 c["Adds 100 to 370 Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalMin",type="BASE",value=100},[2]={flags=0,keywordFlags=0,name="PhysicalMax",type="BASE",value=370}},nil}
-c["+3% to all Elemental Resistances per Minion, up to 30% 3% increased Recovery Rate of Life and Energy Shield per Minion, up to 30%"]={{[1]={flags=0,keywordFlags=0,name="ElementalResist",type="BASE",value=3}},"  per Minion, up to 30% 3% increased Recovery Rate of Life and Energy Shield per Minion, up to 30% "}
 c["15% increased Damage Over Time with Bow Skills"]={{[1]={flags=8,keywordFlags=512,name="Damage",type="INC",value=15}},nil}
 c["30% chance to gain an additional Vaal Soul on Kill Corrupted"]={{}," to gain an additional  Soul on Kill Corrupted "}
 c["Socketed Golem Skills gain 20% of Maximum Life as Extra Maximum Energy Shield"]={{[1]={[1]={keyword="golem",slotName="{SlotName}",type="SocketedIn"},flags=0,keywordFlags=0,name="ExtraSkillMod",type="LIST",value={mod={flags=0,keywordFlags=0,name="LifeGainAsEnergyShield",type="BASE",value=20}}}},nil}
@@ -4027,7 +4021,7 @@ c["Adds 25 to 50 Cold Damage to Spells and Attacks"]={{[1]={flags=0,keywordFlags
 c["You and Allies affected by your placed Banners Regenerate 0.1% of"]={nil,"You and Allies affected by your placed Banners Regenerate 0.1% of "}
 c["8% increased Spell Damage"]={{[1]={flags=2,keywordFlags=0,name="Damage",type="INC",value=8}},nil}
 c["Immune to Ignite"]={{[1]={flags=0,keywordFlags=0,name="AvoidIgnite",type="BASE",value=100}},nil}
-c["+3% to all Elemental Resistances per Minion, up to 30%"]={{[1]={flags=0,keywordFlags=0,name="ElementalResist",type="BASE",value=3}},"  per Minion, up to 30% "}
+c["+3% to all Elemental Resistances per Minion, up to 30%"]={{[1]={[1]={limit=30,limitTotal=true,type="Multiplier",var="SummonedMinion"},flags=0,keywordFlags=0,name="ElementalResist",type="BASE",value=3}},nil}
 c["Adds 1 to 60 Lightning Damage to Spells and Attacks"]={{[1]={flags=0,keywordFlags=196608,name="LightningMin",type="BASE",value=1},[2]={flags=0,keywordFlags=196608,name="LightningMax",type="BASE",value=60}},nil}
 c["0% increased Rarity of Items found"]={{[1]={flags=0,keywordFlags=0,name="LootRarity",type="INC",value=0}},nil}
 c["+14% to Cold and Lightning Resistances"]={{[1]={flags=0,keywordFlags=0,name="ColdResist",type="BASE",value=14},[2]={flags=0,keywordFlags=0,name="LightningResist",type="BASE",value=14}},nil}
@@ -5198,7 +5192,6 @@ c["Cold Spells have 10% of Physical Damage Converted to Cold Damage"]={{[1]={fla
 c["Adds 22 to 33 Cold Damage"]={{[1]={flags=0,keywordFlags=0,name="ColdMin",type="BASE",value=22},[2]={flags=0,keywordFlags=0,name="ColdMax",type="BASE",value=33}},nil}
 c["5% increased Movement Speed while you have Fortify"]={{[1]={[1]={type="Condition",var="Fortify"},flags=0,keywordFlags=0,name="MovementSpeed",type="INC",value=5}},nil}
 c["8% increased Fire Damage"]={{[1]={flags=0,keywordFlags=0,name="FireDamage",type="INC",value=8}},nil}
-c["Grants Level 20 Bone Armour Skill 1% additional Physical Damage Reduction per Minion, up to 10% +3% to all Elemental Resistances per Minion, up to 30% 3% increased Recovery Rate of Life and Energy Shield per Minion, up to 30%"]={nil,nil}
 c["20% chance to Poison on Hit with Attacks"]={{[1]={flags=0,keywordFlags=65536,name="PoisonChance",type="BASE",value=20}},nil}
 c["1% increased Area of Effect per Enemy killed recently, up to 50%"]={{[1]={[1]={limit=50,limitTotal=true,type="Multiplier",var="EnemyKilledRecently"},flags=0,keywordFlags=0,name="AreaOfEffect",type="INC",value=1}},nil}
 c["30% of Physical Damage taken as Lightning Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalDamageTakenAsLightning",type="BASE",value=30}},nil}
@@ -5766,7 +5759,6 @@ c["Left ring slot: You cannot Recharge or Regenerate Energy Shield"]={nil,"You c
 c["10% chance to cause Bleeding on Hit"]={{[1]={flags=0,keywordFlags=0,name="BleedChance",type="BASE",value=10}},nil}
 c["Adds 32 to 42 Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalMin",type="BASE",value=32},[2]={flags=0,keywordFlags=0,name="PhysicalMax",type="BASE",value=42}},nil}
 c["12 Mana Regenerated per Second while you have Avian's Flight"]={{[1]={[1]={type="Condition",var="AffectedByAvian'sFlight"},flags=0,keywordFlags=0,name="ManaRegen",type="BASE",value=12}},nil}
-c["Grants Level 20 Bone Armour Skill 1% additional Physical Damage Reduction per Minion, up to 10%"]={nil,nil}
 c["50% reduced Attack Speed"]={{[1]={flags=1,keywordFlags=0,name="Speed",type="INC",value=-50}},nil}
 c["+20% to Global Critical Strike Multiplier"]={{[1]={[1]={type="Global"},flags=0,keywordFlags=0,name="CritMultiplier",type="BASE",value=20}},nil}
 c["10% reduced Mana Reserved"]={{[1]={flags=0,keywordFlags=0,name="ManaReserved",type="INC",value=-10}},nil}
@@ -6865,7 +6857,6 @@ c["10% chance to Fortify on Melee hit Enemies Taunted by you take 10% increased 
 c["20% chance to gain a Power Charge on Non-Critical Strike +1 to Maximum Power Charges"]={{[1]={flags=0,keywordFlags=0,name="PowerChargesMax",type="BASE",value=20}}," to gain a Power Charge on Non-Critical Strike +1 to  "}
 c["Take 30 Chaos Damage per Second during Flask effect"]={{[1]={[1]={type="Condition",var="UsingFlask"},flags=0,keywordFlags=0,name="ChaosDegen",type="BASE",value=30}},nil}
 c["Grants maximum Energy Shield equal to 15% of your Reserved Mana to"]={nil,"Grants maximum Energy Shield equal to 15% of your Reserved Mana to "}
-c["+3% to all Elemental Resistances per Minion, up to 30% 3% increased Recovery Rate of Life and Energy Shield per Minion, up to 30% Minions have 20% more Maximum Life"]={{[1]={flags=0,keywordFlags=0,name="ElementalResist",type="BASE",value=3}},"  per Minion, up to 30% 3% increased Recovery Rate of Life and Energy Shield per Minion, up to 30% Minions have 20% more Maximum Life "}
 c["-2 to Total Mana Cost of Skills for each Corrupted Item Equipped"]={{[1]={[1]={type="Multiplier",var="CorruptedItem"},flags=0,keywordFlags=0,name="ManaCost",type="BASE",value=-2}},nil}
 c["+20% chance to be Pierced by Projectiles"]={{[1]={flags=0,keywordFlags=0,name="ProjectileCount",type="BASE",value=20}}," to be Pierced by  "}
 c["30% increased Stun and Block Recovery"]={{[1]={flags=0,keywordFlags=0,name="StunRecovery",type="INC",value=30}},nil}
@@ -7509,7 +7500,6 @@ c["40% reduced Rarity of Items found"]={{[1]={flags=0,keywordFlags=0,name="LootR
 c["12% increased Chaos Damage"]={{[1]={flags=0,keywordFlags=0,name="ChaosDamage",type="INC",value=12}},nil}
 c["Damage penetrates 25% Cold Resistance while affected by Herald of Ice"]={{[1]={[1]={type="Condition",var="AffectedByHeraldofIce"},flags=0,keywordFlags=0,name="ColdPenetration",type="BASE",value=25}},nil}
 c["Corpses you Spawn have 50% increased Maximum Life"]={nil,"Corpses you Spawn have 50% increased Maximum Life "}
-c["1% additional Physical Damage Reduction per Minion, up to 10% +3% to all Elemental Resistances per Minion, up to 30% 3% increased Recovery Rate of Life and Energy Shield per Minion, up to 30%"]={{[1]={flags=0,keywordFlags=0,name="PhysicalDamageReduction",type="BASE",value=1}},"  per Minion, up to 10% +3% to all Elemental Resistances per Minion, up to 30% 3% increased Recovery Rate of Life and Energy Shield per Minion, up to 30% "}
 c["+55% to Non-Ailment Chaos Damage over Time Multiplier"]={{[1]={flags=0,keywordFlags=0,name="ChaosDotMultiplier",type="BASE",value=55}}," Non-Ailment  "}
 c["Your Hits permanently Intimidate Enemies that are on Full Life Gain Adrenaline for 20 seconds when you reach Low Life if you\ndo not have Adrenaline Recover 25% of maximum Life when you gain Adrenaline"]={nil,"Your Hits permanently Intimidate Enemies that are on Full Life Gain Adrenaline for 20 seconds when you reach Low Life if you\ndo not have Adrenaline Recover 25% of maximum Life when you gain Adrenaline "}
 c["40% increased Critical Strike Chance with Maces"]={{[1]={flags=1048576,keywordFlags=0,name="CritChance",type="INC",value=40}},nil}

--- a/Modules/ConfigOptions.lua
+++ b/Modules/ConfigOptions.lua
@@ -445,6 +445,9 @@ return {
 	{ var = "multiplierNearbyEnemy", type = "count", label = "# of Nearby Enemies", ifMult = "NearbyEnemy", apply = function(val, modList, enemyModList)
 		modList:NewMod("Multiplier:NearbyEnemy", "BASE", val, "Config", { type = "Condition", var = "Combat" })
 	end },
+	{ var = "multiplierSummonedMinion", type = "count", label = "# of Summoned Minions", ifMult = "SummonedMinion", apply = function(val, modList, enemyModList)
+		modList:NewMod("Multiplier:SummonedMinion", "BASE", val, "Config", { type = "Condition", var = "Combat" })
+	end },
 	{ var = "conditionOnConsecratedGround", type = "check", label = "Are you on Consecrated Ground?", tooltip = "In addition to allowing any 'while on Consecrated Ground' modifiers to apply,\nthis will apply the 6% life regen modifier granted by Consecrated Ground.", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:OnConsecratedGround", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },

--- a/Modules/ModParser-3_0.lua
+++ b/Modules/ModParser-3_0.lua
@@ -734,6 +734,7 @@ local modTagList = {
 	["for each poison you have inflicted recently"] = { tag = { type = "Multiplier", var = "PoisonAppliedRecently" } },
 	["for each shocked enemy you've killed recently"] = { tag = { type = "Multiplier", var = "ShockedEnemyKilledRecently" } },
 	["per enemy killed recently, up to (%d+)%%"] = function(num) return { tag = { type = "Multiplier", var = "EnemyKilledRecently", limit = tonumber(num), limitTotal = true } } end,
+	["per minion, up to (%d+)%%"] = function(num) return { tag = { type = "Multiplier", var = "SummonedMinion", limit = tonumber(num), limitTotal = true } } end,
 	["for each enemy you or your minions have killed recently, up to (%d+)%%"] = function(num) return { tag = { type = "Multiplier", varList = {"EnemyKilledRecently","EnemyKilledByMinionsRecently"}, limit = tonumber(num), limitTotal = true } } end,
 	["for each enemy you or your minions have killed recently, up to (%d+)%% per second"] = function(num) return { tag = { type = "Multiplier", varList = {"EnemyKilledRecently","EnemyKilledByMinionsRecently"}, limit = tonumber(num), limitTotal = true } } end,
 	["per enemy killed by you or your totems recently"] = { tag = { type = "Multiplier", varList = {"EnemyKilledRecently","EnemyKilledByTotemsRecently"} } },


### PR DESCRIPTION
Added "# of Summoned Minions" combat configuration to support 'per minion' modifiers. Only affects Necromancer Bone Barrier notable at this moment. Also cleaned up the related duplicates in ModCache.