### PR TITLE
Update Transcendance Keystone to 3.16 value

### DIFF
--- a/src/Data/LegionPassives.lua
+++ b/src/Data/LegionPassives.lua
@@ -4387,7 +4387,7 @@ return {
 			["not"] = false, 
 			["sd"] = {
 				[1] = "Armour applies to Fire, Cold and Lightning Damage taken from Hits instead of Physical Damage", 
-				[2] = "-5% to all maximum Elemental Resistances", 
+				[2] = "-15% to all maximum Elemental Resistances", 
 			}, 
 			["dn"] = "Transcendence", 
 			["isJewelSocket"] = false, 


### PR DESCRIPTION
This file is to be normally automatically updated by importing the GGPK data.

However as keystones are particularly build-defining, the nerf to Transcendance is manually added in this PR.

Patch Notes:
> Transcendence: Keystone Passive Skill now grants -15% to maximum Elemental Resistances (previously -5%).