### PR TITLE
fix: DPS sorting of Awakened Gems

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -212,7 +212,7 @@ function GemSelectClass:UpdateSortCache()
 				gemInstance.level = self.skillsTab.defaultGemLevel or gemData.defaultLevel
 			end
 			gemInstance.gemData = gemData
-			if gemData.grantedEffect.plusVersionOf or not gemData.grantedEffect.levels[gemInstance.level] then
+			if (gemData.grantedEffect.plusVersionOf and gemInstance.level > gemData.defaultLevel) or not gemData.grantedEffect.levels[gemInstance.level] then
 				gemInstance.level = gemData.defaultLevel
 			end
 			--Calculate the impact of using this gem


### PR DESCRIPTION
Sometime recently GGPK dumps started to include gem data for up to LEVEL 20 of Awakened Gems. That broke the DPS-based gem recommendation sorting as Awakened Gems are never set above Level 6 in reality (5 + 1 from corruption) but their Level 20 data was used when doing comparison calculations of gem recommendations. This allowed the system to recommend a gem you might have already socketed at a different index as its level 20 counter-part was so much better DPS increase then its level 6.