### PR TITLE
Add support for Nightblade Dagger Mastery

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3050,6 +3050,7 @@ local specialModList = {
 	["(%d+)%% chance to deal double damage with attacks if attack time is longer than 1 second"] = function(num) return { 
 		mod("DoubleDamageChance", "BASE", num, 0, 0, { type = "Condition", var = "OneSecondAttackTime" })
 	} end,
+	["elusive also grants %+(%d+)%% to critical strike multiplier for skills supported by nightblade"] = function(num) return { mod("NightbladeElusiveCritMultiplier", "BASE", num) } end,
 	-- Pantheon: Soul of Tukohama support
 	["while stationary, gain ([%d%.]+)%% of life regenerated per second every second, up to a maximum of (%d+)%%"] = function(num, _, limit) return {
 		flag("Condition:Stationary"),


### PR DESCRIPTION
### Description of the problem being solved:

This adds support for the "Elusive also grants +40% to Critical Strike Multiplier for Skills Supported by Nightblade" mod available from the Dagger Mastery nodes. This added multiplier is scalable by elusive effect, as confirmed in-game.

### Steps taken to verify a working solution:
1. Allocate dagger cluster notable
2. Confirm mod is parsed, effect is granted

Also confirmed in-game that this effect scales with elusive effect like the base Nightblade value. On a character with a base 201% critical strike multiplier. a total of 40% increased Elusive effect, and a level 1 Nightblade, the critical strike multiplier value for the skill on the character sheet goes to 397% on crit. This matches the 196% (140% * 1.4) we would expect to see if it scaled, as opposed to the 180% (100% * 1.4 + 40%) if it didn't.

![image](https://user-images.githubusercontent.com/45536/139158447-ae7f2b28-4dfb-4b6f-a30e-6cee070a06b9.png)

![image](https://user-images.githubusercontent.com/45536/139158423-6acdb5be-65c5-4672-ae5b-5b5a01d52132.png)

### Link to a build that showcases this PR:
```
eNq9Wltz4joSfp78ChdV-5YAtsFAKjmnCCEZtkLCQub2NCVsATqRJcaSYZit_e_bkg04CSSy5uzOVCW-fH1vtbrlXPz5M6bOCieCcHZZcav1ioNZyCPC5peVT483Z-3Kn3-cXIyQXDzMrlJC1Zs_Tj5c6GuH4hWmQFdxJErmWH7ecvK_A6clYnKBORuiv3hyy6PLyj1nuOJMEYuI3N6FFAlxj2J8WZksUMTXFQeJELOot3_RFQKuCas4MSJswsMnLG8Tni617BXB6yGPADcYjh7GjwXJhBUlg-IfLkYUbXAykUg6An4Ac7AfzfE1iuEncEM0BVatTjXwPb_hum3XdRuV2mHiyRLjaEfkVpv_P-Aowf3ZDIeSrHAvIbK3QCzcG9BpVhvtY7Q2-GFKJVlSgpMdjV9tHlXv4ysJbr1-DPzIJaLXo8ke63aqjUa76bqtlhu0_jd0XO7ojmr2hcjFFYWQWEhRtIM5IxJbEo84EZz9hn1F0qMm9ng8JczKwi1pdzUvS9pNMHqYZRk8RhFJxY6D5x0jGiKGelzs43Y0Y-_IDD9DHjW_PzHDjaE8mCGVliOcQBGTZgRK2VIEE7lfhN7R4jTGP4rAo9yu8c8dqOm_wa0I7Bx1_YDtLfDeYlcEBu3j2q24hF3FzI37Av5WzQ7PFXbAQjOmn1iCBU5WhcJ8nP1zgjysJkVQEY7xHBtaeodxuLiF_XCMJDZLyn2U3Tedo7BGzlHAA845zv45QQnnKMIXzql23gKXdM8XlEQGtYLhZL6ZLAimBmjtyyKJkU-LBIbpUCQpaXd_hURxcbmtt63J4GbJgWHfBIIIv2gE_kaKUcL_Ui0QLUfWTWKeJoYRzMBGJo8WG0FC2Hp1MznGURqala5dJzfkKxzDmtBtIHS1hU6wcXRVXVFoiU1tB86UlqLoSonCp2sezXEpIeUpJulyCcVBpZgp3Q1JwNGCFLbNs8AA_QBtfw8tTdojtQ5NBezRxgLuyHwhGQxW5lJekJjbskBclDBmDzcWcZNSatR2Tp7Ic6REU4rPnfpP18cIhdHxVcbXoMxCjZzCYE0W0EO0b2COdiY3CWa_Nsb8n8GNBPRZlCYqu41lvKR4LeaipkdydTWIlzyR-mEP0VBolgO2TKXD9DgdExF-n6azmZqaKyAi0fN-_-am33scfO7nWhRJhArWd5bGUzX-Zb_V8J0hJ1iXOSfklKKlwDBwzxAVwJtEeaAnUNpDaYSHyTEfxk3QsHGHCQEnmoDVyGeksh7CTZBqMjYCQlQQxeYOe9wsscoAYeqzvGCaoPVAa4TMJlAzA_WkaxYGHKKNEXLXzRih-xR3CVXbp5nXhrAQsp3XDA8bYUKmqTTMNj2PGOmhenMjA4v9p-HqMAPmHZGREnnLaILN9xqzpISWxDhs13iGId0Nl70uJ4_oCbO8WG4L44Vea8IRUDFvcSyuNrAj3Sj3vjgXeQaAvSpJgXeEZyil6vm_UkSJ3KgSXnh6l52PevBQLPhadTcZG7W4BTj97i5706Uy56BkbHXPLFMK6nPPrm4Q9b1WXx9-EhbSNIJRNt93d3ZTNFWyK85cHZT2eMpgH2GEqhNetdFGWyNesFZcleAPF6BKjr2lfIqot-e9t6sIcLcs9W4x0OFHK7j_kdk20EtfOwfUwrG6H2KJIiRRbSDB8poyv6b1gKvn1Nq3L3QPM7PAD2qbUt36TqbWYUiYPo-epHHMIZQjqJESiTjLmoMmahcZG5iHdJSyUKZqG_2C0VI1_GVN3qXGvWrtphRF5S0vkGarIvOkTvgsz9XlY4Kxg7KAazI3TzS4KR69K1VdlR5C4mSTl0mVUAy6Brjw24F_2vGbzdNGs-23TxuNoO3DtdfyTn3P81qnzbbndU4bddc9DRrNeue0HTTAEgkKFL4UuEH-EUAJDPLc60ewl0T3SlIeqk_jO33xYSHlUpzXauv1urpEcsFn-CfMf9WQx7Wl-kywwmc6PmdKUK0L_67m36563fbXfw7SX9fJ9bcZHo5-fF91BqF6e3mpBdS2Ei6yDwxi60Pwi3ahcpy6uOewAah36uH2Rrv1M8FrR2DoSBYTCf2RyKKKI2e6qTi_OI-_qfM6vxq4gd9q-626384KwEeM5BAtdytMYfPqEeTFA3qBawJRSHTd2-aBAn6FJt71fa_abHlNr97seEFW5nSC5bFW1xOcpUwqMBRMzqIsW_XjQslRUF0380owRtDkbM6d-4fxsHt3cquC5UxgKT2d5FXr3PHqJ7nbzp3bM_h_Ag0PJSFRD9yTf0s0F-fQqEk1Hv_Hr_9DVa4EIyjVTra4nF7-1gHfkSfsZA2NjoHSKEtSyrctaaa7o2qgzBbWth3NTX3DzKJ1h3hO1mjpdKcbIZQ62i6nuRdU39aPA6QvyTwzsldWPENdcS6FpUKHbHlHqStMZUmSG0iKJ8c3Usk7pJJv514zJ3h_E1nDTsnATlpg7033nQAfyqd3IvARQ2ctywo6kEmBjZx30g9KyEoN0uUZ-_aryLWR17DLBdcu8xrvh8fEsWXZHkovS8ON6k7TQh-LGui_JybaONkgVTJ8h71slV9NGyKjJWkSCCs7m9Zu9SziHtitJN8uff3yWdawL_sWOe1aO983SYiGCchC7d9ofgwjaR-FwCIr7cPwG-liWpIVreGqMYdaeG4MA7ZZJ1C6UBx1r2W5MI-njTm-gZ9c-zA0rL3VtLHGZL3YJ_k7KnXjlB7Y27KZE0ZGPfrrQVp_UOFsRuavPo-ojyl9mqqzh4oz5ZxixPIJ_fW3FMxwvBmIKy7E_uPLhCSpOAAOUyF5PORRAet6fqM4Px8enA8x4-ovLwln-lgdeBkom1n1_EvRsPt1MPw03J6l5j65qL38O9H_At5YO38=
```

### Before screenshot:
![image](https://user-images.githubusercontent.com/45536/139157009-2ed3038e-fa71-4560-b978-0bd88e740efc.png)

### After screenshot:

**Level 1 Nightblade, no other Elusive Effect:**
![image](https://user-images.githubusercontent.com/45536/139156791-ce84f83e-033d-4bd0-8fd3-212085dcba4d.png)

**Level 20 Nightblade, no other Elusive Effect:**
![image](https://user-images.githubusercontent.com/45536/139156915-1b1a0815-83db-4427-9149-dc61ad98e4e9.png)
