### PR TITLE
Fix: Add catch for infinite loop

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -726,7 +726,7 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 						end
 					end
 				end
-				if prune then
+				if prune or _ > 100000 then
 					self:DeallocSingleNode(depNode)
 				end
 			end


### PR DESCRIPTION
I hate this PR. Merge at your own peril.

For some godforsaken reason I can't figure out, some builds are not loading items before reaching this section of the code, leading to an infinite loop while checking for intuitive leap on nodes with no start found.

This error should only happen when merging builds from older tree versions.. probably. Either way, this fix just prunes the node if it's tried 100k times.

Can we exclude this PR from my resume? Thanks.