### PR TITLE
feat: added support for '20% chance to defend with 200% armour' mastery

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -141,6 +141,7 @@ local modNameList = {
 	["restoration of ward"] = "WardRechargeFaster",
 	["armour"] = "Armour",
 	["to defend with double armour"] = "DoubleArmourChance",
+	["to defend with 200% of armour"] = "DoubleArmourChance",
 	["evasion"] = "Evasion",
 	["evasion rating"] = "Evasion",
 	["energy shield"] = "EnergyShield",


### PR DESCRIPTION
I left the old `to defend with double armour` for backwards compatibility.

I assume 200% armour == double armour