### PR TITLE
Add support for charge duration mastery

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -358,6 +358,7 @@ local modNameList = {
 	["maximum blitz charges"] = "BlitzChargesMax",
 	["maximum number of crab barriers"] = "CrabBarriersMax",
 	["maximum blood charges"] = "BloodChargesMax",
+	["charge duration"] = "ChargeDuration",
 	-- On hit/kill/leech effects
 	["life gained on kill"] = "LifeOnKill",
 	["mana gained on kill"] = "ManaOnKill",


### PR DESCRIPTION
Note, I've created a new mod for the charge duration as I believe this mastery passive applies to all charges beyond just power/frenzy/end charges. Feel free to reject if this seems wrong. 