### PR TITLE
Checks nil on fileText of save files

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1547,6 +1547,10 @@ function buildMode:LoadDBFile()
 		return true
 	end
 	local xmlText = file:read("*a")
+	if not xmlText then
+		self.dbFileName = nil
+		return true
+	end
 	file:close()
 	return self:LoadDB(xmlText, self.dbFileName)
 end

--- a/src/Modules/BuildList.lua
+++ b/src/Modules/BuildList.lua
@@ -165,13 +165,15 @@ function listMode:BuildList()
 		if fileHnd then
 			local fileText = fileHnd:read("*a")
 			fileHnd:close()
-			fileText = fileText:match("(<Build.->)")
 			if fileText then
-				local xml = common.xml.ParseXML(fileText.."</Build>")
-				if xml and xml[1] then
-					build.level = tonumber(xml[1].attrib.level)
-					build.className = xml[1].attrib.className
-					build.ascendClassName = xml[1].attrib.ascendClassName
+				fileText = fileText:match("(<Build.->)")
+				if fileText then
+					local xml = common.xml.ParseXML(fileText.."</Build>")
+					if xml and xml[1] then
+						build.level = tonumber(xml[1].attrib.level)
+						build.className = xml[1].attrib.className
+						build.ascendClassName = xml[1].attrib.ascendClassName
+					end
 				end
 			end
 		end

--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -626,7 +626,11 @@ function copyFile(srcName, dstName)
 	if not outFile then
 		return nil, "Couldn't create '"..dstName.."': "..msg
 	end
-	outFile:write(inFile:read("*a"))
+	local fileText = inFile:read("*a")
+	if not fileText then
+		return nil, "Couldn't read '"..srcName.."': "..msg
+	end	
+	outFile:write(fileText)
 	inFile:close()
 	outFile:close()
 	return true


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/5368

### Description of the problem being solved:
OneDrive creates weird files that are openable but not readable
This should hopefully stop it crashing at least.

TODO: Get someone to test it that has this problem.
This seems to help minimise the problem but does not solve it as there are still crashes and obviously you cannot save / open any builds.