### PR TITLE
Support for Impresence drop from Uber Uber Elder

### DIFF
--- a/src/Data/Uniques/amulet.lua
+++ b/src/Data/Uniques/amulet.lua
@@ -593,12 +593,20 @@ Damage Penetrates 10% Fire Resistance against Blinded Enemies
 ]],[[
 Impresence
 Onyx Amulet
-Source: Drops from unique{The Elder} (Tier 11+)
+Source: Drops from unique{The Elder, Uber Uber Elder} (Tier 11+)
+Has Alt Variant: True
+Selected Variant: 1
+Selected Alt Variant: 6
 Variant: Physical
 Variant: Fire
 Variant: Cold
 Variant: Lightning
 Variant: Chaos
+Variant: No Curse
+Variant: Curse: Punishment
+Variant: Curse: Elemental Weakness
+Variant: Curse: Enfeeble
+Variant: Curse: Temporal Chains
 Requires Level 64
 Implicits: 1
 {tags:jewellery_attribute}+(10-16) to all Attributes
@@ -618,11 +626,15 @@ Implicits: 1
 {variant:3}{tags:jewellery_resistance}+(20-25)% to Cold Resistance
 {variant:4}{tags:jewellery_resistance}+(20-25)% to Lightning Resistance
 {variant:5}{tags:chaos,jewellery_resistance}+(17-23)% to Chaos Resistance
-{variant:1}Vulnerability has no Reservation if Cast as an Aura
-{variant:2}Flammability has no Reservation if Cast as an Aura
-{variant:3}Frostbite has no Reservation if Cast as an Aura
 {variant:4}Conductivity has no Reservation if Cast as an Aura
 {variant:5}Despair has no Reservation if Cast as an Aura
+{variant:8}Elemental Weakness has no Reservation if Cast as an Aura
+{variant:9}Enfeeble has no Reservation if Cast as an Aura
+{variant:2}Flammability has no Reservation if Cast as an Aura
+{variant:3}Frostbite has no Reservation if Cast as an Aura
+{variant:7}Punishment has no Reservation if Cast as an Aura
+{variant:10}Temporal Chains has no Reservation if Cast as an Aura
+{variant:1}Vulnerability has no Reservation if Cast as an Aura
 Gain Maddening Presence for 10 seconds when you Kill a Rare or Unique Enemy
 Elder Item
 ]],[[


### PR DESCRIPTION
Fixes #4787 .

### Description of the problem being solved:
PoB has no support for the Impresence drop from Uber Uber Elder which adds Shaper Influence to the base and adds `<<Random curse>> has no Reservation if Cast as an Aura` with the `random curse` being from a selection from Punishment,
 Elemental Weakness, Enfeeble or Temporal Chains.

Curse support is added and this PR is waiting for the implementation of the support to add the `Variant` Flag to Influence Modifiers, which someone is working on right now.
### Steps taken to verify a working solution:
-
-
-

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
