### PR TITLE
Fix Arcane Cloak when 100% reduced Reservation Efficiency

### DIFF
--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -220,8 +220,12 @@ end
 function ModStoreClass:GetStat(stat, cfg)
 	-- if ReservationEfficiency is -100, ManaUnreserved is nan which breaks everything if Arcane Cloak is enabled
 	if stat == "ManaUnreserved" and self.actor.output[stat] ~= self.actor.output[stat] then
-		-- 0% reserved means total mana
+		-- 0% reserved = total mana
 		return self.actor.output["Mana"]
+	elseif stat == "ManaUnreserved" and self.actor.output[stat] < 0 then
+		-- This reverse engineers how much mana is unreserved before efficiency for accurate Arcane Cloak calcs
+		local reservedPercentBeforeEfficiency = (math.abs(self.actor.output["ManaUnreservedPercent"]) + 100) * ((100 + self.actor["ManaEfficiency"]) / 100)
+		return self.actor.output["Mana"] * (math.ceil(reservedPercentBeforeEfficiency) / 100);
 	else
 		return (self.actor.output and self.actor.output[stat]) or (cfg and cfg.skillStats and cfg.skillStats[stat]) or 0
 	end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1393,6 +1393,8 @@ function calcs.perform(env, avoidCache)
 				values.more = skillModList:More(skillCfg, name.."Reserved", "Reserved")
 				values.inc = skillModList:Sum("INC", skillCfg, name.."Reserved", "Reserved")
 				values.efficiency = skillModList:Sum("INC", skillCfg, name.."ReservationEfficiency", "ReservationEfficiency")
+				-- used for Arcane Cloak calculations in ModStore.GetStat
+				env.player[name.."Efficiency"] = values.efficiency
 				if activeSkill.skillData[name.."ReservationFlatForced"] then
 					values.reservedFlat = activeSkill.skillData[name.."ReservationFlatForced"]
 				else


### PR DESCRIPTION
### Fixes #3519 

<strike>Note: I'd like to test this some more tomorrow. If any reviewers would like to come through and check things that would be much appreciated. I figured this out at a late hour and I'm tired so I could be very off somewhere. If it's acceptable, I wouldn't be opposed to waking up to a merge. :) </strike>
Update below

### Description of the problem being solved:
When reservation efficiency is 100% reduced and you have Arcane Cloak enabled, any damaging skill bugs out, displaying "nan" in many places. This PR solves that by checking if ManaUnreserved is nan during PerStat calculations (Arcane Cloak uses PerStat) and sets it to total mana instead, which is what 0% reserved/100% unreserved mana would be.

### Steps taken to verify a working solution:
- Loaded issue build, compared with dev code vs fix code to see nan vs actual numbers for Crackling Lance
- Calculations tab shows added lightning from Arcane Cloak, scaling from total mana
- I also removed both items and just added a custom mod of 100% reduced reservation efficiency and it works as well, so it is item agnostic

### Link to a build that showcases this PR:
<pre>https://pastebin.com/XwA85hzT</pre>

### Before screenshot:
![image](https://user-images.githubusercontent.com/92683202/138396879-363d7120-d22e-4751-aa65-db90284515e7.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/92683202/138396766-e5e2a403-721f-4941-ba2b-82cc3640ca92.png)
 

### Notes

If I add this custom mod to current dev code it shows the same DPS, which I think helps validate the fix.

![image](https://user-images.githubusercontent.com/92683202/138396990-7830e007-0910-48ea-a50e-249a675429c6.png)

### Update
As you approach 100% reduced eff, Arcane Cloak was adding negative damage, making AverageHit and TotalDPS negative values. I've updated the PR to handle when Unreserved Mana Percent is negative and calculate Arcane Cloak correctly (while not modifying reservation values). So, the DPS reflects accurately, but it's still impossible due to the auras/reservations taking over 100%
- Before

![image](https://user-images.githubusercontent.com/92683202/138464043-06ee5476-6f45-4c84-a54e-323830f01451.png)

 - After 

![image](https://user-images.githubusercontent.com/92683202/138464225-142cd9c8-9496-48c1-9e5d-19ea49971959.png)
