### PR TITLE
Fix Reigning Veteran

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -183,7 +183,6 @@ function calcs.defence(env, actor)
 		local gearArmour = 0
 		local gearEvasion = 0
 		local slotCfg = wipeTable(tempTable1)
-
 		for _, slot in pairs({"Helmet","Body Armour","Gloves","Boots","Weapon 2","Weapon 3"}) do
 			local armourData = actor.itemList[slot] and actor.itemList[slot].armourData
 			if armourData then


### PR DESCRIPTION
This fixes issue #3406 

**Changes**
- Move Block calculations in CalcDefense above armour/evasion


![image](https://user-images.githubusercontent.com/92683202/137976863-7a163c69-2314-4a33-93aa-cf433f577156.png)
