### PR TITLE
Prevent irrelant tags on secondaryEffect gems and support gems being saved to xml

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -1137,7 +1137,7 @@ function SkillsTabClass:ProcessSocketGroup(socketGroup)
 				gemInstance.reqInt = calcLib.getGemStatRequirement(gemInstance.reqLevel, grantedEffect.support, gemInstance.gemData.reqInt)
 			end
 		end
-		if gemInstance.gemData.tags.support then -- delete active skill stats as they get left behind on supports.
+		if gemInstance.gemData and gemInstance.gemData.tags.support then -- delete active skill stats as they get left behind on supports.
 			gemInstance.skillMinionCalcs = nil
 			gemInstance.skillMinion = nil
 			gemInstance.skillMinionItemSetCalcs = nil

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -1137,6 +1137,20 @@ function SkillsTabClass:ProcessSocketGroup(socketGroup)
 				gemInstance.reqInt = calcLib.getGemStatRequirement(gemInstance.reqLevel, grantedEffect.support, gemInstance.gemData.reqInt)
 			end
 		end
+		if gemInstance.gemData.tags.support then -- delete active skill stats as they get left behind on supports.
+			gemInstance.skillMinionCalcs = nil
+			gemInstance.skillMinion = nil
+			gemInstance.skillMinionItemSetCalcs = nil
+			gemInstance.skillMinionItemSet = nil
+			gemInstance.skillMinionSkill = nil
+			gemInstance.skillMinionSkillCalcs = nil
+			gemInstance.skillStageCountCalcs = nil
+			gemInstance.skillStageCount = nil
+			gemInstance.skillMineCountCalcs = nil
+			gemInstance.skillMineCount = nil
+			gemInstance.skillPart = nil
+			gemInstance.skillPartCalcs = nil
+		end
 	end
 end
 

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -242,7 +242,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 		end
 		activeSkill.skillPartName = part.name
 		skillFlags.multiPart = #activeGemParts > 1
-	elseif activeEffect.srcInstance and not (activeEffect.gemData and activeEffect.gemData.secondaryGrantedEffect) then
+	elseif activeEffect.srcInstance and not (activeEffect.gemData and activeEffect.gemData.secondaryGrantedEffect and activeEffect.gemData.secondaryGrantedEffect.parts and #activeEffect.gemData.secondaryGrantedEffect.parts > 1) then
 		activeEffect.srcInstance.skillPart = nil
 		activeEffect.srcInstance.skillPartCalcs = nil
 	end
@@ -537,7 +537,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 			skillModList:NewMod("Multiplier:ActiveMineCount", "BASE", activeSkill.activeMineCount, "Base")
 			env.enemy.modDB.multipliers["ActiveMineCount"] = m_max(activeSkill.activeMineCount or 0, env.enemy.modDB.multipliers["ActiveMineCount"] or 0)
 		end
-	elseif activeEffect.srcInstance and not (activeEffect.gemData and activeEffect.gemData.secondaryGrantedEffect) then
+	elseif activeEffect.srcInstance and not (activeEffect.gemData and activeEffect.gemData.secondaryGrantedEffect and activeEffect.gemData.secondaryGrantedEffect.tags and activeEffect.gemData.secondaryGrantedEffect.tags.mine) then
 		activeEffect.srcInstance.skillMineCountCalcs = nil
 		activeEffect.srcInstance.skillMineCount = nil
 	end
@@ -639,7 +639,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 					end
 					minion.itemSet = env.build.itemsTab.itemSets[activeEffect.srcInstance.skillMinionItemSet]
 				end
-			elseif activeEffect.srcInstance and not (activeEffect.gemData and activeEffect.gemData.secondaryGrantedEffect) then
+			elseif activeEffect.srcInstance and not (activeEffect.gemData and activeEffect.gemData.secondaryGrantedEffect and activeEffect.gemData.secondaryGrantedEffect.minionHasItemSet) then
 				activeEffect.srcInstance.skillMinionItemSetCalcs = nil
 				activeEffect.srcInstance.skillMinionItemSet = nil
 			end
@@ -681,7 +681,7 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 				end
 			end
 		end
-	elseif activeEffect.srcInstance and not (activeEffect.gemData and activeEffect.gemData.secondaryGrantedEffect) then
+	elseif activeEffect.srcInstance and not (activeEffect.gemData and activeEffect.gemData.secondaryGrantedEffect and activeEffect.gemData.secondaryGrantedEffect.skillTypes and activeEffect.gemData.secondaryGrantedEffect.skillTypes[SkillType.Minion]) then
 		activeEffect.srcInstance.skillMinionCalcs = nil
 		activeEffect.srcInstance.skillMinion = nil
 		activeEffect.srcInstance.skillMinionItemSetCalcs = nil


### PR DESCRIPTION
### Description of the problem being solved:
This fixes minion stuff not being deletable off non minion skill w/ secondary stuff (mostly vaal) and similar.
Fixes replacing an active skill with a support leeching stats.

Still seems to be a few lingering problems.
1. The above fix wasn't done for stages as they are handled with a cfg and wasn't sure how to easily make one for secondary Effect this means if there is a support that adds stages vaal gems could see this tag leeching or something similar.
2. Disabling a support gem seem to still let the flags to get saved to the xml but updating any of the calculations remedies this so might not be rebuilding when it should. Calc active skill not called? As updating anything seems to fix it. Inconsistent as well.
4. Disabled skills do not seem to get rebuild and so tags remain in xml.