### PR TITLE
Cull Item Variants on save, export and item copy

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -605,6 +605,7 @@ function ItemClass:ParseRaw(raw)
 				for _, modLine2 in ipairs(self.implicitModLines) do
 					if modLine.line == modLine2.line then
 						modLine2.range = modLine.range
+						modLine2.valueScalar = modLine.valueScalar
 						modLineFound = true
 						break
 					end
@@ -614,7 +615,7 @@ function ItemClass:ParseRaw(raw)
 				end
 			end
 		else
-			self.implicitModLines = culledVariantsTemplate.implicitModLines
+			self.implicitModLines = copyTable(culledVariantsTemplate.implicitModLines)
 		end
 		if #self.explicitModLines > 0 then
 			local replacerModline = self.explicitModLines
@@ -624,6 +625,7 @@ function ItemClass:ParseRaw(raw)
 				for _, modLine2 in ipairs(self.explicitModLines) do
 					if modLine.line == modLine2.line then
 						modLine2.range = modLine.range
+						modLine2.valueScalar = modLine.valueScalar
 						modLineFound = true
 						break
 					end
@@ -633,7 +635,7 @@ function ItemClass:ParseRaw(raw)
 				end
 			end
 		else
-			self.explicitModLines = culledVariantsTemplate.explicitModLines
+			self.explicitModLines = copyTable(culledVariantsTemplate.explicitModLines)
 		end
 	end
 	self.affixLimit = 0

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -302,7 +302,7 @@ function ItemClass:ParseRaw(raw)
 				elseif specName == "Selected Variant" then
 					self.variant = tonumber(specVal)
 				elseif specName == "Selected Variant Name" then
-					-- item varaints have changed, find same variant
+					-- item variants have changed, find same variant
 					if self.variantList[self.variant] ~= specVal then
 						for i, variantName in ipairs(self.variantList) do
 							if variantName == specVal then
@@ -325,7 +325,7 @@ function ItemClass:ParseRaw(raw)
 						end
 					end
 					if specName:match("Name") then
-						-- item varaints have changed, find same variant
+						-- item variants have changed, find same variant
 						if self.variantList[self["variantAlt"..altVariantNumber]] ~= specVal then
 							for i, variantName in ipairs(self.variantList) do
 								if variantName == specVal then
@@ -629,9 +629,9 @@ function ItemClass:ParseRaw(raw)
 	-- rebuild mods list from template item
 	if culledVariantsTemplate then
 		if #self.implicitModLines > 0 then
-			local replacerModline = self.implicitModLines
+			local replacerModLine = self.implicitModLines
 			self.implicitModLines = copyTable(culledVariantsTemplate.implicitModLines)
-			for _, modLine in ipairs(replacerModline) do
+			for _, modLine in ipairs(replacerModLine) do
 				local modLineFound = false
 				for _, modLine2 in ipairs(self.implicitModLines) do
 					if modLine.line == modLine2.line then
@@ -649,9 +649,9 @@ function ItemClass:ParseRaw(raw)
 			self.implicitModLines = copyTable(culledVariantsTemplate.implicitModLines)
 		end
 		if #self.explicitModLines > 0 then
-			local replacerModline = self.explicitModLines
+			local replacerModLine = self.explicitModLines
 			self.explicitModLines = copyTable(culledVariantsTemplate.explicitModLines)
-			for _, modLine in ipairs(replacerModline) do
+			for _, modLine in ipairs(replacerModLine) do
 				local modLineFound = false
 				for _, modLine2 in ipairs(self.explicitModLines) do
 					if modLine.line == modLine2.line then

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -311,65 +311,36 @@ function ItemClass:ParseRaw(raw)
 							end
 						end
 					end
-				elseif specName == "Selected Alt Variant" then
-					self.variantAlt = tonumber(specVal)
-				elseif specName == "Selected Alt Variant Name" then
-					-- item varaints have changed, find same variant
-					if self.variantList[self.variantAlt] ~= specVal then
-						for i, variantName in ipairs(self.variantList) do
-							if variantName == specVal then
-								self.variantAlt = i
-								break
-							end
+				elseif specName == "Selected Variant Last Legacy Variant" then
+					local curVariantName = self.variantList[self.variant]
+					while self.variant ~= 1 and self.variantList[self.variant - 1] ~= specVal and self.variantList[self.variant - 1]:match(curVariantName) do
+						self.variant = self.variant - 1
+					end
+				elseif specName:match("Selected Alt Variant") then
+					local altVariantNumber = ""
+					for _, AltVariant in ipairs({{"2", " Two"}, {"3", " Three"}, {"4", " Four"}, {"5", " Five"}}) do
+						if specName:match(AltVariant[2]) then
+							altVariantNumber = AltVariant[1]
+							break
 						end
 					end
