### PR TITLE
Added support for "All Damage with Maces and Sceptres inflicts Chill"

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2154,6 +2154,7 @@ local specialModList = {
 	["your shocks can increase damage taken by up to a maximum of (%d+)%%"] = function(num) return { mod("ShockMax", "OVERRIDE", num) } end,
 	["your elemental damage can shock"] = { flag("ColdCanShock"), flag("FireCanShock") },
 	["all your damage can freeze"] = { flag("PhysicalCanFreeze"), flag("LightningCanFreeze"), flag("FireCanFreeze"), flag("ChaosCanFreeze") },
+	["all damage with maces and sceptres inflicts chill"] =  { mod("EnemyModifier", "LIST", { mod = flag("Condition:Chilled") }, { type = "Condition", var = "UsingMace" } )},
 	["your cold damage can ignite"] = { flag("ColdCanIgnite") },
 	["your lightning damage can ignite"] = { flag("LightningCanIgnite") },
 	["your fire damage can shock but not ignite"] = { flag("FireCanShock"), flag("FireCannotIgnite") },


### PR DESCRIPTION
**Changes**
 - Update ModParser, Enemy mod flag (condition:chilled) when UsingMace

**Testing**
- sword by itself in main hand with more dmg to chilled enemies global, no total more in Calc
- put mace in off hand, total more shows in Calc
- scepters and 2H work, tested with dmg to chilled enemies mod

![image](https://user-images.githubusercontent.com/92683202/138201385-2230f198-90c4-4324-bd97-30d2d60b0107.png)
