### PR TITLE
Fix CI keystone

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -77,17 +77,12 @@ function calcs.defence(env, actor)
 	output.PhysicalResistWhenHit = m_min(output.DamageReductionMax, output.PhysicalResist + modDB:Sum("BASE", nil, "PhysicalDamageReductionWhenHit"))
 	for _, elem in ipairs(resistTypeList) do
 		local max, total
-		if elem == "Chaos" and modDB:Flag(nil, "ChaosInoculation") then
-			max = 100
-			total = 100
-		else
 			max = modDB:Override(nil, elem.."ResistMax") or m_min(data.misc.MaxResistCap, modDB:Sum("BASE", nil, elem.."ResistMax", isElemental[elem] and "ElementalResistMax"))
 			total = modDB:Override(nil, elem.."Resist")
 			if not total then
 				local base = modDB:Sum("BASE", nil, elem.."Resist", isElemental[elem] and "ElementalResist")
 				total = base * calcLib.mod(modDB, nil, elem.."Resist", isElemental[elem] and "ElementalResist")
 			end
-		end
 		local final = m_min(total, max)
 		output[elem.."Resist"] = final
 		output[elem.."ResistTotal"] = total

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1420,7 +1420,10 @@ local specialModList = {
 		mod("BlockChance", "MORE", -30),
 		mod("SpellBlockChance", "MORE", -30),
 	},
-	["maximum life becomes 1, immune to chaos damage"] = { flag("ChaosInoculation") },
+	["maximum life becomes 1, immune to chaos damage"] = { 
+		flag("ChaosInoculation"),
+		mod("ChaosDamageTaken", "MORE", -100)
+	},
 	["life regeneration is applied to energy shield instead"] = { flag("ZealotsOath") },
 	["life leeched per second is doubled"] = { mod("LifeLeechRate", "MORE", 100) },
 	["total recovery per second from life leech is doubled"] = { mod("LifeLeechRate", "MORE", 100) },


### PR DESCRIPTION
To prepare for chaos mastery that scales of chaos resistance CI should be changed from giving 100% res to 100% less damage taken
![image](https://user-images.githubusercontent.com/17045310/137602078-10e6d6a9-346d-4e26-bc0e-519a02c9eec6.png)
