### PR TITLE
[3361] Visual bug in new tree. Orbits greater than 90 degress and les…

### DIFF
--- a/src/Launch.lua
+++ b/src/Launch.lua
@@ -15,11 +15,6 @@ launch = { }
 SetMainObject(launch)
 
 function launch:OnInit()
-	package.cpath = package.cpath .. ';C:/Users/summ1/AppData/Local/JetBrains/Toolbox/apps/IDEA-U/ch-0/212.5284.40.plugins/EmmyLua/classes/debugger/emmy/windows/x86/?.dll'
-	local dbg = require('emmy_core')
-	dbg.tcpListen('localhost', 9966)
-	--dbg.waitIDE()
-
 	self.devMode = false
 	self.installedMode = false
 	self.versionNumber = "?"


### PR DESCRIPTION
[#3361] Visual bug in new tree. 
Orbits greater than 90 degrees and less than 180 degrees show disconnected paths between nodes. 
Adding mirrored arcs for such cases. This requires some node connections to generate 2 arcs instead of 1, but the intention is that they appear connected and seamless.

This reverts a recent change where code to process multiple connectors out of the BuildConnector method was removed. That functionality is necessary for this PR (or at least this method of fixing the issue). 

![image](https://user-images.githubusercontent.com/100859/137827637-d0d5120a-c713-4a32-ba73-2e07df63e5ec.png)
![image](https://user-images.githubusercontent.com/100859/137827644-73208cad-6312-425c-823d-7077e5a455a1.png)
