### PR TITLE
Add dropdown for death wish minion selection

### DIFF
--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -349,6 +349,49 @@ function ConfigTabClass:Save(xml)
 	end
 end
 
+local function activeMinionList(control, build)
+	local list = wipeTable(control.list)
+	local function addMinionData(socketGroup, minionId)
+		if not minionId then
+			return
+		end
+		local minionName = data.minions[minionId].name
+		local duplicateMinion = false
+		for k, v in ipairs(list) do
+			if v.label == minionName then
+				duplicateMinion = true
+				break
+			end
+		end
+		if not duplicateMinion then
+			table.insert(list, {val = minionId, label = minionName})
+		end
+	end
+	if build.skillsTab == nil then
+		return
+	end
+	for _, socketGroup in ipairs(build.skillsTab.socketGroupList) do
+		for _, gemInstance in ipairs(socketGroup.gemList) do
+			if gemInstance.enabled then
+				addMinionData(socketGroup, gemInstance.skillMinion)
+				addMinionData(socketGroup, gemInstance.skillMinionCalcs)
+				if gemInstance.gemData then
+					if gemInstance.gemData.grantedEffect.minionList then
+						for _, minionId in ipairs(gemInstance.gemData.grantedEffect.minionList) do
+							addMinionData(socketGroup, minionId)
+						end
+					end
+					if gemInstance.gemData.grantedEffect.addMinionList then
+						for _, minionId in ipairs(gemInstance.gemData.grantedEffect.addMinionList) do
+							addMinionData(socketGroup, minionId)
+						end
+					end
+				end
+			end
+		end
+	end
+end
+
 function ConfigTabClass:UpdateControls()
 	for var, control in pairs(self.varControls) do
 		if control._className == "EditControl" then
@@ -359,6 +402,9 @@ function ConfigTabClass:UpdateControls()
 		elseif control._className == "CheckBoxControl" then
 			control.state = self.input[var]
 		elseif control._className == "DropDownControl" then
+			if var == "deathWishMinionName" then
+				activeMinionList(control, self.build)
+			end
 			control:SelByValue(self.input[var], "val")
 		end
 	end

--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -349,8 +349,9 @@ function ConfigTabClass:Save(xml)
 	end
 end
 
-local function activeMinionList(control, build)
+local function activeMinionList(control, build, previousVal)
 	local list = wipeTable(control.list)
+	local previousValFound = false
 	local function addMinionData(socketGroup, minionId)
 		if not minionId then
 			return
@@ -364,7 +365,10 @@ local function activeMinionList(control, build)
 			end
 		end
 		if not duplicateMinion then
-			table.insert(list, {val = minionId, label = minionName})
+			t_insert(list, {val = minionId, label = minionName})
+			if minionId == previousVal then
+				previousValFound = true
+			end
 		end
 	end
 	if build.skillsTab == nil then
@@ -390,6 +394,17 @@ local function activeMinionList(control, build)
 			end
 		end
 	end
+	if #list == 0 then
+		t_insert(list, {val = "none", label = "<No minions added yet>"})
+		previousValFound = previousVal == "none"
+	end
+	if previousValFound then
+		control:SelByValue(previousVal, "val")
+	elseif #list > 0 then
+		control:SetSel(1)
+		-- We need to force the selFunc to be called in case it was already set to the same index
+		control.selFunc(control.selIndex, control.list[control.selIndex])
+	end
 end
 
 function ConfigTabClass:UpdateControls()
@@ -403,9 +418,10 @@ function ConfigTabClass:UpdateControls()
 			control.state = self.input[var]
 		elseif control._className == "DropDownControl" then
 			if var == "deathWishMinionName" then
-				activeMinionList(control, self.build)
+				activeMinionList(control, self.build, self.input[var])
+			else
+				control:SelByValue(self.input[var], "val")
 			end
-			control:SelByValue(self.input[var], "val")
 		end
 	end
 end

