### PR TITLE
Fix Precise Technique to use max life

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1497,7 +1497,7 @@ function calcs.offence(env, actor, activeSkill)
 
 		-- Check Precise Technique Keystone condition per pass as MH/OH might have different values
 		local condName = pass.label:gsub(" ", "") .. "AccRatingHigherThanMaxLife"
-		skillModList.conditions[condName] = output.Accuracy > env.player.output.LifeUnreserved
+		skillModList.conditions[condName] = output.Accuracy > env.player.output.Life
 
 		-- Calculate attack/cast speed
 		if activeSkill.activeEffect.grantedEffect.castTime == 0 and not skillData.castTimeOverride then


### PR DESCRIPTION
Fixes #4476

Current Precise Technique calculation is checking unreserved life instead of max life, this PR fixes it.

![image](https://user-images.githubusercontent.com/5316261/174854104-bd530c3d-ca32-4254-92d6-e7104d790c1c.png)
