### PR TITLE
Death Wish (Maw of Mischief) rework

### DIFF
--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -24,6 +24,13 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 	self.varControls = { }
 	
 	self:BuildModList()
+	
+	local function checkRunOnceFlag(varData)
+		if varData.runOnce then
+			varData.runOnce = nil
+			varData.apply(varData.var, modList, enemyModList, build)
+		end
+	end
 
 	local lastSection
 	for _, varData in ipairs(varList) do
@@ -75,8 +82,11 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 			else 
 				control = new("Control", {"TOPLEFT",lastSection,"TOPLEFT"}, 234, 0, 16, 16)
 			end
-			if varData.ifNode then
+			if varData.alwaysHide then
+				control.shown = false
+			elseif varData.ifNode then
 				control.shown = function()
+					checkRunOnceFlag(varData)
 					if self.build.spec.allocNodes[varData.ifNode] then
 						return true
 					end
@@ -90,11 +100,13 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 				end
 			elseif varData.ifOption then
 				control.shown = function()
+					checkRunOnceFlag(varData)
 					return self.input[varData.ifOption]
 				end
 				control.tooltipText = varData.tooltip
 			elseif varData.ifCond or varData.ifMinionCond or varData.ifEnemyCond then
 				control.shown = function()
+					checkRunOnceFlag(varData)
 					local mainEnv = self.build.calcsTab.mainEnv
 					if self.input[varData.var] then
 						if varData.implyCondList then
@@ -139,6 +151,7 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 				end
 			elseif varData.ifMult or varData.ifEnemyMult then
 				control.shown = function()
+					checkRunOnceFlag(varData)
 					local mainEnv = self.build.calcsTab.mainEnv
 					if self.input[varData.var] then
 						if varData.implyCondList then
@@ -173,6 +186,7 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 				end
 			elseif varData.ifFlag then
 				control.shown = function()
+					checkRunOnceFlag(varData)
 					local skillModList = self.build.calcsTab.mainEnv.player.mainSkill.skillModList
 					local skillFlags = self.build.calcsTab.mainEnv.player.mainSkill.skillFlags
 					-- Check both the skill mods for flags and flags that are set via calcPerform
@@ -181,6 +195,7 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 				control.tooltipText = varData.tooltip
 			elseif varData.ifSkill or varData.ifSkillList then
 				control.shown = function()
+					checkRunOnceFlag(varData)
 					if varData.ifSkillList then
 						for _, skillName in ipairs(varData.ifSkillList) do
 							if self.build.calcsTab.mainEnv.skillsUsed[skillName] then
@@ -194,6 +209,7 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 				control.tooltipText = varData.tooltip
 			elseif varData.ifSkillFlag or varData.ifSkillFlagList then
 				control.shown = function()
+					checkRunOnceFlag(varData)
 					if varData.ifSkillFlagList then
 						for _, skillFlag in ipairs(varData.ifSkillFlagList) do
 							for _, activeSkill in ipairs(self.build.calcsTab.mainEnv.player.activeSkillList) do
@@ -203,7 +219,6 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 							end
 						end
 					else
-						-- print(ipairs(self.build.calcsTab.mainEnv.skillsUsed))
 						for _, activeSkill in ipairs(self.build.calcsTab.mainEnv.player.activeSkillList) do
 							if activeSkill.skillFlags[varData.ifSkillFlag] then
 								return true
@@ -269,6 +284,13 @@ function ConfigTabClass:GetDefaultState(var)
 end
 
 function ConfigTabClass:Save(xml)
+	-- Store the most recent cached skill option minion life value.
+	local skillOptionMinionName = self.varControls["skillOptionMinionName"]
+	skillOptionMinionName = skillOptionMinionName.list[skillOptionMinionName.selIndex]
+	if type(skillOptionMinionName) == "table" then
+		skillOptionMinionName = skillOptionMinionName.label
+	end
+	self.varControls["skillOptionMinionLife"]:SetText(GlobalCache.cachedMinionLife[skillOptionMinionName] or 0, true)
 	for k, v in pairs(self.input) do
 		if v ~= self:GetDefaultState(k) then
 			local child = { elem = "Input", attrib = {name = k} }

