### PR TITLE
Fix importing passive tree data from profile

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -5,6 +5,8 @@
 --
 local ipairs = ipairs
 local t_insert = table.insert
+local b_rshift = bit.rshift
+local band = bit.band
 
 local realmList = {
 	{ label = "PC", id = "PC", realmCode = "pc", hostName = "https://www.pathofexile.com/", profileURL = "account/view-profile/" },
@@ -468,8 +470,8 @@ function ImportTabClass:ImportPassiveTreeAndJewels(json, charData)
 			if type(value) ~= "string" then
 				break
 			end
-			mastery = bit.band(tonumber(value), 65535)
-			effect = bit.rshift(tonumber(value), 16)
+			mastery = band(tonumber(value), 65535)
+			effect = b_rshift(tonumber(value), 16)
 			t_insert(charPassiveData.mastery_effects, mastery, effect)
 		end
 	end

--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -169,7 +169,10 @@ function PassiveSpecClass:Save(xml)
 	end
 	local masterySelections = { }
 	for mastery, effect in pairs(self.masterySelections) do
-		t_insert(masterySelections, "{"..mastery..","..effect.."}")
+		-- only save pob codes to xml (only profile import should have leftover effects to clean up)
+		if (tonumber(effect) < 65536) then
+			t_insert(masterySelections, "{"..mastery..","..effect.."}")
+		end
 	end
 	local editedNodes = {
 		elem = "EditedNodes"


### PR DESCRIPTION
### Fixes #3587

### Description of the problem being solved:
When importing passive tree data from GGG, the masteryEffects do not correspond to node ids as PoB expects. This PR transforms them based on https://www.pathofexile.com/developer/docs/reference

### Steps taken to verify a working solution:
- Imported my own 3.16 character to see mastery effects set
- Imported 3.15 character to make sure it doesn't break that import
- Verified transformed import saves and can be loaded as xml

### Link to a build that showcases this PR:
- Import any 3.16 character from a profile
### Before screenshot:
![image](https://user-images.githubusercontent.com/92683202/138727222-3e4cbfc5-7239-4029-b375-dbdaf3e4358c.png)

### After screenshot: 
![image](https://user-images.githubusercontent.com/92683202/138727351-ef355539-e366-4c88-9022-e4a48b069ae0.png)
