### PR TITLE
Fix [#3361] Visual bug in new tree.

### DIFF
--- a/src/Classes/PassiveTree.lua
+++ b/src/Classes/PassiveTree.lua
@@ -707,6 +707,7 @@ function PassiveTreeClass:BuildArc(arcAngle, node1, connector, isMirroredArc)
 	local p = 1 - m_max(m_tan(clipAngle), 0)
 	local angle = node1.angle - clipAngle
 	if isMirroredArc then
+		-- The center of the mirrored angle should be positioned at 75% of the way between nodes.
 		angle = angle + arcAngle
 	end
 	connector.vert = { }


### PR DESCRIPTION
[#3361] Visual bug in new tree.
Orbits greater than 90 degrees and less than 180 degrees show disconnected paths between nodes.
Adding mirrored arcs for such cases. This requires some node connections to generate 2 arcs instead of 1, but the intention is that they appear connected and seamless.

This reverts a recent change where code to process multiple connectors out of the BuildConnector method was removed. That functionality is necessary for this PR (or at least this method of fixing the issue).

![image](https://user-images.githubusercontent.com/100859/137831784-fd06647b-1512-44a8-a59c-350245d3aa34.png)

![image](https://user-images.githubusercontent.com/100859/137831798-a6fde5d1-fdba-4585-9009-2d8595fd9179.png)