--- a/src/Data/Global.lua
+++ b/src/Data/Global.lua
@@ -281,4 +281,6 @@ GlobalCache = {
 	dontUseCache = nil,
 	useFullDPS = false,
 	numActiveSkillInFullDPS = 0,
+	cachedMinionList = { },
+	cachedMinionLife = { },
 }

--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -710,9 +710,10 @@ skills["DeathWish"] = {
 	fromItem = true,
 	parts = {
 		{
-			name = "Channelling",
+			name = "Spell Explosion",
 			spell = true,
-			cast = false,
+			cast = true,
+			stages = true,
 		},
 		{
 			name = "Minion Explosion",
@@ -721,19 +722,26 @@ skills["DeathWish"] = {
 			stages = true,
 		},
 	},
-	preDamageFunc = function(activeSkill, output)
+	preDamageFunc = function(activeSkill, output, breakdown, env)
 		if activeSkill.skillPart == 2 then
-			local skillData = activeSkill.skillData
-			skillData.FireBonusMin = output.Life * skillData.selfFireExplosionLifeMultiplier
-			skillData.FireBonusMax = output.Life * skillData.selfFireExplosionLifeMultiplier
+			local skillData = activeSkill.skillData			
+			local skillOptionMinionName = env.build.configTab.varControls["skillOptionMinionName"]
+			skillOptionMinionName = skillOptionMinionName.list[skillOptionMinionName.selIndex]
+			if type(skillOptionMinionName) == "table" then
+				skillOptionMinionName = skillOptionMinionName.label
+			end
+			env.build.configTab.varControls["skillOptionMinionLife"]:SelectAll()
+			local minionLife = GlobalCache.cachedMinionLife[skillOptionMinionName] or tonumber(env.build.configTab.varControls["skillOptionMinionLife"]:GetSelText()) or 0
+			skillData.FireMin = minionLife * skillData.selfFireExplosionLifeMultiplier
+			skillData.FireMax = minionLife * skillData.selfFireExplosionLifeMultiplier
 		end
 	end,
 	statMap = {
 		["spell_minimum_base_fire_damage"] = {
-			skill("FireMin", nil, { type = "SkillPart", skillPart = 2 }),
+			skill("FireMin", nil, { type = "SkillPart", skillPart = 1 }),
 		},
 		["spell_maximum_base_fire_damage"] = {
-			skill("FireMax", nil, { type = "SkillPart", skillPart = 2 }),
+			skill("FireMax", nil, { type = "SkillPart", skillPart = 1 }),
 		},
 		["death_wish_attack_speed_+%"] = {
 			mod("Speed", "INC", nil, ModFlag.Attack, 0, { type = "GlobalEffect", effectType = "Buff" }),
@@ -745,10 +753,10 @@ skills["DeathWish"] = {
 			mod("MovementSpeed", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
 		},
 		["death_wish_hit_and_ailment_damage_+%_final_per_stage"] = {
-			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "Multiplier", var = "DeathWishStage" }, { type = "SkillPart", skillPart = 2 }),
+			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "Multiplier", var = "DeathWishStage" }),
 		},
 		["death_wish_max_stages"] = {
-			mod("Multiplier:DeathWishMaxStages", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
+			mod("Multiplier:DeathWishMaxStages", "BASE", nil),
 		},
 	},
 	baseFlags = {
@@ -756,8 +764,8 @@ skills["DeathWish"] = {
 		area = true,
 	},
 	baseMods = {
-		skill("explodeCorpse", true, { type = "SkillPart", skillPart = 2 }),
-		skill("radius", 10, { type = "SkillPart", skillPart = 2 }),
+		skill("showAverage", true),
+		skill("radius", 10),
 		skill("buffMinions", true),
 		skill("buffNotPlayer", true),
 	},

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -218,9 +218,10 @@ local skills, mod, flag, skill = ...
 	fromItem = true,
 	parts = {
 		{
-			name = "Channelling",
+			name = "Spell Explosion",
 			spell = true,
-			cast = false,
+			cast = true,
+			stages = true,
 		},
 		{
 			name = "Minion Explosion",
@@ -229,19 +230,26 @@ local skills, mod, flag, skill = ...
 			stages = true,
 		},
 	},
-	preDamageFunc = function(activeSkill, output)
+	preDamageFunc = function(activeSkill, output, breakdown, env)
 		if activeSkill.skillPart == 2 then
-			local skillData = activeSkill.skillData
-			skillData.FireBonusMin = output.Life * skillData.selfFireExplosionLifeMultiplier
-			skillData.FireBonusMax = output.Life * skillData.selfFireExplosionLifeMultiplier
+			local skillData = activeSkill.skillData			
+			local skillOptionMinionName = env.build.configTab.varControls["skillOptionMinionName"]
+			skillOptionMinionName = skillOptionMinionName.list[skillOptionMinionName.selIndex]
+			if type(skillOptionMinionName) == "table" then
+				skillOptionMinionName = skillOptionMinionName.label
+			end
+			env.build.configTab.varControls["skillOptionMinionLife"]:SelectAll()
+			local minionLife = GlobalCache.cachedMinionLife[skillOptionMinionName] or tonumber(env.build.configTab.varControls["skillOptionMinionLife"]:GetSelText()) or 0
+			skillData.FireMin = minionLife * skillData.selfFireExplosionLifeMultiplier
+			skillData.FireMax = minionLife * skillData.selfFireExplosionLifeMultiplier
 		end
 	end,
 	statMap = {
 		["spell_minimum_base_fire_damage"] = {
-			skill("FireMin", nil, { type = "SkillPart", skillPart = 2 }),
+			skill("FireMin", nil, { type = "SkillPart", skillPart = 1 }),
 		},
 		["spell_maximum_base_fire_damage"] = {
-			skill("FireMax", nil, { type = "SkillPart", skillPart = 2 }),
+			skill("FireMax", nil, { type = "SkillPart", skillPart = 1 }),
 		},
 		["death_wish_attack_speed_+%"] = {
 			mod("Speed", "INC", nil, ModFlag.Attack, 0, { type = "GlobalEffect", effectType = "Buff" }),
@@ -253,16 +261,16 @@ local skills, mod, flag, skill = ...
 			mod("MovementSpeed", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
 		},
 		["death_wish_hit_and_ailment_damage_+%_final_per_stage"] = {
-			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "Multiplier", var = "DeathWishStage" }, { type = "SkillPart", skillPart = 2 }),
+			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "Multiplier", var = "DeathWishStage" }),
 		},
 		["death_wish_max_stages"] = {
-			mod("Multiplier:DeathWishMaxStages", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
+			mod("Multiplier:DeathWishMaxStages", "BASE", nil),
 		},
 	},