--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -693,9 +693,10 @@ skills["DeathWish"] = {
 	fromItem = true,
 	parts = {
 		{
-			name = "Channelling",
+			name = "Spell Explosion",
 			spell = true,
-			cast = false,
+			cast = true,
+			stages = true,
 		},
 		{
 			name = "Minion Explosion",
@@ -707,16 +708,16 @@ skills["DeathWish"] = {
 	preDamageFunc = function(activeSkill, output)
 		if activeSkill.skillPart == 2 then
 			local skillData = activeSkill.skillData
-			skillData.FireBonusMin = output.Life * skillData.selfFireExplosionLifeMultiplier
-			skillData.FireBonusMax = output.Life * skillData.selfFireExplosionLifeMultiplier
+			skillData.FireBonusMin = skillData.minionLife * skillData.selfFireExplosionLifeMultiplier
+			skillData.FireBonusMax = skillData.minionLife * skillData.selfFireExplosionLifeMultiplier
 		end
 	end,
 	statMap = {
 		["spell_minimum_base_fire_damage"] = {
-			skill("FireMin", nil, { type = "SkillPart", skillPart = 2 }),
+			skill("FireMin", nil, { type = "SkillPart", skillPart = 1 }),
 		},
 		["spell_maximum_base_fire_damage"] = {
-			skill("FireMax", nil, { type = "SkillPart", skillPart = 2 }),
+			skill("FireMax", nil, { type = "SkillPart", skillPart = 1 }),
 		},
 		["death_wish_attack_speed_+%"] = {
 			mod("Speed", "INC", nil, ModFlag.Attack, 0, { type = "GlobalEffect", effectType = "Buff" }),
@@ -728,10 +729,10 @@ skills["DeathWish"] = {
 			mod("MovementSpeed", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
 		},
 		["death_wish_hit_and_ailment_damage_+%_final_per_stage"] = {
-			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "Multiplier", var = "DeathWishStage" }, { type = "SkillPart", skillPart = 2 }),
+			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "Multiplier", var = "DeathWishStage" }),
 		},
 		["death_wish_max_stages"] = {
-			mod("Multiplier:DeathWishMaxStages", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
+			mod("Multiplier:DeathWishMaxStages", "BASE", nil, 0, 0),
 		},
 	},
 	baseFlags = {
@@ -739,8 +740,8 @@ skills["DeathWish"] = {
 		area = true,
 	},
 	baseMods = {
-		skill("explodeCorpse", true, { type = "SkillPart", skillPart = 2 }),
-		skill("radius", 10, { type = "SkillPart", skillPart = 2 }),
+		skill("showAverage", true),
+		skill("radius", 10),
 		skill("buffMinions", true),
 		skill("buffNotPlayer", true),
 	},

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -235,9 +235,10 @@ local skills, mod, flag, skill = ...
 	fromItem = true,
 	parts = {
 		{
-			name = "Channelling",
+			name = "Spell Explosion",
 			spell = true,
-			cast = false,
+			cast = true,
+			stages = true,
 		},
 		{
 			name = "Minion Explosion",
@@ -249,16 +250,16 @@ local skills, mod, flag, skill = ...
 	preDamageFunc = function(activeSkill, output)
 		if activeSkill.skillPart == 2 then
 			local skillData = activeSkill.skillData
-			skillData.FireBonusMin = output.Life * skillData.selfFireExplosionLifeMultiplier
-			skillData.FireBonusMax = output.Life * skillData.selfFireExplosionLifeMultiplier
+			skillData.FireBonusMin = skillData.minionLife * skillData.selfFireExplosionLifeMultiplier
+			skillData.FireBonusMax = skillData.minionLife * skillData.selfFireExplosionLifeMultiplier
 		end
 	end,
 	statMap = {
 		["spell_minimum_base_fire_damage"] = {
-			skill("FireMin", nil, { type = "SkillPart", skillPart = 2 }),
+			skill("FireMin", nil, { type = "SkillPart", skillPart = 1 }),
 		},
 		["spell_maximum_base_fire_damage"] = {
-			skill("FireMax", nil, { type = "SkillPart", skillPart = 2 }),
+			skill("FireMax", nil, { type = "SkillPart", skillPart = 1 }),
 		},
 		["death_wish_attack_speed_+%"] = {
 			mod("Speed", "INC", nil, ModFlag.Attack, 0, { type = "GlobalEffect", effectType = "Buff" }),
@@ -270,14 +271,14 @@ local skills, mod, flag, skill = ...
 			mod("MovementSpeed", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
 		},
 		["death_wish_hit_and_ailment_damage_+%_final_per_stage"] = {
-			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "Multiplier", var = "DeathWishStage" }, { type = "SkillPart", skillPart = 2 }),
+			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "Multiplier", var = "DeathWishStage" }),
 		},
 		["death_wish_max_stages"] = {
-			mod("Multiplier:DeathWishMaxStages", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
+			mod("Multiplier:DeathWishMaxStages", "BASE", nil),
 		},
 	},
-	#baseMod skill("explodeCorpse", true, { type = "SkillPart", skillPart = 2 })
-	#baseMod skill("radius", 10, { type = "SkillPart", skillPart = 2 })
+	#baseMod skill("showAverage", true)
+	#baseMod skill("radius", 10)
 	#baseMod skill("buffMinions", true)
 	#baseMod skill("buffNotPlayer", true)
 #mods

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -977,6 +977,9 @@ function buildMode:OnFrame(inputEvents)
 	-- Update contents of main skill dropdowns
 	self:RefreshSkillSelectControls(self.controls, self.mainSocketGroup, "")
 
+	-- Update config controls
+	self.configTab:UpdateControls()
+
 	-- Delete any possible fabricated groups
 	if checkFabricatedGroups then
 		deleteFabricatedGroup(self.skillsTab)

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2514,6 +2514,36 @@ function calcs.perform(env, avoidCache)
 		end
 	end
 
+	-- Death Wish
+	if env.player.mainSkill.skillCfg.skillName == "Death Wish" then
+		-- We need to calculate the selected minion's life to use in the explosion
+		local selectedMinion = env.player.mainSkill.skillData.deathWishMinionName
+		local minionSkill
+		for i, aux in ipairs(env.auxSkillList) do
+			if aux.minion and aux.minion.type == selectedMinion then
+				minionSkill = aux
+			end
+		end
+
+		if not minionSkill then
+			env.player.mainSkill.skillData.minionLife = 100;
+		else
+			local usedSkill = nil
+			local uuid = cacheSkillUUID(minionSkill)
+			local calcMode = env.mode == "CALCS" and "CALCS" or "MAIN"
+
+			-- cache a new copy of the selected minion
+			--if not GlobalCache.cachedData[calcMode][uuid] then
+				calcs.buildActiveSkill(env, calcMode, minionSkill, true)
+			--end
+
+			if GlobalCache.cachedData[calcMode][uuid] then
+				usedSkill = GlobalCache.cachedData[calcMode][uuid].ActiveSkill
+			end
+			env.player.mainSkill.skillData.minionLife = usedSkill.minion.output.Life;
+		end
+	end
+
 	-- Kitava's Thirst
 	if env.player.mainSkill.skillData.triggeredByManaSpent and not env.player.mainSkill.skillFlags.minion then
 		local triggerName = "Kitava"

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2519,9 +2519,15 @@ function calcs.perform(env, avoidCache)
 		-- We need to calculate the selected minion's life to use in the explosion
 		local selectedMinion = env.player.mainSkill.skillData.deathWishMinionName
 		local minionSkill
-		for i, aux in ipairs(env.auxSkillList) do
-			if aux.minion and aux.minion.type == selectedMinion then
-				minionSkill = aux
+		for _, skill in ipairs(env.player.activeSkillList) do
+			if skill.minion and skill.minion.type == selectedMinion then
+				minionSkill = skill
+			elseif skill.minionList then
+				for _, minionId in ipairs(skill.minionList) do
+					if minionId == selectedMinion then
+						minionSkill = skill
+					end
+				end
 			end
 		end
 
@@ -2536,7 +2542,6 @@ function calcs.perform(env, avoidCache)
 			--if not GlobalCache.cachedData[calcMode][uuid] then
 				calcs.buildActiveSkill(env, calcMode, minionSkill, true)
 			--end
-
 			if GlobalCache.cachedData[calcMode][uuid] then
 				usedSkill = GlobalCache.cachedData[calcMode][uuid].ActiveSkill
 			end

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -217,6 +217,11 @@ return {
 	{ var = "darkPactSkeletonLife", type = "count", label = "Skeleton ^xE05030Life:", ifSkill = "Dark Pact", tooltip = "Sets the maximum ^xE05030Life ^7of the Skeleton that is being targeted.", apply = function(val, modList, enemyModList)
 		modList:NewMod("SkillData", "LIST", { key = "skeletonLife", value = val }, "Config", { type = "SkillName", skillName = "Dark Pact" })
 	end },
+	{ label = "Death Wish:", ifSkill = "Death Wish" },
+	{ var = "deathWishMinionName", type = "list", label = "Death Wish minion:", ifSkill = "Death Wish", tooltip = "Sets the minion being targeted by Death Wish.",
+	  list = {}, apply = function(val, modList, enemyModList, build)
+		modList:NewMod("SkillData", "LIST", { key = "deathWishMinionName", value = val }, "Config", { type = "SkillName", skillName = "Death Wish" })
+	end },
 	{ label = "Predator:", ifSkill = "Predator" },
 	{ var = "deathmarkDeathmarkActive", type = "check", label = "Is the enemy marked with Signal Prey?", ifSkill = "Predator", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:EnemyHasDeathmark", "FLAG", true, "Config")


### PR DESCRIPTION
Fixes #2372, #4462, and #4601.

### Description of the problem being solved:
The current Death Wish implementation has a couple of problems. The first is that it's set to scale off of enemy corpse life which needs to be updated manually. The second is that the ability has two damaging parts to it, a spell explosion and a minion explosion. This PR adds a dropdown selector that can be used to select a specific minion to use for the damage calculation.

This work is based off of [Lothrik](https://github.com/Lothrik)'s PR #4241

### Steps taken to verify a working solution:
Set up required:
- Equip Maw of Mischief helmet
- Add Stone Golem skill
- Add Ice Golem skill

Tests:
- Switch between the minions
- Check tooltip dps on the tree by hovering a minion health node
- Select and deselect the minion health node
- Toggled Full DPS for the Death Wish skill
- Add and remove the Minion Life support gem
- Import character from account
- Import from existing PoB
- Disable all minion gems

### Link to a build that showcases this PR:
https://pobb.in/yZB6sVbD5tJa

### After screenshot:
![image](https://user-images.githubusercontent.com/1395090/187017083-8fdd20a5-74de-43eb-8c1e-9c912ca2bccf.png)