### PR TITLE
Issue 3585: Fix Mana Efficiency rounding

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1399,13 +1399,13 @@ function calcs.perform(env, avoidCache)
 					values.reservedFlat = activeSkill.skillData[name.."ReservationFlatForced"]
 				else
 					local baseFlatVal = m_floor(values.baseFlat * mult)
-					values.reservedFlat = m_max(round((baseFlatVal - m_modf(baseFlatVal * -1 * ((100 + values.inc) * values.more - 100) / 100)) / (1 + values.efficiency / 100), 2), 0)
+					values.reservedFlat = m_max(round((baseFlatVal - m_modf(baseFlatVal * -m_floor((100 + values.inc) * values.more - 100) / 100)) / (1 + values.efficiency / 100), 2), 0)
 				end
 				if activeSkill.skillData[name.."ReservationPercentForced"] then
 					values.reservedPercent = activeSkill.skillData[name.."ReservationPercentForced"]
 				else
 					local basePercentVal = values.basePercent * mult
-					values.reservedPercent = m_max(round((basePercentVal - m_modf(basePercentVal * -1 * ((100 + values.inc) * values.more - 100)) / 100) / (1 + values.efficiency / 100), 2), 0)
+					values.reservedPercent = m_max(round((basePercentVal - m_modf(basePercentVal * -m_floor((100 + values.inc) * values.more - 100)) / 100) / (1 + values.efficiency / 100), 2), 0)
 				end
 				if activeSkill.activeMineCount then
 					values.reservedFlat = values.reservedFlat * activeSkill.activeMineCount


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/3585

Update efficiency calculation to round to two significant figures as per in game reservation.

PoB of character that demonstrates fix: https://pastebin.com/4hLR9bC9
![image](https://user-images.githubusercontent.com/9113318/138751666-355cc986-0280-4d30-b8ec-e3e0396bdffa.png)

![image](https://user-images.githubusercontent.com/9113318/138751388-8bdddb62-b514-4af3-906a-644fa88cdcfb.png)

![image](https://user-images.githubusercontent.com/9113318/138751228-aa45985b-0e07-45fe-b130-e27a34eeef16.png)

![image](https://user-images.githubusercontent.com/9113318/138751590-eada93bd-4faf-4e32-8f23-64502c970bbe.png)

![image](https://user-images.githubusercontent.com/9113318/138751505-83076ff6-9852-4f9a-b645-c7d7f2b4a4e8.png)

![image](https://user-images.githubusercontent.com/9113318/138751555-488af76e-58f0-4b56-afe6-4450b29ec503.png)

![image](https://user-images.githubusercontent.com/9113318/138751454-2c3aba1a-c2cd-44c6-82b6-0fe58a933973.png)