### PR TITLE
Add support for "increased Damage with Bleeding inflicted on Poisoned Enemies"

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2210,13 +2210,8 @@ local specialModList = {
 	} end,
 	["bleeding you inflict deals damage (%d+)%% faster per frenzy charge"] = function(num) return { mod("BleedFaster", "INC", num, { type = "Multiplier", var = "FrenzyCharge" }) } end,
 	-- Impale and Bleed
-	-- Commented out due to modifier having NO effect on calculations
-	--["(%d+)%% increased effect of impales inflicted by hits that also inflict bleeding"] = function(num) return {
-	--	mod("ImpaleEffectOnBleed", "INC", num, nil, 0, KeywordFlag.Hit)
-	--} end,
-	-- Impale
-	["(%d+)%% increased effect of impales you inflict on non%-impaled enemies"] = function(num) return {
-		mod("ImpaleEffect", "INC", num, { type = "ActorCondition", actor = "enemy", var = "Impaled", neg = true })
+	["(%d+)%% increased effect of impales inflicted by hits that also inflict bleeding"] = function(num) return {
+		mod("ImpaleEffectOnBleed", "INC", num, nil, 0, KeywordFlag.Hit)
 	} end,
 	-- Poison and Bleed
 	["(%d+)%% increased damage with bleeding inflicted on poisoned enemies"] = function(num) return {


### PR DESCRIPTION
Masteries:
20% increased effect of impales you inflict on non-impaled enemies.
60% increased damage with bleeding inflicted on poisoned enemies.