### PR TITLE
Variant Improvements

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -304,73 +304,23 @@ holding Shift will put it in the second.]])
 		if not self.controls.displayItemVariant:IsShown() then
 			return 0
 		end
-		return (28 + 
-		(self.displayItem.hasAltVariant and 24 or 0) + 
-		(self.displayItem.hasAltVariant2 and 24 or 0) + 
-		(self.displayItem.hasAltVariant3 and 24 or 0) +
-		(self.displayItem.hasAltVariant4 and 24 or 0) + 
-		(self.displayItem.hasAltVariant5 and 24 or 0))
+		local val = 4
+		for _, variant in pairs(self.displayItem.variantList) do
+			val = val + 24
+		end
+		return val 
 	end)
 	self.controls.displayItemVariant = new("DropDownControl", {"TOPLEFT", self.controls.displayItemSectionVariant,"TOPLEFT"}, 0, 0, 300, 20, nil, function(index, value)
-		self.displayItem.variant = index
+		self.displayItem.variantList.Base.value = index
 		self.displayItem:BuildAndParseRaw()
 		self:UpdateDisplayItemTooltip()
 		self:UpdateDisplayItemRangeLines()
 	end)
 	self.controls.displayItemVariant.maxDroppedWidth = 1000
 	self.controls.displayItemVariant.shown = function()
-		return self.displayItem.variantList and #self.displayItem.variantList > 1
+		return self.displayItem.variantNameList and #self.displayItem.variantNameList > 1
 	end
-	self.controls.displayItemAltVariant = new("DropDownControl", {"TOPLEFT",self.controls.displayItemVariant,"BOTTOMLEFT"}, 0, 4, 300, 20, nil, function(index, value)
-		self.displayItem.variantAlt = index
-		self.displayItem:BuildAndParseRaw()
-		self:UpdateDisplayItemTooltip()
-		self:UpdateDisplayItemRangeLines()
-	end)
-	self.controls.displayItemAltVariant.maxDroppedWidth = 1000
-	self.controls.displayItemAltVariant.shown = function()
-		return self.displayItem.hasAltVariant
-	end
-	self.controls.displayItemAltVariant2 = new("DropDownControl", {"TOPLEFT",self.controls.displayItemAltVariant,"BOTTOMLEFT"}, 0, 4, 300, 20, nil, function(index, value)
-		self.displayItem.variantAlt2 = index
-		self.displayItem:BuildAndParseRaw()
-		self:UpdateDisplayItemTooltip()
-		self:UpdateDisplayItemRangeLines()
-	end)
-	self.controls.displayItemAltVariant2.maxDroppedWidth = 1000
-	self.controls.displayItemAltVariant2.shown = function()
-		return self.displayItem.hasAltVariant2
-	end
-	self.controls.displayItemAltVariant3 = new("DropDownControl", {"TOPLEFT",self.controls.displayItemAltVariant2,"BOTTOMLEFT"}, 0, 4, 300, 20, nil, function(index, value)
-		self.displayItem.variantAlt3 = index
-		self.displayItem:BuildAndParseRaw()
-		self:UpdateDisplayItemTooltip()
-		self:UpdateDisplayItemRangeLines()
-	end)
-	self.controls.displayItemAltVariant3.maxDroppedWidth = 1000
-	self.controls.displayItemAltVariant3.shown = function()
-		return self.displayItem.hasAltVariant3
-	end
-	self.controls.displayItemAltVariant4 = new("DropDownControl", {"TOPLEFT",self.controls.displayItemAltVariant3,"BOTTOMLEFT"}, 0, 4, 300, 20, nil, function(index, value)
-		self.displayItem.variantAlt4 = index
-		self.displayItem:BuildAndParseRaw()
-		self:UpdateDisplayItemTooltip()
-		self:UpdateDisplayItemRangeLines()
-	end)
-	self.controls.displayItemAltVariant4.maxDroppedWidth = 1000
-	self.controls.displayItemAltVariant4.shown = function()
-		return self.displayItem.hasAltVariant4
-	end
-	self.controls.displayItemAltVariant5 = new("DropDownControl", {"TOPLEFT",self.controls.displayItemAltVariant4,"BOTTOMLEFT"}, 0, 4, 300, 20, nil, function(index, value)
-		self.displayItem.variantAlt5 = index
-		self.displayItem:BuildAndParseRaw()
-		self:UpdateDisplayItemTooltip()
-		self:UpdateDisplayItemRangeLines()
-	end)
-	self.controls.displayItemAltVariant5.maxDroppedWidth = 1000
-	self.controls.displayItemAltVariant5.shown = function()
-		return self.displayItem.hasAltVariant5
-	end
+	self.controls.displayItemVariant.variantControls = {}
 
 	-- Section: Sockets and Links
 	self.controls.displayItemSectionSockets = new("Control", {"TOPLEFT",self.controls.displayItemSectionVariant,"BOTTOMLEFT"}, 0, 0, 0, function()
@@ -866,27 +816,6 @@ function ItemsTabClass:Load(xml, dbFileName)
 		if node.elem == "Item" then
 			local item = new("Item", "")
 			item.id = tonumber(node.attrib.id)
-			item.variant = tonumber(node.attrib.variant)
-			if node.attrib.variantAlt then
-				item.hasAltVariant = true
-				item.variantAlt = tonumber(node.attrib.variantAlt)
-			end
-			if node.attrib.variantAlt2 then
-				item.hasAltVariant2 = true
-				item.variantAlt2 = tonumber(node.attrib.variantAlt2)
-			end
-			if node.attrib.variantAlt3 then
-				item.hasAltVariant3 = true
-				item.variantAlt3 = tonumber(node.attrib.variantAlt3)
-			end
-			if node.attrib.variantAlt4 then
-				item.hasAltVariant4 = true
-				item.variantAlt4 = tonumber(node.attrib.variantAlt4)
-			end
-			if node.attrib.variantAlt5 then
-				item.hasAltVariant5 = true
-				item.variantAlt5 = tonumber(node.attrib.variantAlt5)
-			end
 			for _, child in ipairs(node) do
 				if type(child) == "string" then
 					item:ParseRaw(child)
@@ -961,12 +890,6 @@ function ItemsTabClass:Save(xml)
 			elem = "Item", 
 			attrib = { 
 				id = tostring(id), 
-				variant = item.variant and tostring(item.variant), 
-				variantAlt = item.variantAlt and tostring(item.variantAlt), 
-				variantAlt2 = item.variantAlt2 and tostring(item.variantAlt2),
-				variantAlt3 = item.variantAlt3 and tostring(item.variantAlt3), 
-				variantAlt4 = item.variantAlt4 and tostring(item.variantAlt4), 
-				variantAlt5 = item.variantAlt5 and tostring(item.variantAlt5)
 			} 
 		}
 		item:BuildAndParseRaw()
