### PR TITLE
Improve build list loading speed

### DIFF
--- a/src/Modules/BuildList.lua
+++ b/src/Modules/BuildList.lua
@@ -161,14 +161,15 @@ function listMode:BuildList()
 		build.fullFileName = main.buildPath..self.subPath..fileName
 		build.modified = handle:GetFileModifiedTime()
 		build.buildName = fileName:gsub("%.xml$","")
-		local dbXML = common.xml.LoadXMLFile(build.fullFileName)
-		if dbXML and dbXML[1] and dbXML[1].elem == "PathOfBuilding" then
-			for _, node in ipairs(dbXML[1]) do
-				if type(node) == "table" and node.elem == "Build" then
-					build.level = tonumber(node.attrib.level)
-					build.className = node.attrib.className
-					build.ascendClassName = node.attrib.ascendClassName
-				end
+		local fileHnd = io.open(build.fullFileName, "r")
+		if fileHnd then
+			local fileText = fileHnd:read("*a")
+			fileHnd:close()
+			local xml = common.xml.ParseXML(fileText:match("(<Build.->)").."</Build>")
+			if xml and xml[1] then
+				build.level = tonumber(xml[1].attrib.level)
+				build.className = xml[1].attrib.className
+				build.ascendClassName = xml[1].attrib.ascendClassName
 			end
 		end
 		t_insert(self.list, build)


### PR DESCRIPTION
When browsing build folders all builds were loaded and parsed which could cause slowdowns.
I don't think the profiler counts IO time but the code should be about 2 orders of magnitude faster.