### PR TITLE
Mastery Mod - Cannot be frozen if energy shield recharge has started recently

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2581,6 +2581,7 @@ local specialModList = {
 	["you cannot be shocked while at maximum endurance charges"] = { mod("AvoidShock", "BASE", 100, { type = "StatThreshold", stat = "EnduranceCharges", thresholdStat = "EnduranceChargesMax" }) },
 	["cannot be shocked if intelligence is higher than strength"] = { mod("AvoidShock", "BASE", 100, { type = "Condition", var = "IntHigherThanStr" }) },
 	["cannot be frozen if dexterity is higher than intelligence"] = { mod("AvoidFreeze", "BASE", 100, { type = "Condition", var = "DexHigherThanInt" }) },
+	["cannot be frozen if energy shield recharge has started recently"] = { mod("AvoidFreeze", "BASE", 100, { type = "Condition", var = "EnergyShieldRechargeRecently" }) },
 	["cannot be ignited if strength is higher than dexterity"] = { mod("AvoidIgnite", "BASE", 100, { type = "Condition", var = "StrHigherThanDex" }) },
 	["cannot be chilled while burning"] = { mod("AvoidChill", "BASE", 100, { type = "Condition", var = "Burning" }) },
 	["cannot be inflicted with bleeding"] = { mod("AvoidBleed", "BASE", 100) },


### PR DESCRIPTION
**Changes**
Add parse for new text to make freeze immune if energy shield recharge has started recently conditional is true

**Testing**
Allocate "Cannot be frozen if energy shield recharge has started recently" on any energy shield mastery
Check configuration tab checkbox
Verify freeze immune if true

![image](https://user-images.githubusercontent.com/92683202/137752259-ac938109-0717-4688-8c29-45dadbf01f7f.png)
