### PR TITLE
Added checkbox to quickly toggle flasks in the calcs tab

### DIFF
--- a/src/Classes/CalcsTab.lua
+++ b/src/Classes/CalcsTab.lua
@@ -13,7 +13,7 @@ local buffModeDropList = {
 	{ label = "Unbuffed", buffMode = "UNBUFFED" },
 	{ label = "Buffed", buffMode = "BUFFED" },
 	{ label = "In Combat", buffMode = "COMBAT" },
-	{ label = "Effective DPS", buffMode = "EFFECTIVE" } 
+	{ label = "Effective DPS", buffMode = "EFFECTIVE" }
 }
 
 local CalcsTabClass = newClass("CalcsTab", "UndoHandler", "ControlHost", "Control", function(self, build)
@@ -28,6 +28,7 @@ local CalcsTabClass = newClass("CalcsTab", "UndoHandler", "ControlHost", "Contro
 	self.input = { }
 	self.input.skill_number = 1
 	self.input.misc_buffMode = "EFFECTIVE"
+	self.input.flasksActive = true
 
 	self.colWidth = 230
 	self.sectionList = { }
@@ -114,10 +115,10 @@ local CalcsTabClass = newClass("CalcsTab", "UndoHandler", "ControlHost", "Contro
 				self.build.buildFlag = true
 			end)
 		} },
-		{ label = "Calculation Mode", { 
-			controlName = "mode", 
-			control = new("DropDownControl", nil, 0, 0, 100, 16, buffModeDropList, function(index, value) 
-				self.input.misc_buffMode = value.buffMode 
+		{ label = "Calculation Mode", {
+			controlName = "mode",
+			control = new("DropDownControl", nil, 0, 0, 100, 16, buffModeDropList, function(index, value)
+				self.input.misc_buffMode = value.buffMode
 				self:AddUndoState()
 				self.build.buildFlag = true
 			end, [[
@@ -127,8 +128,17 @@ The stats in the sidebar are always shown in Effective DPS mode, regardless of t
 Unbuffed: No auras, buffs, or other support skills or effects will apply. This is equivalent to standing in town.
 Buffed: Aura and buff skills apply. This is equivalent to standing in your hideout with auras and buffs turned on.
 In Combat: Charges and combat buffs such as Onslaught will also apply. This will show your character sheet stats in combat.
-Effective DPS: Curses and enemy properties (such as resistances and status conditions) will also apply. This estimates your true DPS.]]) 
+Effective DPS: Curses and enemy properties (such as resistances and status conditions) will also apply. This estimates your true DPS.]])
 		}, },
+		{ label = "Flasks Active", {
+			controlName = "flasksActive",
+			control = new("CheckBoxControl", {"LEFT", nil, "RIGHT"}, 0, 0, 16, nil, function(value)
+				self.input.flasksActive = value
+				self:AddUndoState()
+				self.build.buildFlag = true
+			end, [[
+This control allows you to get a quick glance at your damage without your flasks, in a context where you would not normally gain enough charges to maintain them.]], true)
+		}, flag = "combat" },
 		{ label = "Aura and Buff Skills", flag = "buffs", textSize = 12, { format = "{output:BuffList}", { breakdown = "SkillBuffs" } }, },
 		{ label = "Combat Buffs", flag = "combat", textSize = 12, { format = "{output:CombatList}" }, },
 		{ label = "Curses and Debuffs", flag = "effective", textSize = 12, { format = "{output:CurseList}", { breakdown = "SkillDebuffs" } }, },

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1432,7 +1432,7 @@ function calcs.perform(env, avoidCache)
 	end
 
 	-- Merge flask modifiers
-	if env.mode_combat then
+	if env.mode_combat and (env.mode ~= "CALCS" or env.flasksActive) then -- Don't merge flasks for the calcs tab if they are marked as not active
 		local effectInc = modDB:Sum("INC", nil, "FlaskEffect")
 		local flaskBuffs = { }
 		local usingFlask = false

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -281,6 +281,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 		env.configPlaceholder = build.configTab.placeholder
 		env.calcsInput = build.calcsTab.input
 		env.mode = mode
+		env.flasksActive = env.calcsInput.flasksActive
 		env.spec = override.spec or build.spec
 		env.classId = env.spec.curClassId
 


### PR DESCRIPTION
### Description of the problem being solved:
I wanted a quick and easy way to see what my final DPS would be like without flasks up, in a scenario like Uber bosses where my build doesn't generate any flask charges during the fight. But only without flasks and not everything else the Calculation Mode removes. So I added a little checkbox just below it to quickly toggle flasks on or off.

Since this is the first time I am contributing to PoB I am very open to criticism and feedback.

### Link to a build that showcases this PR:
https://pastebin.com/14gXSciK

### Before screenshot:
![image](https://user-images.githubusercontent.com/11169733/179023020-2425804b-4710-4670-ab03-dc2480830943.png)

### After screenshot:
![image](https://user-images.githubusercontent.com/11169733/179023126-e58b63c6-d931-459f-af19-9dc5c5b1dc55.png)