-	#baseMod skill("explodeCorpse", true, { type = "SkillPart", skillPart = 2 })
-	#baseMod skill("radius", 10, { type = "SkillPart", skillPart = 2 })
-	#baseMod skill("buffMinions", true)
-	#baseMod skill("buffNotPlayer", true)
+#baseMod skill("showAverage", true)
+#baseMod skill("radius", 10)
+#baseMod skill("buffMinions", true)
+#baseMod skill("buffNotPlayer", true)
 #mods
 
 #skill Melee Default Attack
@@ -311,9 +319,9 @@ local skills, mod, flag, skill = ...
 			name = "Convert to lightning",
 		},
 	},
-	#baseMod mod("SkillPhysicalDamageConvertToFire", "BASE", 100, 0, 0, { type = "SkillPart", skillPart = 1 })
-	#baseMod mod("SkillPhysicalDamageConvertToCold", "BASE", 100, 0, 0, { type = "SkillPart", skillPart = 2 })
-	#baseMod mod("SkillPhysicalDamageConvertToLightning", "BASE", 100, 0, 0, { type = "SkillPart", skillPart = 3 })
+#baseMod mod("SkillPhysicalDamageConvertToFire", "BASE", 100, 0, 0, { type = "SkillPart", skillPart = 1 })
+#baseMod mod("SkillPhysicalDamageConvertToCold", "BASE", 100, 0, 0, { type = "SkillPart", skillPart = 2 })
+#baseMod mod("SkillPhysicalDamageConvertToLightning", "BASE", 100, 0, 0, { type = "SkillPart", skillPart = 3 })
 #mods
 
 #skill EmbraceMadness

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -383,7 +383,7 @@ function calcs.offence(env, actor, activeSkill)
 	local function runSkillFunc(name)
 		local func = activeSkill.activeEffect.grantedEffect[name]
 		if func then
