### PR TITLE
Fix replacement of notable passives conquered by Eternal Empire

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -670,6 +670,7 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 					node.mods = {""}
 					node.modList = new("ModList")
 					node.modKey = ""
+					node.reminderText = { }
 				elseif conqueredBy.conqueror.type == "templar" then
 					if isValueInArray(attributes, node.dn) then
 						local legionNode =legionNodes["templar_devotion_node"]
@@ -699,6 +700,7 @@ function PassiveSpecClass:BuildAllDependsAndPaths()
 					node.mods = {""}
 					node.modList = new("ModList")
 					node.modKey = ""
+					node.reminderText = { }
 				end
 				self:ReconnectNodeToClassStart(node)
 			end
@@ -844,7 +846,7 @@ function PassiveSpecClass:ReplaceNode(old, newNode)
 	old.keystoneMod = newNode.keystoneMod
 	old.icon = newNode.icon
 	old.spriteId = newNode.spriteId
-	old.reminderText = newNode.reminderText
+	old.reminderText = newNode.reminderText or { }
 end
 
 ---Reconnects altered timeless jewel to class start, for Pure Talent

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -590,6 +590,7 @@ function TreeTabClass:ModifyNodePopup(selectedNode)
 			selectedNode.mods = {""}
 			selectedNode.modList = new("ModList")
 			selectedNode.modKey = ""
+			selectedNode.reminderText = { }
 		elseif selectedNode.conqueredBy.conqueror.type == "vaal" and selectedNode.type == "Notable" then
 			local legionNode = self.build.spec.tree.legion.nodes["vaal_notable_curse_1"]
 			selectedNode.dn = "Vaal notable node"
@@ -598,6 +599,7 @@ function TreeTabClass:ModifyNodePopup(selectedNode)
 			selectedNode.mods = {""}
 			selectedNode.modList = new("ModList")
 			selectedNode.modKey = ""
+			selectedNode.reminderText = { }
 		elseif selectedNode.conqueredBy.conqueror.type == "eternal" and selectedNode.type == "Notable" then
 			local legionNode = self.build.spec.tree.legion.nodes["eternal_notable_fire_resistance_1"]
 			selectedNode.dn = "Eternal Empire notable node"
@@ -606,6 +608,7 @@ function TreeTabClass:ModifyNodePopup(selectedNode)
 			selectedNode.mods = {""}
 			selectedNode.modList = new("ModList")
 			selectedNode.modKey = ""
+			selectedNode.reminderText = { }
 		else
 			self.build.spec:ReplaceNode(selectedNode, self.build.spec.tree.nodes[selectedNode.id])
 			if selectedNode.conqueredBy.conqueror.type == "templar" then


### PR DESCRIPTION
- Transform notable passives within the radius into blank ones when reset, or if no mods were selected for those.