### PR TITLE
Add support for "Enemies Ignited or Chilled by you have -5% to Elemental Resistances"

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2334,6 +2334,9 @@ local specialModList = {
 		mod("EnemyModifier", "LIST", { mod = mod("ElementalResist", "BASE", num) }),
 		mod("EnemyModifier", "LIST", { mod = mod("ChaosResist", "BASE", num) }),
 	} end,
+	["enemies ignited or chilled by you have (%-%d+)%% to elemental resistances"] = function(num) return {
+		mod("EnemyModifier", "LIST", { mod = mod("ElementalResist", "BASE", num )}, { type = "ActorCondition", actor = "enemy", varList = { "Ignited", "Chilled" } })
+	} end,
 	["your hits inflict decay, dealing (%d+) chaos damage per second for %d+ seconds"] = function(num) return { mod("SkillData", "LIST", { key = "decay", value = num, merge = "MAX" }) } end,
 	["temporal chains has (%d+)%% reduced effect on you"] = function(num) return { mod("CurseEffectOnSelf", "INC", -num, { type = "SkillName", skillName = "Temporal Chains" }) } end,
 	["unaffected by temporal chains"] = { mod("CurseEffectOnSelf", "MORE", -100, { type = "SkillName", skillName = "Temporal Chains" }) },


### PR DESCRIPTION
Supports #3602
### Description of the problem being solved:
- Add support for snowforged notable

### Steps taken to verify a working solution:
- Checked effective dps in Calc when enemy is chilled, ignited, or both

### Link to a build that showcases this PR:
<pre>https://pastebin.com/845sVeU9</pre>
### Before screenshot:
![image](https://user-images.githubusercontent.com/92683202/138959891-642fd981-5ffd-46e6-b000-0498ab1a4ff8.png)

### After screenshot: 
![image](https://user-images.githubusercontent.com/92683202/138959981-c18faef4-8c5a-4911-8a87-cd62971441e2.png)