@@ -1408,33 +1331,32 @@ function ItemsTabClass:SetDisplayItem(item)
 		self:UpdateDisplayItemTooltip()
 		self.snapHScroll = "RIGHT"
 
-		self.controls.displayItemVariant.list = item.variantList
-		self.controls.displayItemVariant.selIndex = item.variant
+		self.controls.displayItemVariant.list = item.variantList.Base.list or item.variantNameList
+		self.controls.displayItemVariant.selIndex = item.variantList.Base.value
 		self.controls.displayItemVariant:CheckDroppedWidth(true)
-		if item.hasAltVariant then
-			self.controls.displayItemAltVariant.list = item.variantList
-			self.controls.displayItemAltVariant.selIndex = item.variantAlt
-			self.controls.displayItemAltVariant:CheckDroppedWidth(true)
+		for variantControlName, variantControl in pairs(self.controls.displayItemVariant.variantControls) do
+			variantControl.shown = false
 		end
-		if item.hasAltVariant2 then
-			self.controls.displayItemAltVariant2.list = item.variantList
-			self.controls.displayItemAltVariant2.selIndex = item.variantAlt2
-			self.controls.displayItemAltVariant2:CheckDroppedWidth(true)
-		end
-		if item.hasAltVariant3 then
-			self.controls.displayItemAltVariant3.list = item.variantList
-			self.controls.displayItemAltVariant3.selIndex = item.variantAlt3
-			self.controls.displayItemAltVariant3:CheckDroppedWidth(true)
-		end
-		if item.hasAltVariant4 then
-			self.controls.displayItemAltVariant4.list = item.variantList
-			self.controls.displayItemAltVariant4.selIndex = item.variantAlt4
-			self.controls.displayItemAltVariant4:CheckDroppedWidth(true)
-		end
-		if item.hasAltVariant5 then
-			self.controls.displayItemAltVariant5.list = item.variantList
-			self.controls.displayItemAltVariant5.selIndex = item.variantAlt5
-			self.controls.displayItemAltVariant5:CheckDroppedWidth(true)
+		self.controls.displayItemVariant.lastControl = self.controls.displayItemVariant
+		for variantName, variant in pairs(item.variantList) do
+			if variantName ~= "Base" then
+				local list = variant.list or item.variantNameList
+				if not self.controls["displayItemAltVariant"..variantName] or self.controls["displayItemAltVariant"..variantName].list ~= list then
+					self.controls["displayItemAltVariant"..variantName] = new("DropDownControl", {"TOPLEFT",self.controls.displayItemVariant.lastControl,"BOTTOMLEFT"}, 0, 4, 300, 20, list, function(index, value)
+						self.displayItem.variantList[variantName].value = index + (variant.range and (variant.range[1] - 1) or 0)
+						self.displayItem:BuildAndParseRaw()
+						self:UpdateDisplayItemTooltip()
+						self:UpdateDisplayItemRangeLines()
+					end)
+					self.controls["displayItemAltVariant"..variantName].maxDroppedWidth = 1000
+					self.controls.displayItemVariant.variantControls["displayItemAltVariant"..variantName] = self.controls["displayItemAltVariant"..variantName]
+				else
+					self.controls["displayItemAltVariant"..variantName].shown = true
+				end
+				self.controls.displayItemVariant.lastControl = self.controls["displayItemAltVariant"..variantName]
+				self.controls["displayItemAltVariant"..variantName].selIndex = variant.value - (variant.range and (variant.range[1] - 1) or 0)
+				self.controls["displayItemAltVariant"..variantName]:CheckDroppedWidth(true)
+			end
 		end
 		self:UpdateSocketControls()
 		if item.crafted then
