### PR TITLE
Add support for Gladiator Violent Retaliation and Ascendant Gladiator nodes

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2120,7 +2120,11 @@ function calcs.offence(env, actor, activeSkill)
 							end
 							local enemyArmour = calcLib.val(enemyDB, "Armour")
 							local armourReduction = calcs.armourReductionF(enemyArmour, damageTypeHitAvg)
-							resist = m_max(0, enemyDB:Sum("BASE", nil, "PhysicalDamageReduction") + skillModList:Sum("BASE", cfg, "EnemyPhysicalDamageReduction") + armourReduction)
+							if skillModList:Flag(cfg, "IgnoreEnemyPhysicalDamageReduction") then
+								resist = 0
+							else
+								resist = m_max(0, enemyDB:Sum("BASE", nil, "PhysicalDamageReduction") + skillModList:Sum("BASE", cfg, "EnemyPhysicalDamageReduction") + armourReduction)
+							end
 						else
 							if (skillModList:Flag(cfg, "ChaosDamageUsesLowestResistance") and damageType == "Chaos") or 
 							   (skillModList:Flag(cfg, "ElementalDamageUsesLowestResistance") and isElemental[damageType]) then

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1436,9 +1436,9 @@ end
 -- List of special modifiers
 local specialModList = {
 	-- Keystones
-	["modifiers to chance to suppress spell damage instead apply to chance to dodge spell hits at 50%% of their value"] = { 
+	["modifiers to chance to suppress spell damage instead apply to chance to dodge spell hits at 50%% of their value"] = {
 		flag("ConvertSpellSuppressionToSpellDodge"),
-		mod("SpellSuppressionChance", "OVERRIDE", 0, "Acrobatics"), 
+		mod("SpellSuppressionChance", "OVERRIDE", 0, "Acrobatics"),
 	},
 	["dexterity provides no inherent bonus to evasion rating"] = { flag("NoDexBonusToEvasion") },
 	["strength's damage bonus applies to all spell damage as well"] = { flag("IronWill") },
@@ -1458,7 +1458,7 @@ local specialModList = {
 	},
 	["(%d+)%% increased blind effect"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("BlindEffect", "INC", num) }), } end,
 	["%+(%d+)%% chance to block spell damage for each (%d+)%% overcapped chance to block attack damage"] = function(num, _, div) return { mod("SpellBlockChance", "BASE", num, { type = "PerStat", stat = "BlockChanceOverCap", div = tonumber(div) }) } end,
-	["maximum life becomes 1, immune to chaos damage"] = { 
+	["maximum life becomes 1, immune to chaos damage"] = {
 		flag("ChaosInoculation"),
 		mod("ChaosDamageTaken", "MORE", -100)
 	},
@@ -1661,7 +1661,7 @@ local specialModList = {
 		mod("ColdDamageTaken", "INC", -num, { type = "Condition", var = "HitByColdDamageRecently" }),
 		mod("LightningDamageTaken", "INC", -num, { type = "Condition", var = "HitByLightningDamageRecently" }),
 	} end,
-	["gain convergence when you hit a unique enemy, no more than once every %d+ seconds"] = { 
+	["gain convergence when you hit a unique enemy, no more than once every %d+ seconds"] = {
 		flag("Condition:CanGainConvergence"),
 	},
 	["(%d+)%% increased area of effect while you don't have convergence"] = function(num) return { mod("AreaOfEffect", "INC", num, { type = "Condition", neg = true, var = "Convergence" }) } end,
@@ -1742,7 +1742,13 @@ local specialModList = {
 		mod("DoubleDamageChance", "BASE", 100, { type = "SkillName", skillName = "Riposte" }),
 		mod("DoubleDamageChance", "BASE", 100, { type = "SkillName", skillName = "Vengeance" }),
 	},
-	-- Guardian
+	["attack damage is lucky if you[' ]h?a?ve blocked in the past (%d+) seconds"] = function(num) return {
+		flag("LuckyHits", { type = "Condition", var = "BlockedRecently"} )
+	} end,
+	["hits ignore enemy monster physical damage reduction if you[' ]h?a?ve blocked in the past (%d+) seconds"] = function(num) return {
+		flag("IgnoreEnemyPhysicalDamageReduction", { type = "Condition", var = "BlockedRecently"} )
+	} end,
+    -- Guardian
 	["grants armour equal to (%d+)%% of your reserved life to you and nearby allies"] = function(num) return { mod("GrantReservedLifeAsAura", "LIST", { mod = mod("Armour", "BASE", num / 100) }) } end,
 	["grants maximum energy shield equal to (%d+)%% of your reserved mana to you and nearby allies"] = function(num) return { mod("GrantReservedManaAsAura", "LIST", { mod = mod("EnergyShield", "BASE", num / 100) }) } end,
 	["warcries cost no mana"] = { mod("ManaCost", "MORE", -100, nil, 0, KeywordFlag.Warcry) },


### PR DESCRIPTION
### New Mods - Ignore Enemy Monster Physical Damage Reduction if you've blocked in the past 20 seconds, Attack Damage is Lucky if you've Blocked in the past 20 seconds

**Changes**
- Update ModParser to handle new mods, create new var IgnoreEnemyPhysicalDamageReduction, use BlockedRecently conditional
- Update CalcOffense to set Enemy Phys Reduction to 0 if Ignore... is true

**Testing**
- allocate Violent Retaliation
- add bow and split arrow to build
- set enemy phys reduction in config to 50
- check Blocked Recently config
- verify average hit calculation matches the lucky hit vs normal
- verify effect dps mod is 1.00

![image](https://user-images.githubusercontent.com/92683202/138020694-8363f90b-8f8e-4d03-8092-78eb45c2467f.png)
![image](https://user-images.githubusercontent.com/92683202/138020584-f1d7dbfa-5bdb-4803-8c7a-8fa727055831.png)

**Ascendant Gladiator**
![image](https://user-images.githubusercontent.com/92683202/138020873-c3459493-6f7b-4a87-93cc-715271dc2163.png)

