### PR TITLE
Fix Elemental Overload not only applying to Hits and Ailments

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1478,9 +1478,6 @@ local specialModList = {
 		mod("LightningDamageConvertToFire", "BASE", num),
 		mod("ColdDamageConvertToFire", "BASE", num),
 	} end,
-	["skills that have dealt a critical strike in the past (%d+) seconds deal (%d+)%% more elemental damage with hits and ailments"] = function(num, _, dmg) return {
-		mod("ElementalDamage", "MORE", tonumber(dmg)),
-	} end,
 	["removes all mana%. spend life instead of mana for skills"] = { mod("Mana", "MORE", -100), flag("BloodMagic") },
 	["removes all mana"] = { mod("Mana", "MORE", -100) },
 	["skills cost life instead of mana"] = { flag("CostLifeInsteadOfMana") },


### PR DESCRIPTION
Elemental overload used to have:
40% more Elemental Damage if you've dealt a Crit in the past 8 seconds
But now has
Skills that have dealt a Critical Strike in the past 8 seconds deal 40% more Elemental Damage with Hits and Ailments

An easy fix is to just add "Skills that have dealt a Critical Strike in the past 8 seconds deal " to be the same conditional modifer as before, meaning "CritInPast8Sec". Which is done here, even though in practice their different.

Tested:
* Damage is the same as with old elemental overload for this line.