-			func(activeSkill, output, breakdown)
+			func(activeSkill, output, breakdown, env)
 		end
 	end
 

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -520,12 +520,12 @@ local function doActorAttribsPoolsConditions(env, actor)
 					breakdown[stat] = breakdown.simple(nil, nil, output[stat], stat)
 				end
 			end
-			
-      local stats = { output.Str, output.Dex, output.Int }
-      table.sort(stats)
-      output.LowestAttribute = stats[1]
-      condList["TwoHighestAttributesEqual"] = stats[2] == stats[3]
-      
+
+			local stats = { output.Str, output.Dex, output.Int }
+			table.sort(stats)
+			output.LowestAttribute = stats[1]
+			condList["TwoHighestAttributesEqual"] = stats[2] == stats[3]
+
 			condList["DexHigherThanInt"] = output.Dex > output.Int
 			condList["StrHigherThanDex"] = output.Str > output.Dex
 			condList["IntHigherThanStr"] = output.Int > output.Str
@@ -566,7 +566,7 @@ local function doActorAttribsPoolsConditions(env, actor)
 				modDB:NewMod("Omni", "INC", -reduction["INC"], "Reduction from Double/Triple Dipped attributes to Omniscience")
 				modDB:NewMod("Omni", "MORE", -reduction["MORE"], "Reduction from Double/Triple Dipped attributes to Omniscience")
 			end
-				
+
 			for _, stat in pairs({"Str","Dex","Int"}) do
 				local base = classStats["base_"..stat:lower()]
 				output[stat] = base
@@ -576,11 +576,11 @@ local function doActorAttribsPoolsConditions(env, actor)
 			if breakdown then
 				breakdown["Omni"] = breakdown.simple(nil, nil, output["Omni"], "Omni")
 			end
-      
-      local stats = { output.Str, output.Dex, output.Int }
-      table.sort(stats)
-      output.LowestAttribute = stats[1]
-      condList["TwoHighestAttributesEqual"] = stats[2] == stats[3]
+
+			local stats = { output.Str, output.Dex, output.Int }
+			table.sort(stats)
+			output.LowestAttribute = stats[1]
+			condList["TwoHighestAttributesEqual"] = stats[2] == stats[3]
 
 			output.LowestAttribute = m_min(output.Str, output.Dex, output.Int)
 			condList["DexHigherThanInt"] = output.Dex > output.Int
@@ -648,6 +648,9 @@ local function doActorAttribsPoolsConditions(env, actor)
 		local more = modDB:More(nil, "Life")
 		local conv = modDB:Sum("BASE", nil, "LifeConvertToEnergyShield")
 		output.Life = m_max(round(base * (1 + inc/100) * more * (1 - conv/100)), 1)
+		if actor.minionData then
+			GlobalCache.cachedMinionLife[actor.minionData.name] = output.Life
+		end
 		if breakdown then
 			if inc ~= 0 or more ~= 1 or conv ~= 0 then
 				breakdown.Life = { }

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -168,7 +168,7 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 	local igniteSource = ""
 	GlobalCache.numActiveSkillInFullDPS = 0
 	for _, activeSkill in ipairs(fullEnv.player.activeSkillList) do
-		if activeSkill.socketGroup and activeSkill.socketGroup.includeInFullDPS and not isExcludedFromFullDps(activeSkill) then
+		if activeSkill.socketGroup and (activeSkill.socketGroup.hiddenFullDPS or activeSkill.socketGroup.includeInFullDPS) and not isExcludedFromFullDps(activeSkill) then
 			GlobalCache.numActiveSkillInFullDPS = GlobalCache.numActiveSkillInFullDPS + 1
 			local activeSkillCount, enabled = getActiveSkillCount(activeSkill)
 			if enabled then
