### PR TITLE
Added support for increased Melee Damage with Hits at Close Range

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -490,6 +490,7 @@ local modNameList = {
 	["maximum physical attack damage"] = { "MaxPhysicalDamage", tag = { type = "SkillType", skillType = SkillType.Attack } },
 	["physical weapon damage"] = { "PhysicalDamage", flags = ModFlag.Weapon },
 	["physical damage with weapons"] = { "PhysicalDamage", flags = ModFlag.Weapon },
+	["melee damage"] = { "Damage", flags = ModFlag.Melee },
 	["physical melee damage"] = { "PhysicalDamage", flags = ModFlag.Melee },
 	["melee physical damage"] = { "PhysicalDamage", flags = ModFlag.Melee },
 	["projectile damage"] = { "Damage", flags = ModFlag.Projectile },


### PR DESCRIPTION
Added support for `40% increased Melee Damage with Hits at Close Range` mod.
'melee' and 'damage' tags were conflicting, so I added 'melee damage' variant for damage.

![image](https://user-images.githubusercontent.com/5316261/138196466-071a2634-1206-4125-bd9f-1ece76a51aa9.png)