@@ -2824,11 +2746,11 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 
 	-- Special fields for database items
 	if dbMode then
-		if item.variantList then
-			if #item.variantList == 1 then
-				tooltip:AddLine(16, "^xFFFF30Variant: "..item.variantList[1])
+		if item.variantNameList then
+			if #item.variantNameList == 1 then
+				tooltip:AddLine(16, "^xFFFF30Variant: "..item.variantNameList[1])
 			else
-				tooltip:AddLine(16, "^xFFFF30Variant: "..item.variantList[item.variant].." ("..#item.variantList.." variants)")
+				tooltip:AddLine(16, "^xFFFF30Variant: "..item.variantNameList[item.variantList.Base.value].." ("..#item.variantNameList.." variants)")
 			end
 		end
 		if item.league then

--- a/src/Classes/TimelessJewelListControl.lua
+++ b/src/Classes/TimelessJewelListControl.lua
@@ -180,8 +180,8 @@ Timeless Jewel
 League: Legion
 Requires Level: 20
 Limited to: 1
-Has Alt Variant: true
-Has Alt Variant Two: true
+Has Alt Variant: (5,19)
+Has Alt Variant Two: (5,19)
 Variant: Avarius (Power of Purpose)
 Variant: Dominus (Inner Conviction)
 Variant: Maxarius (Transcendence)

--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -52,26 +52,29 @@ local getVeiledMods = function (veiledPool, baseType, specificType1, specificTyp
 end
 
 local paradoxicaMods = getVeiledMods("base", "weapon", "one_hand_weapon")
+local paradoxicaPrefixLength = 1
+for index, mod in pairs(paradoxicaMods) do
+	if (mod.veiledName:match("%(Prefix%) "))then
+		paradoxicaPrefixLength = paradoxicaPrefixLength + 1 
+	elseif (mod.veiledName == "(Suffix) Double Damage Chance") then
+		table.remove(paradoxicaMods, index)
+	end
+end
+
 local paradoxica = {
 	"Paradoxica",
 	"Vaal Rapier",
 	"League: Betrayal",
-	"Source: Drops from unique{Intervention Leaders} in normal{Safehouses}",
-	"Has Alt Variant: true",
-	"Selected Variant: 4",
-	"Selected Alt Variant: 16"
+	"Source: Drops from unique{Intervention Leaders} in normal{Safehouses}"
 }
-
-for index, mod in pairs(paradoxicaMods) do
-	if (mod.veiledName == "(Suffix) Double Damage Chance") then
-		table.remove(paradoxicaMods, index)
-	end
-end
 
 for index, mod in pairs(paradoxicaMods) do
 	table.insert(paradoxica, "Variant: "..mod.veiledName)
 end
 
+table.insert(paradoxica, "Selected Variant: 4")
+table.insert(paradoxica, "Has Alt Variant: ("..tostring(paradoxicaPrefixLength)..","..tostring(#paradoxicaMods)..")")
+table.insert(paradoxica, "Selected Alt Variant: 16")
 table.insert(paradoxica, "Requires Level 66, 212 Dex")
 table.insert(paradoxica, "Implicits: 1")
 table.insert(paradoxica, "+25% to Global Critical Strike Multiplier")
@@ -86,20 +89,25 @@ table.insert(paradoxica, "Attacks with this Weapon deal Double Damage")
 table.insert(data.uniques.generated, table.concat(paradoxica, "\n"))
 
 local caneOfKulemakMods = getVeiledMods("catarina", "weapon", "staff", "two_hand_weapon")
+local caneOfKulemakPrefixLength = 0
+for index, mod in pairs(caneOfKulemakMods) do
+	if (mod.veiledName:match("%(Prefix%) "))then
+		caneOfKulemakPrefixLength = caneOfKulemakPrefixLength + 1 
+	end
+end
 local caneOfKulemak = {
 	"Cane of Kulemak",
 	"Serpentine Staff",
-	"Source: Drops from unique{Catarina, Master of Undeath}",
-	"Has Alt Variant: true",
-	"Has Alt Variant Two: true",
-	"Selected Variant: 1",
-	"Selected Alt Variant: 20"
+	"Source: Drops from unique{Catarina, Master of Undeath}"
 }
-
 for index, mod in pairs(caneOfKulemakMods) do
 	table.insert(caneOfKulemak, "Variant: "..mod.veiledName)
 end
 
+table.insert(caneOfKulemak, "Selected Variant: 20")
+table.insert(caneOfKulemak, "Has Alt Variant: (1,"..tostring(caneOfKulemakPrefixLength)..")")
+table.insert(caneOfKulemak, "Selected Alt Variant: 1")
+table.insert(caneOfKulemak, "Has Alt Variant Two: ("..tostring(caneOfKulemakPrefixLength + 1)..","..#caneOfKulemakMods..")")
 table.insert(caneOfKulemak, "Requires Level 68, 85 Str, 85 Int")
 table.insert(caneOfKulemak, "Implicits: 1")
 table.insert(caneOfKulemak, "+20% Chance to Block Attack Damage while wielding a Staff")
@@ -119,16 +127,16 @@ local replicaParadoxica = {
 	"Vaal Rapier",
 	"League: Heist",
 	"Source: Steal from a unique{Curio Display} during a Grand Heist",
-	"Has Alt Variant: true",
-	"Has Alt Variant Two: true",
-	"Has Alt Variant Three: true",
-	"Has Alt Variant Four: true",
-	"Has Alt Variant Five: true",
 	"Selected Variant: 1",
+	"Has Alt Variant: true",
 	"Selected Alt Variant: 2",
+	"Has Alt Variant Two: true",
 	"Selected Alt Variant Two: 3",
+	"Has Alt Variant Three: true",
 	"Selected Alt Variant Three: 25",
+	"Has Alt Variant Four: true",
 	"Selected Alt Variant Four: 27",
+	"Has Alt Variant Five: true",
 	"Selected Alt Variant Five: 34"
 }
 
@@ -149,20 +157,27 @@ end
 table.insert(data.uniques.generated, table.concat(replicaParadoxica, "\n"))
 
 local queensHungerMods = getVeiledMods("base", "body_armour", "int_armour")
+local queensHungerPrefixLength = 1
+for index, mod in pairs(queensHungerMods) do
+	if (mod.veiledName:match("%(Prefix%) "))then
+		queensHungerPrefixLength = queensHungerPrefixLength + 1 
+	end
+end
 local queensHunger = {
 	"The Queen's Hunger",
 	"Vaal Regalia",
 	"League: Betrayal",
-	"Source: Drops from unique{Catarina, Master of Undeath}",
-	"Has Alt Variant: true",
-	"Selected Variant: 1",
-	"Selected Alt Variant: 24"
+	"Source: Drops from unique{Catarina, Master of Undeath}"
 }
 
 for index, mod in pairs(queensHungerMods) do
 	table.insert(queensHunger, "Variant: "..mod.veiledName)
 end
 
+
+table.insert(queensHunger, "Selected Variant: 1")
+table.insert(queensHunger, "Has Alt Variant: ("..tostring(queensHungerPrefixLength)..","..tostring(#queensHungerMods)..")")
+table.insert(queensHunger, "Selected Alt Variant: 24")
 table.insert(queensHunger, "Requires Level 68, 194 Int")
 table.insert(queensHunger, "Trigger Level 20 Bone Offering, Flesh Offering or Spirit Offering every 5 seconds")
 table.insert(queensHunger, "Offering Skills Triggered this way also affect you")
@@ -351,6 +366,7 @@ Variant: Two-Stone Ring (Fire/Cold)
 Variant: Prismatic Ring]]
 }
 
+local precursorsEmblemTotalMods = 7 * 3 * 2 + 5 * 3
 for _, type in ipairs({ { prefix = "Endurance - ", mods = enduranceChargeMods }, { prefix = "Frenzy - ", mods = frenzyChargeMods }, { prefix = "Power - ", mods = powerChargeMods } }) do
 	for tier, mods in ipairs(type.mods) do
 		for desc, mod in pairs(mods) do
@@ -358,11 +374,11 @@ for _, type in ipairs({ { prefix = "Endurance - ", mods = enduranceChargeMods },
 		end
 	end
 end
-table.insert(precursorsEmblem, [[Selected Variant: 1
-Has Alt Variant: true
-Has Alt Variant Two: true
-Has Alt Variant Three: true
-LevelReq: 49
+table.insert(precursorsEmblem, "Selected Variant: 1")
+table.insert(precursorsEmblem, "Has Alt Variant: (8,"..tostring(precursorsEmblemTotalMods + 8)..")")
+table.insert(precursorsEmblem, "Has Alt Variant Two: (8,"..tostring(precursorsEmblemTotalMods + 8)..")")
+table.insert(precursorsEmblem, "Has Alt Variant Three: (8,"..tostring(precursorsEmblemTotalMods + 8)..")")
+table.insert(precursorsEmblem, [[LevelReq: 49
 Implicits: 7
 {tags:jewellery_resistance}{variant:1}+(20-30)% to Lightning Resistance
 {tags:jewellery_resistance}{variant:2}+(20-30)% to Cold Resistance

--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -1736,8 +1736,8 @@ League: Legion
 Source: Drops from Templar Legion
 Requires Level: 20
 Limited to: 1 Historic
-Has Alt Variant: true
-Has Alt Variant Two: true
+Has Alt Variant: (5,19)
+Has Alt Variant Two: (5,19)
 Selected Variant: 1
 Variant: Avarius (Power of Purpose)
 Variant: Dominus (Inner Conviction)


### PR DESCRIPTION
This modifies Variants a lot, so testing needs to be setup, though I could not find issues with my limited testing

Alt Variant names can now be almost arbitrary and you can have arbitrarily as many as you want
eg 
![image](https://user-images.githubusercontent.com/49933620/218449916-6d765e94-7926-4e67-af10-628831f7bf35.png)

This also lets you set a range for variants
eg precursor
![image](https://user-images.githubusercontent.com/49933620/218450073-c41836cc-8f64-4903-8bec-21f7cbd26c55.png)
only lets you pick the base for the first dropdown, and does not let you pick base for any other dropdown

paradoxica has one dropdown for prefixes, and one for suffixes
Cane of Kulemak has one for either prefix or suffix, one for only prefixes and one for only suffixes
Militant faith has one for selecting keystone and 2 for other mods
and a few others have been modified as well

I will likely add more modifications to this, some planned modifications are;
1) variant influences (for Impresence drop from Uber Uber Elder)
2) variant level requirements

possibly) variant variants (eg for watchers eye, if you pick a variant that enables a legacy mod then it activates a new variant dropdown to let you select between the current and any legacy variants of said mod)