### PR TITLE
Feat/add global default gem quality

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -83,8 +83,8 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 		self.defaultGemLevel = m_max(m_min(tonumber(buf) or 20, 21), 1)
 	end)
 	self.controls.defaultLevelLabel = new("LabelControl", {"RIGHT",self.controls.defaultLevel,"LEFT"}, -4, 0, 0, 16, "^7Default gem level:")
-	self.controls.defaultQuality = new("EditControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, optionInputsX, 118, 60, 20, main.defaultGemQuality, nil, "%D", 2, function(gemQuality)
-		self.defaultGemQuality = m_min(tonumber(gemQuality) or 0, 23)
+	self.controls.defaultQuality = new("EditControl", {"TOPLEFT",self.controls.groupList,"BOTTOMLEFT"}, optionInputsX, 118, 60, 20, nil, nil, "%D", 2, function(buf)
+		self.defaultGemQuality = m_min(tonumber(buf) or 0, 23)
 	end)
 
 	self.controls.defaultQualityLabel = new("LabelControl", {"RIGHT",self.controls.defaultQuality,"LEFT"}, -4, 0, 0, 16, "^7Default gem quality:")
@@ -812,7 +812,6 @@ end
 
 -- Update the gem slot controls to reflect the currently displayed socket group
 function SkillsTabClass:UpdateGemSlots()
-
 	if not self.displayGroup then
 		return
 	end

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -631,7 +631,7 @@ function main:OpenOptionsPopup()
 		self.betaTest = state
 	end)
 
-	controls.defaultGemQuality = new("EditControl", {"TOPLEFT",nil,"TOPLEFT"}, 230, 204, 30, 20, self.defaultGemQuality, nil, "%%^", 2, function(gemQuality)
+	controls.defaultGemQuality = new("EditControl", {"TOPLEFT",nil,"TOPLEFT"}, 230, 204, 60, 20, self.defaultGemQuality, nil, "%D", 2, function(gemQuality)
 		self.defaultGemQuality = m_min(tonumber(gemQuality) or 0, 23)
 	end)
 	controls.defaultGemQuality.tooltipText="Set the default quality that can be overwritten by build-related quality settings in the skill panel."


### PR DESCRIPTION
This adds a global setting for default gem quality that saves the value in the `Settings.xml` and loads it from there.
![x](https://user-images.githubusercontent.com/3480240/136699144-47ee4ec7-30e3-4233-977f-6f8b57b2fa89.png)

It automatically applies itself in the skill tab by fetching the value on and applying to the edit box in the Skillstab if the value is > 0:

![y](https://user-images.githubusercontent.com/3480240/136699128-aaac24ca-180c-43ae-84c8-8c3faa1a53d4.png)

I didnt find a nicer way to sync default value globally with the values per build, if you have any idea i'd be open for any changes to the behaviour :)
