### PR TITLE
Add support for Increased Curse Effect on Enemies in Chilling Areas

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2277,6 +2277,7 @@ local specialModList = {
 	["enemies can have 1 additional curse"] = { mod("EnemyCurseLimit", "BASE", 1) },
 	["you can apply an additional curse"] = { mod("EnemyCurseLimit", "BASE", 1) },
 	["you can apply one fewer curse"] = { mod("EnemyCurseLimit", "BASE", -1) },
+	["curses on enemies in your chilling areas have (%d+)%% increased effect"] = function(num) return { mod("CurseEffect", "INC", num, { type = "ActorCondition", actor = "enemy", var = "InChillingArea" } ) } end,
 	["hexes you inflict have their effect increased by twice their doom instead"] = { mod("DoomEffect", "MORE", 100) },
 	["nearby enemies have an additional (%d+)%% chance to receive a critical strike"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("SelfExtraCritChance", "BASE", num) }) } end,
 	["nearby enemies have (%-%d+)%% to all resistances"] = function(num) return {


### PR DESCRIPTION
**Changes**
Update ModParser for increased curse effect on enemies in chilling areas

**Testing**

Set curse (vulnerability)
- No mastery, no enemies in chilling areas (no option to do so)
![image](https://user-images.githubusercontent.com/92683202/137806769-54a0a932-57a3-4fb8-b4a8-340296b94827.png)

- Mastery, enemies in chilling areas config
![image](https://user-images.githubusercontent.com/92683202/137807012-df49bdf2-dd5c-4b83-bf20-f22f85bb687c.png)
![image](https://user-images.githubusercontent.com/92683202/137806907-3953bac4-2134-4051-beed-e81be05f4f85.png)


