### PR TITLE
Add support for Call of the Void enemy damage reduction

### DIFF
--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -339,6 +339,8 @@ function ModStoreClass:EvalMod(mod, cfg)
 			-- if the actor is 'parent', we don't want to return if we're already using 'parent', just keep using 'self'
 			if tag.actor and self.actor[tag.actor] then
 				target = self.actor[tag.actor].modDB
+			elseif tag.from_enemy and self.actor.enemy then
+				target = self.actor.enemy.modDB
 			end
 			if tag.statList then
 				base = 0

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -950,6 +950,21 @@ function calcs.defence(env, actor)
 		local enemyCritDamage = env.configInput["enemyCritDamage"] or env.configPlaceholder["enemyCritDamage"] or 0
 		output["EnemyCritEffect"] = 1 + enemyCritChance / 100 * (enemyCritDamage / 100) * (1 - output.CritExtraDamageReduction / 100)
 		local enemyCfg = {keywordFlags = bit.bnot(KeywordFlag.MatchAll)} -- Match all keywordFlags parameter for enemy min-max damage mods
+
+		-- Enemy chill damage reduction, ex. Call of the Void
+		local chill_damage_reduction = 0
+		local chill_damage_reduction_source = nil
+		for _, value in ipairs(enemyDB:Tabulate("MAX", enemyCfg, "EnemyChillDamageReduction")) do
+			local val = enemyDB:EvalMod(value.mod, enemyCfg)
+			if val > chill_damage_reduction then
+				chill_damage_reduction = val
+				chill_damage_reduction_source = value.mod.source
+			end	
+		end
+		if chill_damage_reduction > 0 then
+			enemyDB:NewMod("Damage", "MORE", -chill_damage_reduction, chill_damage_reduction_source)
+		end
+
 		for _, damageType in ipairs(dmgTypeList) do
 			local enemyDamageMult = calcLib.mod(enemyDB, nil, "Damage", damageType.."Damage", isElemental[damageType] and "ElementalDamage" or nil) -- missing taunt from allies
 			local enemyDamage = tonumber(env.configInput["enemy"..damageType.."Damage"])
@@ -966,10 +981,10 @@ function calcs.defence(env, actor)
 			if enemyOverwhelm == nil then
 				enemyOverwhelm = tonumber(env.configPlaceholder["enemy"..damageType.."enemyOverwhelm"]) or 0
 			end
-			
+
 			-- Add min-max enemy damage from mods
 			enemyDamage = enemyDamage + (enemyDB:Sum("BASE", enemyCfg, (damageType.."Min")) + enemyDB:Sum("BASE", enemyCfg, (damageType.."Max"))) / 2
-			
+		
 			output[damageType.."EnemyPen"] = enemyPen
 			output[damageType.."EnemyOverwhelm"] = enemyOverwhelm
 			output["totalEnemyDamageIn"] = output["totalEnemyDamageIn"] + enemyDamage

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2550,6 +2550,9 @@ local specialModList = {
 		mod("ShockBase", "BASE", data.nonDamagingAilment["Shock"].default, { type = "ActorCondition", actor = "enemy", var = "ChilledByYourHits" }),
 		mod("EnemyModifier", "LIST", { mod = flag("Condition:Shocked", { type = "Condition", var = "ChilledByYourHits" }) })
 	},
+	["enemies chilled by your hits lessen their damage dealt by half of chill effect"] = { 
+		mod("EnemyModifier", "LIST", { mod = mod("EnemyChillDamageReduction", "MAX", 1, { type = "PerStat", stat = "CurrentChill", from_enemy = true, div = 2 }, { type = "Condition", var = "ChilledByYourHits" })})
+	},
 	["cannot inflict ignite"] = { flag("CannotIgnite") },
 	["cannot inflict freeze or chill"] = { flag("CannotFreeze"), flag("CannotChill") },
 	["cannot inflict shock"] = { flag("CannotShock") },


### PR DESCRIPTION
### Description of the problem being solved:
Implementing Call of the Void's 'Enemies chilled by your Hits lessen their Damage dealt by half of Chill Effect'

### Steps taken to verify a working solution:
- With two Call of the Void's equipped (ensuring only 1 is contributing to enemy damage reduction) and 40% chill effect:
![image](https://user-images.githubusercontent.com/3247221/207995864-82e4502e-06ef-4eab-8986-a8d3ca2a0163.png)
- With two Call of the Void's equipped and base chill effect with Shaper of Winter and some chill effect: 
![image](https://user-images.githubusercontent.com/3247221/207996281-c3d3633d-189e-42e5-9a59-1ef49a45430e.png)
- With Call of the Void but with 'Is the enemy Chilled by your hits' config option turned off (also without Call of the Void displays the same): 
![image](https://user-images.githubusercontent.com/3247221/207996535-d74f248b-8ed1-4c8c-a205-b3f5d958bc3a.png)

### Link to a build that showcases this PR:
https://pastebin.com/DW4wLKiK