-				elseif specName == "Selected Alt Variant Two" then
-					self.variantAlt2 = tonumber(specVal)
-				elseif specName == "Selected Alt Variant Two Name" then
-					-- item varaints have changed, find same variant
-					if self.variantList[self.variantAlt2] ~= specVal then
-						for i, variantName in ipairs(self.variantList) do
-							if variantName == specVal then
-								self.variantAlt2 = i
-								break
+					if specName:match("Name") then
+						-- item varaints have changed, find same variant
+						if self.variantList[self["variantAlt"..altVariantNumber]] ~= specVal then
+							for i, variantName in ipairs(self.variantList) do
+								if variantName == specVal then
+									self["variantAlt"..altVariantNumber] = i
+									break
+								end
 							end
 						end
-					end
-				elseif specName == "Selected Alt Variant Three" then
-					self.variantAlt3 = tonumber(specVal)
-				elseif specName == "Selected Alt Variant Three Name" then
-					-- item varaints have changed, find same variant
-					if self.variantList[self.variantAlt3] ~= specVal then
-						for i, variantName in ipairs(self.variantList) do
-							if variantName == specVal then
-								self.variantAlt3 = i
-								break
-							end
+					elseif specName:match("Last Legacy Variant") then
+						local curVariantName = self.variantList[self["variantAlt"..altVariantNumber]]
+						while self["variantAlt"..altVariantNumber] ~= 1 and self.variantList[self["variantAlt"..altVariantNumber] - 1] ~= specVal and self.variantList[self["variantAlt"..altVariantNumber] - 1]:match(curVariantName) do
+							self["variantAlt"..altVariantNumber] = self["variantAlt"..altVariantNumber] - 1
 						end
-					end
-				elseif specName == "Selected Alt Variant Four" then
-					self.variantAlt4 = tonumber(specVal)
-				elseif specName == "Selected Alt Variant Four Name" then
-					-- item varaints have changed, find same variant
-					if self.variantList[self.variantAlt4] ~= specVal then
-						for i, variantName in ipairs(self.variantList) do
-							if variantName == specVal then
-								self.variantAlt4 = i
-								break
-							end
-						end
-					end
-				elseif specName == "Selected Alt Variant Five" then
-					self.variantAlt5 = tonumber(specVal)
-				elseif specName == "Selected Alt Variant Five Name" then
-					-- item varaints have changed, find same variant
-					if self.variantList[self.variantAlt5] ~= specVal then
-						for i, variantName in ipairs(self.variantList) do
-							if variantName == specVal then
-								self.variantAlt5 = i
-								break
-							end
-						end
+					else
+						self["variantAlt"..altVariantNumber] = tonumber(specVal)
 					end
 				elseif specName == "Has Variants" or specName == "Selected Variants" then
 					-- Need to skip this line for backwards compatibility
