### PR TITLE
Add support for Increased Damage when using Bow and Totem

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2418,6 +2418,7 @@ local specialModList = {
 	["([%d%.]+)%% of damage dealt by y?o?u?r? ?mines is leeched to you as life"] = function(num) return { mod("DamageLifeLeechToPlayer", "BASE", num, nil, 0, KeywordFlag.Mine) } end,
 	["you can cast an additional brand"] = { mod("ActiveBrandLimit", "BASE", 1) },
 	["you can cast (%d+) additional brands"] = function(num) return { mod("ActiveBrandLimit", "BASE", num) } end,
+	["(%d+)%% increased damage while you are wielding a bow and have a totem"] = function(num) return { mod("Damage", "INC", num, { type = "Condition", var = "HaveTotem" }, { type = "Condition", var = "UsingBow" }) } end,
 	-- Minions
 	["your strength is added to your minions"] = { flag("HalfStrengthAddedToMinions") },
 	["half of your strength is added to your minions"] = { flag("HalfStrengthAddedToMinions") },


### PR DESCRIPTION
### Bow Mastery - 35% increased Damage while you are wielding a Bow and have a Totem
**Changes**
Update ModParser for string, reusing UsingBow and HaveTotem conditionals

**Testing**
- Allocate mastery
- Add bow and split arrow to build
- Add decoy totem to build, check HaveTotem config
- Check for 35% increased in calculations

![image](https://user-images.githubusercontent.com/92683202/137839238-c56425d3-5bd5-4204-b118-c454c24847ed.png)

