### PR TITLE
Fix edited Legion jewel nodes not saving/loading properly

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -129,8 +129,13 @@ function PassiveSpecClass:Load(xml, dbFileName)
 
 					local editorSeed = tonumber(child.attrib.editorSeed)
 					local nodeId = tonumber(child.attrib.nodeId)
-					self.tree.legion.editedNodes = { }
-					self.tree.legion.editedNodes[editorSeed] = { [nodeId] = copyTable(self.nodes[nodeId], true) }
+					if not self.tree.legion.editedNodes then
+						self.tree.legion.editedNodes = { }
+					end
+					if not self.tree.legion.editedNodes[editorSeed] then
+						self.tree.legion.editedNodes[editorSeed] = { }
+					end
+					self.tree.legion.editedNodes[editorSeed][nodeId] = copyTable(self.nodes[nodeId], true)
 					self.tree.legion.editedNodes[editorSeed][nodeId].id = nodeId
 					self.tree.legion.editedNodes[editorSeed][nodeId].dn = child.attrib.nodeName
 					self.tree.legion.editedNodes[editorSeed][nodeId].icon = child.attrib.icon
@@ -171,7 +176,15 @@ function PassiveSpecClass:Save(xml)
 				for _, modLine in ipairs(node.sd) do
 					t_insert(editedNode, modLine)
 				end
-				t_insert(editedNodes, editedNode)
+				-- Do not save current editedNode data unless the current node is conquered
+				if self.nodes[nodeId].conqueredBy then
+					-- Do not save current editedNode data unless the current node is allocated
+					for allocNodeId in pairs(self.allocNodes) do
+						if nodeId == allocNodeId then
+							t_insert(editedNodes, editedNode)
+						end
+					end
+				end
 			end
 		end
 	end


### PR DESCRIPTION
This fixes loading and saving multiple legion jewel conquered passives. Currently only a single modified node saves/loads properly and anything beyond the first node is discarded. Edited nodes that are not conquered or allocated anywhere in the build are pruned when the build is saved, to avoid reintroducing issue #3156 (that was technically fixed by #3229, but with.. various downsides.)