@@ -972,6 +943,10 @@ function ItemClass:BuildRaw(cullVariants)
 		t_insert(rawLines, "Selected Variant: " .. self.variant)
 		if cullVariantsTemplate and self.variantList[#self.variantList] ~= "Current" then
 			t_insert(rawLines, "Selected Variant Name: " .. self.variantList[self.variant])
+			if not self.variantList[self.variant]:match(" %(Pre ") then
+				local lastVariant = self.variant ~= 1 and (self.variantList[self.variant - 1]:match(self.variantList[self.variant]) and self.variantList[self.variant - 1] or self.variantList[self.variant]) or self.variantList[self.variant]
+				t_insert(rawLines, "Selected Variant Last Legacy Variant: " .. lastVariant)
+			end
 		end
 
 		for _, baseLine in pairs(self.baseLines) do
@@ -983,6 +958,10 @@ function ItemClass:BuildRaw(cullVariants)
 				t_insert(rawLines, "Selected Alt Variant" .. AltVariant[2] .. ": " .. self["variantAlt" .. AltVariant[1]])
 				if cullVariantsTemplate and self.variantList[#self.variantList] ~= "Current" then
 					t_insert(rawLines, "Selected Alt Variant" .. AltVariant[2] .. " Name: " .. self.variantList[self["variantAlt" .. AltVariant[1]]])
+					if not self.variantList[self["variantAlt" .. AltVariant[1]]]:match(" %(Pre ") then
+						local lastVariant = self["variantAlt" .. AltVariant[1]] ~= 1 and (self.variantList[self["variantAlt" .. AltVariant[1]] - 1]:match(self.variantList[self["variantAlt" .. AltVariant[1]]]) and self.variantList[self["variantAlt" .. AltVariant[1]] - 1] or self.variantList[self["variantAlt" .. AltVariant[1]]]) or self.variantList[self["variantAlt" .. AltVariant[1]]]
+						t_insert(rawLines, "Selected Alt Variant" .. AltVariant[2] .. " Last Legacy Variant: " .. lastVariant)
+					end
 				end
 			else
 				break

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -301,16 +301,76 @@ function ItemClass:ParseRaw(raw)
 					self.hasAltVariant5 = true
 				elseif specName == "Selected Variant" then
 					self.variant = tonumber(specVal)
+				elseif specName == "Selected Variant Name" then
+					-- item varaints have changed, find same variant
+					if self.variantList[self.variant] ~= specVal then
+						for i, variantName in ipairs(self.variantList) do
+							if variantName == specVal then
+								self.variant = i
+								break
+							end
+						end
+					end
 				elseif specName == "Selected Alt Variant" then
 					self.variantAlt = tonumber(specVal)
+				elseif specName == "Selected Alt Variant Name" then
+					-- item varaints have changed, find same variant
+					if self.variantList[self.variantAlt] ~= specVal then
+						for i, variantName in ipairs(self.variantList) do
+							if variantName == specVal then
+								self.variantAlt = i
+								break
+							end
+						end
+					end
 				elseif specName == "Selected Alt Variant Two" then
 					self.variantAlt2 = tonumber(specVal)
+				elseif specName == "Selected Alt Variant Two Name" then
+					-- item varaints have changed, find same variant
+					if self.variantList[self.variantAlt2] ~= specVal then
+						for i, variantName in ipairs(self.variantList) do
+							if variantName == specVal then
+								self.variantAlt2 = i
+								break
+							end
+						end
+					end
 				elseif specName == "Selected Alt Variant Three" then
 					self.variantAlt3 = tonumber(specVal)
+				elseif specName == "Selected Alt Variant Three Name" then
+					-- item varaints have changed, find same variant
+					if self.variantList[self.variantAlt3] ~= specVal then
+						for i, variantName in ipairs(self.variantList) do
+							if variantName == specVal then
+								self.variantAlt3 = i
+								break
+							end
+						end
+					end
 				elseif specName == "Selected Alt Variant Four" then
 					self.variantAlt4 = tonumber(specVal)
+				elseif specName == "Selected Alt Variant Four Name" then
+					-- item varaints have changed, find same variant
+					if self.variantList[self.variantAlt4] ~= specVal then
+						for i, variantName in ipairs(self.variantList) do
+							if variantName == specVal then
+								self.variantAlt4 = i
+								break
+							end
+						end
+					end
 				elseif specName == "Selected Alt Variant Five" then
 					self.variantAlt5 = tonumber(specVal)
+				elseif specName == "Selected Alt Variant Five Name" then
+					-- item varaints have changed, find same variant
+					if self.variantList[self.variantAlt5] ~= specVal then
+						for i, variantName in ipairs(self.variantList) do
+							if variantName == specVal then
+								self.variantAlt5 = i
+								break
+							end
+						end
+					end
 				elseif specName == "Has Variants" or specName == "Selected Variants" then
 					-- Need to skip this line for backwards compatibility
 					-- with builds that used an old Watcher's Eye implementation
@@ -910,29 +970,23 @@ function ItemClass:BuildRaw(cullVariants)
 			end
 		end
 		t_insert(rawLines, "Selected Variant: " .. self.variant)
+		if cullVariantsTemplate and self.variantList[#self.variantList] ~= "Current" then
+			t_insert(rawLines, "Selected Variant Name: " .. self.variantList[self.variant])
+		end
 
 		for _, baseLine in pairs(self.baseLines) do
 			writeModLine(baseLine)
 		end
-		if self.hasAltVariant then
-			t_insert(rawLines, "Has Alt Variant: true")
-			t_insert(rawLines, "Selected Alt Variant: " .. self.variantAlt)
-		end
-		if self.hasAltVariant2 then
-			t_insert(rawLines, "Has Alt Variant Two: true")
-			t_insert(rawLines, "Selected Alt Variant Two: " .. self.variantAlt2)
-		end
-		if self.hasAltVariant3 then
-			t_insert(rawLines, "Has Alt Variant Three: true")
-			t_insert(rawLines, "Selected Alt Variant Three: " .. self.variantAlt3)
-		end
-		if self.hasAltVariant4 then
-			t_insert(rawLines, "Has Alt Variant Four: true")
-			t_insert(rawLines, "Selected Alt Variant Four: " .. self.variantAlt4)
-		end
-		if self.hasAltVariant5 then
-			t_insert(rawLines, "Has Alt Variant Five: true")
-			t_insert(rawLines, "Selected Alt Variant Five: " .. self.variantAlt5)
+		for _, AltVariant in ipairs({{"", ""}, {"2", " Two"}, {"3", " Three"}, {"4", " Four"}, {"5", " Five"}}) do
+			if self["hasAltVariant" .. AltVariant[1]] then
+				t_insert(rawLines, "Has Alt Variant" .. AltVariant[2] .. ": true")
+				t_insert(rawLines, "Selected Alt Variant" .. AltVariant[2] .. ": " .. self["variantAlt" .. AltVariant[1]])
+				if cullVariantsTemplate and self.variantList[#self.variantList] ~= "Current" then
+					t_insert(rawLines, "Selected Alt Variant" .. AltVariant[2] .. " Name: " .. self.variantList[self["variantAlt" .. AltVariant[1]]])
+				end
+			else
+				break
+			end
 		end
 	end
 	if self.quality then

--- a/src/Classes/ItemListControl.lua
+++ b/src/Classes/ItemListControl.lua
@@ -193,7 +193,7 @@ end
 
 function ItemListClass:OnSelCopy(index, itemId)
 	local item = self.itemsTab.items[itemId]
-	Copy(item:BuildRaw():gsub("\n", "\r\n"))
+	Copy(item:BuildRaw(true):gsub("\n", "\r\n"))
 end
 
 function ItemListClass:OnSelDelete(index, itemId)

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -971,31 +971,6 @@ function ItemsTabClass:Save(xml)
 		}
 		item:BuildAndParseRaw(true)
 		t_insert(child, item.raw)
-		local id = #item.buffModLines + 1
-		for _, modLine in ipairs(item.enchantModLines) do
-			if modLine.range then
-				t_insert(child, { elem = "ModRange", attrib = { id = tostring(id), range = tostring(modLine.range) } })
-			end
-			id = id + 1
-		end
-		for _, modLine in ipairs(item.scourgeModLines) do
-			if modLine.range then
-				t_insert(child, { elem = "ModRange", attrib = { id = tostring(id), range = tostring(modLine.range) } })
-			end
-			id = id + 1
-		end
-		for _, modLine in ipairs(item.implicitModLines) do
-			if modLine.range then
-				t_insert(child, { elem = "ModRange", attrib = { id = tostring(id), range = tostring(modLine.range) } })
-			end
-			id = id + 1
-		end
-		for _, modLine in ipairs(item.explicitModLines) do
-			if modLine.range then
-				t_insert(child, { elem = "ModRange", attrib = { id = tostring(id), range = tostring(modLine.range) } })
-			end
-			id = id + 1
-		end
 		t_insert(xml, child)
 	end
 	for _, itemSetId in ipairs(self.itemSetOrderList) do

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -969,7 +969,7 @@ function ItemsTabClass:Save(xml)
 				variantAlt5 = item.variantAlt5 and tostring(item.variantAlt5)
 			} 
 		}
-		item:BuildAndParseRaw()
+		item:BuildAndParseRaw(true)
 		t_insert(child, item.raw)
 		local id = #item.buffModLines + 1
 		for _, modLine in ipairs(item.enchantModLines) do


### PR DESCRIPTION
This culls an item so that the list of variants, as well as any mods with unused variants with unmodified ranges are not saved in the item raw

This cuts down the storage of these items, particularly things like watchers eyes and forbidden jewels, and makes it much easier to copy/paste them in places with limited text space

an example of a culled item:

> Rarity: UNIQUE
> Watcher's Eye
> Prismatic Jewel
> Variant: RebuildCulledVariants
> Selected Variant: 86
> Selected Variant Name: Vitality: Life Recovery Rate
> Selected Variant Last Legacy Variant: Vitality: Life Recovery Rate (Pre 3.12.0)
> Prismatic Jewel
> Has Alt Variant: true
> Selected Alt Variant: 86
> Selected Alt Variant Name: Vitality: Life Recovery Rate
> Selected Alt Variant Last Legacy Variant: Vitality: Life Recovery Rate (Pre 3.12.0)
> Has Alt Variant Two: true
> Selected Alt Variant Two: 101
> Selected Alt Variant Two Name: Zealotry: Maximum ES Per Second To Maximum ES Leech Rate
> Selected Alt Variant Two Last Legacy Variant: Zealotry: Maximum ES Per Second To Maximum ES Leech Rate
> Limited to: 1
> Implicits: 0
> {range:0.5}(4-6)% increased maximum Energy Shield
> {range:0.5}(4-6)% increased maximum Life
> {range:0.5}(4-6)% increased maximum Mana
> {variant:86}{range:0.5}(10-15)% increased Life Recovery Rate while affected by Vitality
> {variant:101}30% increased Maximum total Energy Shield Recovery per second from Leech while affected by Zealotry

This will not cull an item if any of the mods have been modified as it causes complications when reconstructing the item, and also updates the item if the unique gets updated with new variants
such that if its a generated unique it will find variants with the same name (if it can) and set the variant number to that, and if a new legacy version of a used variant is introduced it will set the variant to that instead