### PR TITLE
Fix url encoding during save after profile import

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -169,10 +169,7 @@ function PassiveSpecClass:Save(xml)
 	end
 	local masterySelections = { }
 	for mastery, effect in pairs(self.masterySelections) do
-		-- only save pob codes to xml (only profile import should have leftover effects to clean up)
-		if (tonumber(effect) < 65536) then
-			t_insert(masterySelections, "{"..mastery..","..effect.."}")
-		end
+		t_insert(masterySelections, "{"..mastery..","..effect.."}")
 	end
 	local editedNodes = {
 		elem = "EditedNodes"
@@ -253,7 +250,10 @@ function PassiveSpecClass:ImportFromNodeList(classId, ascendClassId, hashList, m
 	end
 	wipeTable(self.masterySelections)
 	for mastery, effect in pairs(masteryEffects) do
-		self.masterySelections[mastery] = effect
+		-- ignore ggg codes from profile import
+		if (tonumber(effect) < 65536) then
+			self.masterySelections[mastery] = effect
+		end
 	end
 	self:SelectAscendClass(ascendClassId)
 end
@@ -351,13 +351,11 @@ function PassiveSpecClass:EncodeURL(prefix)
 			nodeCount = nodeCount + 1
 			if self.masterySelections[node.id] then
 				local effect_id = self.masterySelections[node.id]
-				if (tonumber(effect_id) < 65536) then
-					t_insert(masteryNodeIds, m_floor(effect_id / 256))
-					t_insert(masteryNodeIds, effect_id % 256)
-					t_insert(masteryNodeIds, m_floor(node.id / 256))
-					t_insert(masteryNodeIds, node.id % 256)
-					masteryCount = masteryCount + 1
-				end
+				t_insert(masteryNodeIds, m_floor(effect_id / 256))
+				t_insert(masteryNodeIds, effect_id % 256)
+				t_insert(masteryNodeIds, m_floor(node.id / 256))
+				t_insert(masteryNodeIds, node.id % 256)
+				masteryCount = masteryCount + 1
 			end
 		elseif id >= 65536 then
 			local clusterId = id - 65536


### PR DESCRIPTION
### Fixes #3645

### Description of the problem being solved:
- When we profile import, there are ggg codes on self.masterySelections until the build is saved and then loaded again. We check this table when saving the Spec tag to make sure we don't save these codes onto the xml, but we need to check while encoding the URL as well within the same first save-after-import. I'm moving this check higher up the chain so it affects self.masterySelections at the root. 

### Steps taken to verify a working solution:
- Import profile and save, no error
- Validate build xml has URL and the PoE site tree has masteries selected as before
- Load newly saved profile and verify codes are definitely not showing up in encodeURL() (more of a test of the Spec saving piece)

### Link to a build that showcases this PR:
<pre>https://pastebin.com/jCBthbBw</pre>
- Any profile import
### Before screenshot:
![image](https://user-images.githubusercontent.com/92683202/139294276-b1da4101-8bc5-44bb-962f-94a6a00ba8d9.png)

### After screenshot:
- No error