### PR TITLE
Fix player ignite dps breakdown visual

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3070,7 +3070,7 @@ function calcs.offence(env, actor, activeSkill)
 					output.TotalIgniteDPS = output.IgniteDPS * output.TotalIgniteStacks
 				end
 				if breakdown then
-					t_insert(breakdown.IgniteDPS, "x 0.5 ^8(ignite deals 50% per second)")
+					t_insert(breakdown.IgniteDPS, "x 1.25 ^8(ignite deals 125% per second)")
 					t_insert(breakdown.IgniteDPS, s_format("= %.1f", baseVal, 1))
 					breakdown.multiChain(breakdown.IgniteDPS, {
 						label = "Ignite DPS:",


### PR DESCRIPTION
Fixing player ignite dps breakdown from 50% to 125% as per scourge manifesto pt3.