@@ -188,7 +188,7 @@ function calcs.calcFullDPS(build, mode, override, specEnv)
 					GlobalCache.dontUseCache = forceCache
 				end
 				local minionName = nil
-				if activeSkill.minion or usedEnv.minion then
+				if activeSkill.socketGroup.includeInFullDPS and (activeSkill.minion or usedEnv.minion) then
 					if usedEnv.minion.output.TotalDPS and usedEnv.minion.output.TotalDPS > 0 then
 						minionName = (activeSkill.minion and activeSkill.minion.minionData.name..": ") or (usedEnv.minion and usedEnv.minion.minionData.name..": ") or ""
 						t_insert(fullDPS.skills, { name = activeSkill.activeEffect.grantedEffect.name, dps = usedEnv.minion.output.TotalDPS, count = activeSkillCount, trigger = activeSkill.infoTrigger, skillPart = minionName..activeSkill.skillPartName })

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -190,7 +190,6 @@ return {
 			socketGroup.hiddenFullDPS = nil
 			for _, gemInstance in ipairs(socketGroup.gemList) do
 				if gemInstance.enabled then
-					local minionId = nil
 					cacheMinionData(socketGroup, gemInstance.skillMinion)
 					cacheMinionData(socketGroup, gemInstance.skillMinionCalcs)
 					if gemInstance.gemData then

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -167,7 +167,7 @@ return {
 	{ var = "skillOptionMinionLife", type = "count", alwaysHide = true },
 	{ var = "skillOptionMinionName", type = "list", label = "Minion Name:", ifSkill = "Death Wish", tooltip = "Sets the minion being targeted by Death Wish. Assign this minion to an active skill or you will see unusual behavior.", list = GlobalCache.cachedMinionList, runOnce = true, apply = function(val, modList, enemyModList, build)
 		wipeTable(GlobalCache.cachedMinionList)
-		local function cacheMinionData(socketGroup, minionId, minionLevel, isSpectre)
+		local function cacheMinionData(socketGroup, minionId)
 			if not minionId then
 				return
 			end
@@ -191,23 +191,17 @@ return {
 			for _, gemInstance in ipairs(socketGroup.gemList) do
 				if gemInstance.enabled then
 					local minionId = nil
-					-- We assume that minions we can't detect the level of are level 70.
-					-- This is technically incorrect at lower levels, but Death Wish requires level 73 to equip and we currently don't use this for anything else.
-					local minionLevel = m_max(1, m_min(100, gemInstance.reqLevel or 70))
-					-- Spectres have their level defined explicitly in skill gem data.
-					local isSpectre = gemInstance.skillId == "RaiseSpectre"
-					local spectreLevel = isSpectre and gemInstance.gemData.grantedEffect.levels[gemInstance.level][4] or minionLevel
-					cacheMinionData(socketGroup, gemInstance.skillMinion, spectreLevel, isSpectre)
-					cacheMinionData(socketGroup, gemInstance.skillMinionCalcs, spectreLevel, isSpectre)
+					cacheMinionData(socketGroup, gemInstance.skillMinion)
+					cacheMinionData(socketGroup, gemInstance.skillMinionCalcs)
 					if gemInstance.gemData then
 						if gemInstance.gemData.grantedEffect.minionList then
 							for _, minionId in ipairs(gemInstance.gemData.grantedEffect.minionList) do
-								cacheMinionData(socketGroup, minionId, minionLevel, false)
+								cacheMinionData(socketGroup, minionId)
 							end
 						end
 						if gemInstance.gemData.grantedEffect.addMinionList then
 							for _, minionId in ipairs(gemInstance.gemData.grantedEffect.addMinionList) do
-								cacheMinionData(socketGroup, minionId, minionLevel, false)
+								cacheMinionData(socketGroup, minionId)
 							end
 						end
 					end


### PR DESCRIPTION
This adds a minion selector (currently only used by Death Wish), separates the spell and minion explosion components of Death Wish, add some new functionality to the config tab. There's also a bit of miscellaneous code clean up in here (formatting mostly).

Fixes #2372.

### Link to a build that showcases this PR:
https://pobb.in/VcllNw4VS8tM

### After screenshot:
![](http://puu.sh/ILODF/6f38564098.png)