### PR TITLE
Add support for  "% increased Evasion Rating from your Body Armour"

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -766,6 +766,7 @@ local modFlagList = {
 	["global"] = { tag = { type = "Global" } },
 	["from equipped shield"] = { tag = { type = "SlotName", slotName = "Weapon 2" } },
 	["from body armour"] = { tag = { type = "SlotName", slotName = "Body Armour" } },
+	["from your body armour"] = { tag = { type = "SlotName", slotName = "Body Armour" } },
 }
 
 -- List of modifier flags/tags that appear at the start of a line


### PR DESCRIPTION
Added to the parser to recognize the wording "from your Body Armour" where the "your" is new.
Assuming this effect is the exact same as "from Body Armour".
This new wording can be found in evasion mastery.

Considered adding "your" in a regex, but modFlagList does not seem to be parsed using regex.
Resulting added evasion is the same as the tag without the "your".