### PR TITLE
Rebuild dependencies and paths for all nodes upon tree reset

### DIFF
--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -94,6 +94,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 	self.controls.reset = new("ButtonControl", {"LEFT",self.controls.compareCheck,"RIGHT"}, 8, 0, 60, 20, "Reset", function()
 		main:OpenConfirmPopup("Reset Tree", "Are you sure you want to reset your passive tree?", "Reset", function()
 			self.build.spec:ResetNodes()
+			self.build.spec:BuildAllDependsAndPaths()
 			self.build.spec:AddUndoState()
 			self.build.buildFlag = true
 		end)


### PR DESCRIPTION
Fixes situations, such as:
1. Selected Mastery mod descriptions are not being not reset
2. Passives transformed by Timeless Jewels are not being reset
3. Selections on tree are not being reset

Closes #3484 