### PR TITLE
Feat/add global default level

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -57,7 +57,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild)
 	self.xmlSectionList = { }
 	self.spectreList = { }
 	self.viewMode = "TREE"
-	self.characterLevel = 1
+	self.characterLevel = main.defaultCharLevel or 1
 	self.targetVersion = liveTargetVersion
 	self.bandit = "None"
 	self.pantheonMajorGod = "None"

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -522,6 +522,9 @@ function main:LoadSettings(ignoreBuild)
 				if node.attrib.defaultGemQuality then
 					self.defaultGemQuality = m_min(tonumber(node.attrib.defaultGemQuality) or 0, 23)
 				end
+				if node.attrib.defaultCharLevel then
+					self.defaultCharLevel = m_min(tonumber(node.attrib.defaultCharLevel) or 1, 100)
+				end
 			end
 		end
 	end
@@ -569,7 +572,8 @@ function main:SaveSettings()
 		decimalSeparator = self.decimalSeparator,
 		showTitlebarName = tostring(self.showTitlebarName),
 		betaTest = tostring(self.betaTest),
-		defaultGemQuality = tostring(self.defaultGemQuality),
+		defaultGemQuality = tostring(self.defaultGemQuality or 0),
+		defaultCharLevel = tostring(self.defaultCharLevel or 1),
 	} })
 	local res, errMsg = common.xml.SaveXMLFile(setXML, self.userPath.."Settings.xml")
 	if not res then
@@ -680,6 +684,14 @@ function main:OpenOptionsPopup()
 	controls.defaultGemQuality.tooltipText="Set the default quality that can be overwritten by build-related quality settings in the skill panel."
 	controls.defaultGemQualityLabel = new("LabelControl", {"RIGHT",controls.defaultGemQuality,"LEFT"}, defaultLabelSpacingPx, 0, 0, 16, "^7Default gem quality:")
 
+
+    nextRow()
+	controls.defaultCharLevel = new("EditControl", {"TOPLEFT",nil,"TOPLEFT"}, defaultLabelPlacementX, currentY, 80, 20, self.defaultCharLevel, nil, "%D", 3, function(charLevel)
+		self.defaultCharLevel = m_min(tonumber(charLevel) or 1, 100)
+	end)
+	controls.defaultCharLevel.tooltipText="Set the default char level that can be overwritten by build-related level settings."
+	controls.defaultCharLevelLabel = new("LabelControl", {"RIGHT",controls.defaultCharLevel,"LEFT"}, defaultLabelSpacingPx, 0, 0, 16, "^7Default character level:")
+
 	controls.betaTest.state = self.betaTest
 	controls.titlebarName.state = self.showTitlebarName
 	local initialNodePowerTheme = self.nodePowerTheme
@@ -688,7 +700,8 @@ function main:OpenOptionsPopup()
 	local initialThousandsSeparator = self.thousandsSeparator
 	local initialDecimalSeparator = self.decimalSeparator
 	local initialBetaTest = self.betaTest
-	local initialDefaultGemQuality = self.defaultGemQuality
+	local initialDefaultGemQuality = self.defaultGemQuality or 0
+	local initialDefaultCharLevel = self.defaultCharLevel or 1
 
     -- last line with buttons has more spacing
     nextRow(1.5)
@@ -721,6 +734,7 @@ function main:OpenOptionsPopup()
 		self.showTitlebarName = initialTitlebarName
 		self.betaTest = initialBetaTest
 		self.defaultGemQuality = initialDefaultGemQuality
+		self.defaultCharLevel = initialDefaultCharLevel
 		main:ClosePopup()
 	end)
     nextRow(1.5)


### PR DESCRIPTION
this brings in a global default char level setting to pob but requires #3255 for ease of adding elements to the options menu.

![grafik](https://user-images.githubusercontent.com/3480240/137522054-d9324fe0-bfa0-42af-866c-0e7379a4ed4e.png)
