### PR TITLE
Fix Awakened Cast on Crit not applying cooldown recovery

### DIFF
--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -437,6 +437,9 @@ return {
 ["base_cooldown_speed_+%"] = {
 	mod("CooldownRecovery", "INC", nil),
 },
+["base_spell_cooldown_speed_+%"] = {
+	mod("CooldownRecovery", "INC", nil),
+},
 ["additional_weapon_base_attack_time_ms"] = {
 	mod("Speed", "BASE", nil, ModFlag.Attack),
 	div = 1000,


### PR DESCRIPTION
The stat was renamed in 3.16, this updates the mapping for it