### PR TITLE
Fix: Added two mastery supports for bleed/impale

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2213,6 +2213,14 @@ local specialModList = {
 	["(%d+)%% increased effect of impales inflicted by hits that also inflict bleeding"] = function(num) return {
 		mod("ImpaleEffectOnBleed", "INC", num, nil, 0, KeywordFlag.Hit)
 	} end,
+	-- Impale
+	["(%d+)%% increased effect of impales you inflict on non%-impaled enemies"] = function(num) return {
+		mod("ImpaleEffect", "INC", num, { type = "ActorCondition", actor = "enemy", var = "Impaled", neg = true })
+	} end,
+	-- Poison and Bleed
+	["(%d+)%% increased damage with bleeding inflicted on poisoned enemies"] = function(num) return {
+		mod("BleedDamage", "INC", num, { type = "ActorCondition", actor = "enemy", var = "Poisoned"})
+	} end,
 	-- Poison
 	["y?o?u?r? ?fire damage can poison"] = { flag("FireCanPoison") },
 	["y?o?u?r? ?cold damage can poison"] = { flag("ColdCanPoison") },


### PR DESCRIPTION
Masteries:
20% increased effect of impales you inflict on non-impaled enemies.
60% increased damage with bleeding inflicted on poisoned enemies.