### PR TITLE
Damage over time explode

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -225,6 +225,13 @@ which comes from the following sources:]]
 				label = label .. "\n\t" .. colorCodes[source.rarity or "NORMAL"] .. (source.name or source.dn or "???")
 			end
 			label = label .. "^7\nYou cannot delete this group, but it will disappear if you lose the above sources."
+		elseif self.displayGroup.totemExplodeSources then
+			label = [[^7This is a special group created for the totem explosion effect,
+which comes from the following sources:]]
+			for _, source in ipairs(self.displayGroup.totemExplodeSources) do
+				label = label .. "\n\t" .. colorCodes[source.rarity or "NORMAL"] .. (source.name or source.dn or "???")
+			end
+			label = label .. "^7\nYou cannot delete this group, but it will disappear if you lose the above sources."
 		else
 			local activeGem = self.displayGroup.gemList[1]
 			local sourceName
@@ -1155,6 +1162,12 @@ end
 function SkillsTabClass:AddSocketGroupTooltip(tooltip, socketGroup)
 	if socketGroup.explodeSources then
 		for _, source in ipairs(socketGroup.explodeSources) do
+			tooltip:AddLine(18, "^7Source: " .. colorCodes[source.rarity or "NORMAL"] .. (source.name or source.dn or "???"))
+		end
+		return
+	end
+	if socketGroup.totemExplodeSources then
+		for _, source in ipairs(socketGroup.totemExplodeSources) do
 			tooltip:AddLine(18, "^7Source: " .. colorCodes[source.rarity or "NORMAL"] .. (source.name or source.dn or "???"))
 		end
 		return

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -228,8 +228,15 @@ which comes from the following sources:]]
 		elseif self.displayGroup.totemExplodeSources then
 			label = [[^7This is a special group created for the totem explosion effect,
 which comes from the following sources:]]
+			local types = { count = 0 }
 			for _, source in ipairs(self.displayGroup.totemExplodeSources) do
-				label = label .. "\n\t" .. colorCodes[source.rarity or "NORMAL"] .. (source.name or source.dn or "???")
+				if not types[source.type] then
+					types[source.type] = true
+					types.count = types.count + 1
+				end
+			end
+			for _, source in ipairs(self.displayGroup.totemExplodeSources) do
+				label = label .. "\n\t" .. colorCodes[source.source.rarity or "NORMAL"] .. (source.source.name or source.source.dn or "???") .. ((types.count > 1) and ("^7, of type: " .. source.type) or "")
 			end
 			label = label .. "^7\nYou cannot delete this group, but it will disappear if you lose the above sources."
 		else
@@ -1168,7 +1175,7 @@ function SkillsTabClass:AddSocketGroupTooltip(tooltip, socketGroup)
 	end
 	if socketGroup.totemExplodeSources then
 		for _, source in ipairs(socketGroup.totemExplodeSources) do
-			tooltip:AddLine(18, "^7Source: " .. colorCodes[source.rarity or "NORMAL"] .. (source.name or source.dn or "???"))
+			tooltip:AddLine(18, "^7Source: " .. colorCodes[source.source.rarity or "NORMAL"] .. (source.source.name or source.source.dn or "???"))
 		end
 		return
 	end

--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -3456,21 +3456,12 @@ skills["TotemExplode"] = {
 		local typeAmounts = { }
 		local explodeModList = activeSkill.skillModList:List(activeSkill.skillCfg, "TotemExplodeMod")
 		for _, explodeMod in ipairs(explodeModList) do
-			local amounts = typeAmounts[explodeMod.type] or {}
-			amounts[explodeMod.amount] = true
-			typeAmounts[explodeMod.type] = amounts
-		end
-		for type, amounts in pairs(typeAmounts) do
-			local physExplodeChance = 100
-			for amount, _ in pairs(amounts) do
-				local amountXChance = amount
-				if type == "RandomElement" then
-					activeSkill.skillData["FireEffectiveExplodePercentage"] = (activeSkill.skillData["FireEffectiveExplodePercentage"] or 0) + amountXChance / 3
-					activeSkill.skillData["ColdEffectiveExplodePercentage"] = (activeSkill.skillData["ColdEffectiveExplodePercentage"] or 0) + amountXChance / 3
-					activeSkill.skillData["LightningEffectiveExplodePercentage"] = (activeSkill.skillData["LightningEffectiveExplodePercentage"] or 0) + amountXChance / 3
-				else
-					activeSkill.skillData[type.."EffectiveExplodePercentage"] = (activeSkill.skillData[type.."EffectiveExplodePercentage"] or 0) + amountXChance
-				end
+			if explodeMod.type == "RandomElement" then
+				activeSkill.skillData["FireEffectiveExplodePercentage"] = (activeSkill.skillData["FireEffectiveExplodePercentage"] or 0) + explodeMod.amount / 3
+				activeSkill.skillData["ColdEffectiveExplodePercentage"] = (activeSkill.skillData["ColdEffectiveExplodePercentage"] or 0) + explodeMod.amount / 3
+				activeSkill.skillData["LightningEffectiveExplodePercentage"] = (activeSkill.skillData["LightningEffectiveExplodePercentage"] or 0) + explodeMod.amount / 3
+			else
+				activeSkill.skillData[explodeMod.type.."EffectiveExplodePercentage"] = (activeSkill.skillData[explodeMod.type.."EffectiveExplodePercentage"] or 0) + explodeMod.amount
 			end
 		end
 	end,

--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -3444,3 +3444,52 @@ skills["EnemyExplode"] = {
 		[1] = { damageEffectiveness = 0, baseMultiplier = 1, levelRequirement = 1, }
 	}
 }
+
+skills["TotemExplode"] = {
+	name = "On Death Totem Explosion",
+	hidden = true,
+	color = 4,
+	skillTypes = { [SkillType.Damage] = true, [SkillType.Area] = true },
+	castTime = 1,
+	preDamageFunc = function(activeSkill, output)
+		local typeAmounts = { }
+		local explodeModList = activeSkill.skillModList:List(activeSkill.skillCfg, "TotemExplodeMod")
+		for _, explodeMod in ipairs(explodeModList) do
+			local amounts = typeAmounts[explodeMod.type] or {}
+			amounts[explodeMod.amount] = true
+			typeAmounts[explodeMod.type] = amounts
+		end
+		for type, amounts in pairs(typeAmounts) do
+			local physExplodeChance = 100
+			for amount, _ in pairs(amounts) do
+				local amountXChance = amount
+				if type == "RandomElement" then
+					activeSkill.skillData["FireEffectiveExplodePercentage"] = (activeSkill.skillData["FireEffectiveExplodePercentage"] or 0) + amountXChance / 3
+					activeSkill.skillData["ColdEffectiveExplodePercentage"] = (activeSkill.skillData["ColdEffectiveExplodePercentage"] or 0) + amountXChance / 3
+					activeSkill.skillData["LightningEffectiveExplodePercentage"] = (activeSkill.skillData["LightningEffectiveExplodePercentage"] or 0) + amountXChance / 3
+				else
+					activeSkill.skillData[type.."EffectiveExplodePercentage"] = (activeSkill.skillData[type.."EffectiveExplodePercentage"] or 0) + amountXChance
+				end
+			end
+		end
+	end,
+	baseMods = {
+		skill("radius", 22),
+		skill("showAverage", true),
+		skill("explodeCorpse", true),
+		skill("corpseExplosionLifeMultiplier", 0),
+	},
+	baseFlags = {
+		area = true,
+		totemExplode = true
+	},
+	stats = {
+		"is_area_damage",
+		"display_skill_deals_secondary_damage",
+		"damage_cannot_be_reflected",
+		"skill_can_add_multiple_charges_per_action",
+	},
+	levels = {
+		[1] = { damageEffectiveness = 0, baseMultiplier = 1, levelRequirement = 1, }
+	}
+}

--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -3452,6 +3452,7 @@ skills["TotemExplode"] = {
 	skillTypes = { [SkillType.Damage] = true, [SkillType.Area] = true },
 	castTime = 1,
 	preDamageFunc = function(activeSkill, output)
+		activeSkill.skillData.hitTimeOverride = 1
 		local typeAmounts = { }
 		local explodeModList = activeSkill.skillModList:List(activeSkill.skillCfg, "TotemExplodeMod")
 		for _, explodeMod in ipairs(explodeModList) do

--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -3417,6 +3417,7 @@ skills["EnemyExplode"] = {
 			for type, amountChance in pairs(typeAmountChances) do
 				local physExplodeChance = 0
 				for amount, chance in pairs(amountChance) do
+					chance = math.min(chance, 1)
 					local amountXChance = amount * chance
 					if type == "RandomElement" then
 						activeSkill.skillData["FireEffectiveExplodePercentage"] = (activeSkill.skillData["FireEffectiveExplodePercentage"] or 0) + amountXChance / 3
@@ -3444,15 +3445,14 @@ skills["EnemyExplode"] = {
 			end
 			for type, amountChance in pairs(typeAmountChances) do
 				for amount, chance in pairs(amountChance) do
-					local amountXChance = amount * chance
 					if type == "RandomElement" then
-						activeSkill.skillData["FireDotEffectiveExplodePercentage"] = (activeSkill.skillData["FireDotEffectiveExplodePercentage"] or 0) + amountXChance / 3
-						activeSkill.skillData["ColdDotEffectiveExplodePercentage"] = (activeSkill.skillData["ColdDotEffectiveExplodePercentage"] or 0) + amountXChance / 3
-						activeSkill.skillData["LightningDotEffectiveExplodePercentage"] = (activeSkill.skillData["LightningDotEffectiveExplodePercentage"] or 0) + amountXChance / 3
+						activeSkill.skillData["FireDotEffectiveExplodePercentage"] = (activeSkill.skillData["FireDotEffectiveExplodePercentage"] or 0) + amount / 3
+						activeSkill.skillData["ColdDotEffectiveExplodePercentage"] = (activeSkill.skillData["ColdDotEffectiveExplodePercentage"] or 0) + amount / 3
+						activeSkill.skillData["LightningDotEffectiveExplodePercentage"] = (activeSkill.skillData["LightningDotEffectiveExplodePercentage"] or 0) + amount / 3
 					else
-						activeSkill.skillData[type.."DotEffectiveExplodePercentage"] = (activeSkill.skillData[type.."DotEffectiveExplodePercentage"] or 0) + amountXChance
+						activeSkill.skillData[type.."DotEffectiveExplodePercentage"] = (activeSkill.skillData[type.."DotEffectiveExplodePercentage"] or 0) + amount
 					end
-					output.ExplodeChance = 1 - ((1 - output.ExplodeChance) * (1 - chance))
+					output.ExplodeChance = 1 - ((1 - output.ExplodeChance) * (1 - math.min(chance, 1)))
 				end
 			end
 		end

--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -3376,8 +3376,8 @@ skills["EnemyExplode"] = {
 	preDamageFunc = function(activeSkill, output)
 		output.ExplodeChance = 0
 		if activeSkill.skillPart ~= 3 then
-			local allExplodeMods = activeSkill.skillModList:Tabulate("LIST", activeSkill.skillCfg, "ExplodeMod")
-			for _, explodeMod in ipairs(allExplodeMods) do
+			local allHitExplodeMods = activeSkill.skillModList:Tabulate("LIST", activeSkill.skillCfg, "ExplodeMod")
+			for _, explodeMod in ipairs(allHitExplodeMods) do
 				local activeEffectSource = activeSkill.activeEffect.srcInstance.explodeSource.modSource or "Tree:"..activeSkill.activeEffect.srcInstance.explodeSource.id
 				if explodeMod.mod.source == activeEffectSource then
 					local explodeMod = explodeMod.value
@@ -3387,6 +3387,21 @@ skills["EnemyExplode"] = {
 						activeSkill.skillData["LightningEffectiveExplodePercentage"] = explodeMod.amount / 3
 					else
 						activeSkill.skillData[explodeMod.type.."EffectiveExplodePercentage"] = explodeMod.amount
+					end
+					output.ExplodeChance = activeSkill.skillPart == 2 and 1 or explodeMod.chance
+				end
+			end
+			local allDotExplodeMods = activeSkill.skillModList:Tabulate("LIST", activeSkill.skillCfg, "ExplodeModDot")
+			for _, explodeMod in ipairs(allDotExplodeMods) do
+				local activeEffectSource = activeSkill.activeEffect.srcInstance.explodeSource.modSource or "Tree:"..activeSkill.activeEffect.srcInstance.explodeSource.id
+				if explodeMod.mod.source == activeEffectSource then
+					local explodeMod = explodeMod.value
+					if explodeMod.type == "RandomElement" then
+						activeSkill.skillData["FireDotEffectiveExplodePercentage"] = explodeMod.amount / 3
+						activeSkill.skillData["ColdDotEffectiveExplodePercentage"] = explodeMod.amount / 3
+						activeSkill.skillData["LightningDotEffectiveExplodePercentage"] = explodeMod.amount / 3
+					else
+						activeSkill.skillData[explodeMod.type.."DotEffectiveExplodePercentage"] = explodeMod.amount
 					end
 					output.ExplodeChance = activeSkill.skillPart == 2 and 1 or explodeMod.chance
 				end
@@ -3417,6 +3432,27 @@ skills["EnemyExplode"] = {
 				end
 				if type == "Physical" and physExplodeChance ~= 0 then
 					activeSkill.skillModList:NewMod("CalcArmourAsThoughDealing", "MORE", 100 / math.min(physExplodeChance, 1) - 100)
+				end
+			end
+			typeAmountChances = { }
+			explodeModList = activeSkill.skillModList:List(activeSkill.skillCfg, "ExplodeModDot")
+			ConPrintTable(explodeModList)
+			for _, explodeMod in ipairs(explodeModList) do
+				local amountChance = typeAmountChances[explodeMod.type] or {}
+				amountChance[explodeMod.amount] = (amountChance[explodeMod.amount] or 0) + explodeMod.chance
+				typeAmountChances[explodeMod.type] = amountChance
+			end
+			for type, amountChance in pairs(typeAmountChances) do
+				for amount, chance in pairs(amountChance) do
+					local amountXChance = amount * chance
+					if type == "RandomElement" then
+						activeSkill.skillData["FireDotEffectiveExplodePercentage"] = (activeSkill.skillData["FireDotEffectiveExplodePercentage"] or 0) + amountXChance / 3
+						activeSkill.skillData["ColdDotEffectiveExplodePercentage"] = (activeSkill.skillData["ColdDotEffectiveExplodePercentage"] or 0) + amountXChance / 3
+						activeSkill.skillData["LightningDotEffectiveExplodePercentage"] = (activeSkill.skillData["LightningDotEffectiveExplodePercentage"] or 0) + amountXChance / 3
+					else
+						activeSkill.skillData[type.."DotEffectiveExplodePercentage"] = (activeSkill.skillData[type.."DotEffectiveExplodePercentage"] or 0) + amountXChance
+					end
+					output.ExplodeChance = 1 - ((1 - output.ExplodeChance) * (1 - chance))
 				end
 			end
 		end

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -988,3 +988,52 @@ skills["EnemyExplode"] = {
 		[1] = { damageEffectiveness = 0, baseMultiplier = 1, levelRequirement = 1, }
 	}
 }
+
+skills["TotemExplode"] = {
+	name = "On Death Totem Explosion",
+	hidden = true,
+	color = 4,
+	skillTypes = { [SkillType.Damage] = true, [SkillType.Area] = true },
+	castTime = 1,
+	preDamageFunc = function(activeSkill, output)
+		local typeAmounts = { }
+		local explodeModList = activeSkill.skillModList:List(activeSkill.skillCfg, "TotemExplodeMod")
+		for _, explodeMod in ipairs(explodeModList) do
+			local amounts = typeAmounts[explodeMod.type] or {}
+			amounts[explodeMod.amount] = true
+			typeAmounts[explodeMod.type] = amounts
+		end
+		for type, amounts in pairs(typeAmounts) do
+			local physExplodeChance = 100
+			for amount, _ in pairs(amounts) do
+				local amountXChance = amount
+				if type == "RandomElement" then
+					activeSkill.skillData["FireEffectiveExplodePercentage"] = (activeSkill.skillData["FireEffectiveExplodePercentage"] or 0) + amountXChance / 3
+					activeSkill.skillData["ColdEffectiveExplodePercentage"] = (activeSkill.skillData["ColdEffectiveExplodePercentage"] or 0) + amountXChance / 3
+					activeSkill.skillData["LightningEffectiveExplodePercentage"] = (activeSkill.skillData["LightningEffectiveExplodePercentage"] or 0) + amountXChance / 3
+				else
+					activeSkill.skillData[type.."EffectiveExplodePercentage"] = (activeSkill.skillData[type.."EffectiveExplodePercentage"] or 0) + amountXChance
+				end
+			end
+		end
+	end,
+	baseMods = {
+		skill("radius", 22),
+		skill("showAverage", true),
+		skill("explodeCorpse", true),
+		skill("corpseExplosionLifeMultiplier", 0),
+	},
+	baseFlags = {
+		area = true,
+		totemExplode = true
+	},
+	stats = {
+		"is_area_damage",
+		"display_skill_deals_secondary_damage",
+		"damage_cannot_be_reflected",
+		"skill_can_add_multiple_charges_per_action",
+	},
+	levels = {
+		[1] = { damageEffectiveness = 0, baseMultiplier = 1, levelRequirement = 1, }
+	}
+}

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -996,6 +996,7 @@ skills["TotemExplode"] = {
 	skillTypes = { [SkillType.Damage] = true, [SkillType.Area] = true },
 	castTime = 1,
 	preDamageFunc = function(activeSkill, output)
+		activeSkill.skillData.hitTimeOverride = 1
 		local typeAmounts = { }
 		local explodeModList = activeSkill.skillModList:List(activeSkill.skillCfg, "TotemExplodeMod")
 		for _, explodeMod in ipairs(explodeModList) do

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -920,8 +920,8 @@ skills["EnemyExplode"] = {
 	preDamageFunc = function(activeSkill, output)
 		output.ExplodeChance = 0
 		if activeSkill.skillPart ~= 3 then
-			local allExplodeMods = activeSkill.skillModList:Tabulate("LIST", activeSkill.skillCfg, "ExplodeMod")
-			for _, explodeMod in ipairs(allExplodeMods) do
+			local allHitExplodeMods = activeSkill.skillModList:Tabulate("LIST", activeSkill.skillCfg, "ExplodeMod")
+			for _, explodeMod in ipairs(allHitExplodeMods) do
 				local activeEffectSource = activeSkill.activeEffect.srcInstance.explodeSource.modSource or "Tree:"..activeSkill.activeEffect.srcInstance.explodeSource.id
 				if explodeMod.mod.source == activeEffectSource then
 					local explodeMod = explodeMod.value
@@ -931,6 +931,21 @@ skills["EnemyExplode"] = {
 						activeSkill.skillData["LightningEffectiveExplodePercentage"] = explodeMod.amount / 3
 					else
 						activeSkill.skillData[explodeMod.type.."EffectiveExplodePercentage"] = explodeMod.amount
+					end
+					output.ExplodeChance = activeSkill.skillPart == 2 and 1 or explodeMod.chance
+				end
+			end
+			local allDotExplodeMods = activeSkill.skillModList:Tabulate("LIST", activeSkill.skillCfg, "ExplodeModDot")
+			for _, explodeMod in ipairs(allDotExplodeMods) do
+				local activeEffectSource = activeSkill.activeEffect.srcInstance.explodeSource.modSource or "Tree:"..activeSkill.activeEffect.srcInstance.explodeSource.id
+				if explodeMod.mod.source == activeEffectSource then
+					local explodeMod = explodeMod.value
+					if explodeMod.type == "RandomElement" then
+						activeSkill.skillData["FireDotEffectiveExplodePercentage"] = explodeMod.amount / 3
+						activeSkill.skillData["ColdDotEffectiveExplodePercentage"] = explodeMod.amount / 3
+						activeSkill.skillData["LightningDotEffectiveExplodePercentage"] = explodeMod.amount / 3
+					else
+						activeSkill.skillData[explodeMod.type.."DotEffectiveExplodePercentage"] = explodeMod.amount
 					end
 					output.ExplodeChance = activeSkill.skillPart == 2 and 1 or explodeMod.chance
 				end
@@ -961,6 +976,27 @@ skills["EnemyExplode"] = {
 				end
 				if type == "Physical" and physExplodeChance ~= 0 then
 					activeSkill.skillModList:NewMod("CalcArmourAsThoughDealing", "MORE", 100 / math.min(physExplodeChance, 1) - 100)
+				end
+			end
+			typeAmountChances = { }
+			explodeModList = activeSkill.skillModList:List(activeSkill.skillCfg, "ExplodeModDot")
+			ConPrintTable(explodeModList)
+			for _, explodeMod in ipairs(explodeModList) do
+				local amountChance = typeAmountChances[explodeMod.type] or {}
+				amountChance[explodeMod.amount] = (amountChance[explodeMod.amount] or 0) + explodeMod.chance
+				typeAmountChances[explodeMod.type] = amountChance
+			end
+			for type, amountChance in pairs(typeAmountChances) do
+				for amount, chance in pairs(amountChance) do
+					local amountXChance = amount * chance
+					if type == "RandomElement" then
+						activeSkill.skillData["FireDotEffectiveExplodePercentage"] = (activeSkill.skillData["FireDotEffectiveExplodePercentage"] or 0) + amountXChance / 3
+						activeSkill.skillData["ColdDotEffectiveExplodePercentage"] = (activeSkill.skillData["ColdDotEffectiveExplodePercentage"] or 0) + amountXChance / 3
+						activeSkill.skillData["LightningDotEffectiveExplodePercentage"] = (activeSkill.skillData["LightningDotEffectiveExplodePercentage"] or 0) + amountXChance / 3
+					else
+						activeSkill.skillData[type.."DotEffectiveExplodePercentage"] = (activeSkill.skillData[type.."DotEffectiveExplodePercentage"] or 0) + amountXChance
+					end
+					output.ExplodeChance = 1 - ((1 - output.ExplodeChance) * (1 - chance))
 				end
 			end
 		end

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -1000,21 +1000,12 @@ skills["TotemExplode"] = {
 		local typeAmounts = { }
 		local explodeModList = activeSkill.skillModList:List(activeSkill.skillCfg, "TotemExplodeMod")
 		for _, explodeMod in ipairs(explodeModList) do
-			local amounts = typeAmounts[explodeMod.type] or {}
-			amounts[explodeMod.amount] = true
-			typeAmounts[explodeMod.type] = amounts
-		end
-		for type, amounts in pairs(typeAmounts) do
-			local physExplodeChance = 100
-			for amount, _ in pairs(amounts) do
-				local amountXChance = amount
-				if type == "RandomElement" then
-					activeSkill.skillData["FireEffectiveExplodePercentage"] = (activeSkill.skillData["FireEffectiveExplodePercentage"] or 0) + amountXChance / 3
-					activeSkill.skillData["ColdEffectiveExplodePercentage"] = (activeSkill.skillData["ColdEffectiveExplodePercentage"] or 0) + amountXChance / 3
-					activeSkill.skillData["LightningEffectiveExplodePercentage"] = (activeSkill.skillData["LightningEffectiveExplodePercentage"] or 0) + amountXChance / 3
-				else
-					activeSkill.skillData[type.."EffectiveExplodePercentage"] = (activeSkill.skillData[type.."EffectiveExplodePercentage"] or 0) + amountXChance
-				end
+			if explodeMod.type == "RandomElement" then
+				activeSkill.skillData["FireEffectiveExplodePercentage"] = (activeSkill.skillData["FireEffectiveExplodePercentage"] or 0) + explodeMod.amount / 3
+				activeSkill.skillData["ColdEffectiveExplodePercentage"] = (activeSkill.skillData["ColdEffectiveExplodePercentage"] or 0) + explodeMod.amount / 3
+				activeSkill.skillData["LightningEffectiveExplodePercentage"] = (activeSkill.skillData["LightningEffectiveExplodePercentage"] or 0) + explodeMod.amount / 3
+			else
+				activeSkill.skillData[explodeMod.type.."EffectiveExplodePercentage"] = (activeSkill.skillData[explodeMod.type.."EffectiveExplodePercentage"] or 0) + explodeMod.amount
 			end
 		end
 	end,

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -961,6 +961,7 @@ skills["EnemyExplode"] = {
 			for type, amountChance in pairs(typeAmountChances) do
 				local physExplodeChance = 0
 				for amount, chance in pairs(amountChance) do
+					chance = math.min(chance, 1)
 					local amountXChance = amount * chance
 					if type == "RandomElement" then
 						activeSkill.skillData["FireEffectiveExplodePercentage"] = (activeSkill.skillData["FireEffectiveExplodePercentage"] or 0) + amountXChance / 3
@@ -988,15 +989,14 @@ skills["EnemyExplode"] = {
 			end
 			for type, amountChance in pairs(typeAmountChances) do
 				for amount, chance in pairs(amountChance) do
-					local amountXChance = amount * chance
 					if type == "RandomElement" then
-						activeSkill.skillData["FireDotEffectiveExplodePercentage"] = (activeSkill.skillData["FireDotEffectiveExplodePercentage"] or 0) + amountXChance / 3
-						activeSkill.skillData["ColdDotEffectiveExplodePercentage"] = (activeSkill.skillData["ColdDotEffectiveExplodePercentage"] or 0) + amountXChance / 3
-						activeSkill.skillData["LightningDotEffectiveExplodePercentage"] = (activeSkill.skillData["LightningDotEffectiveExplodePercentage"] or 0) + amountXChance / 3
+						activeSkill.skillData["FireDotEffectiveExplodePercentage"] = (activeSkill.skillData["FireDotEffectiveExplodePercentage"] or 0) + amount / 3
+						activeSkill.skillData["ColdDotEffectiveExplodePercentage"] = (activeSkill.skillData["ColdDotEffectiveExplodePercentage"] or 0) + amount / 3
+						activeSkill.skillData["LightningDotEffectiveExplodePercentage"] = (activeSkill.skillData["LightningDotEffectiveExplodePercentage"] or 0) + amount / 3
 					else
-						activeSkill.skillData[type.."DotEffectiveExplodePercentage"] = (activeSkill.skillData[type.."DotEffectiveExplodePercentage"] or 0) + amountXChance
+						activeSkill.skillData[type.."DotEffectiveExplodePercentage"] = (activeSkill.skillData[type.."DotEffectiveExplodePercentage"] or 0) + amount
 					end
-					output.ExplodeChance = 1 - ((1 - output.ExplodeChance) * (1 - chance))
+					output.ExplodeChance = 1 - ((1 - output.ExplodeChance) * (1 - math.min(chance, 1)))
 				end
 			end
 		end

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1251,7 +1251,9 @@ function buildMode:RefreshSkillSelectControls(controls, mainGroup, suffix)
 		for i, activeSkill in ipairs(displaySkillList) do
 			local explodeSource = activeSkill.activeEffect.srcInstance.explodeSource
 			local explodeSourceName = explodeSource and (explodeSource.name or explodeSource.dn)
-			local colourCoded = explodeSourceName and ("From "..colorCodes[explodeSource.rarity or "NORMAL"]..explodeSourceName)
+			local totemExplodeSource = activeSkill.activeEffect.srcInstance.totemExplodeSource
+			local totemExplodeSourceName = totemExplodeSource and (totemExplodeSource.name or totemExplodeSource.dn)
+			local colourCoded = explodeSourceName and ("From "..colorCodes[explodeSource.rarity or "NORMAL"]..explodeSourceName) or (totemExplodeSourceName and ("From "..colorCodes[totemExplodeSource.rarity or "NORMAL"]..totemExplodeSourceName))
 			t_insert(controls.mainSkill.list, { val = i, label = colourCoded or activeSkill.activeEffect.grantedEffect.name })
 		end
 		controls.mainSkill.enabled = #displaySkillList > 1

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1565,6 +1565,14 @@ function calcs.offence(env, actor, activeSkill)
 			skillData[damageType.."Max"] = base
 		end
 	end
+	if skillFlags.totemExplode then
+		for _, damageType in pairs(dmgTypeList) do
+			local percentage = skillData[damageType.."EffectiveExplodePercentage"]
+			local base = (percentage or 0) * monsterLife / 100
+			skillData[damageType.."Min"] = base
+			skillData[damageType.."Max"] = base
+		end
+	end
 
 	-- Cache global damage disabling flags
 	local canDeal = { }

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1563,6 +1563,10 @@ function calcs.offence(env, actor, activeSkill)
 			local base = (percentage or 0) * monsterLife / 100
 			skillData[damageType.."Min"] = base
 			skillData[damageType.."Max"] = base
+			local dotPercentage = skillData[damageType.."DotEffectiveExplodePercentage"]
+			base = (dotPercentage or 0) * monsterLife / 100
+			ConPrintTable({damageType, base})
+			skillData[damageType.."Dot"] = base
 		end
 	end
 	if skillFlags.totemExplode then

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -142,7 +142,7 @@ function calcs.buildModListForNode(env, node)
 	end
 
 	if modList:Flag(nil, "TotemExplodes") then
-		t_insert(env.totemExplodeSources, node)
+		t_insert(env.totemExplodeSources, {source = node, type = "All"})
 	end
 
 	return modList
@@ -621,7 +621,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 				t_insert(env.explodeSources, item)
 			end
 			if item and item.baseModList and item.baseModList:Flag(nil, "TotemExplodes") then
-				t_insert(env.totemExplodeSources, item)
+				t_insert(env.totemExplodeSources, {source = item, type = "All"})
 			end
 			if slot.weaponSet and slot.weaponSet ~= (build.itemsTab.activeItemSet.useSecondWeaponSet and 2 or 1) then
 				item = nil
@@ -1129,14 +1129,21 @@ function calcs.initEnv(build, mode, override, specEnv)
 				local gemsBySource = { }
 				for _, gem in ipairs(group.gemList) do
 					if gem.totemExplodeSource then
-						gemsBySource[gem.totemExplodeSource.modSource or gem.totemExplodeSource.id] = gem
+						gemsBySource["TotemExplode"] = gem
 					end
 				end
 				wipeTable(group.gemList)
+				local explodeTypes = { }
 				for _, totemExplodeSource in ipairs(env.totemExplodeSources) do
+					if not explodeTypes[totemExplodeSource.type] then
+						explodeTypes[totemExplodeSource.type] = totemExplodeSource
+						explodeTypes.count = (explodeTypes.count or 0) + 1
+					end
+				end
+				if explodeTypes["All"] and explodeTypes.count == 1 then -- always true atm, will not be once decoy totem is implemented
 					local activeGemInstance
-					if gemsBySource[totemExplodeSource.modSource or totemExplodeSource.id] then
-						activeGemInstance = gemsBySource[totemExplodeSource.modSource or totemExplodeSource.id]
+					if gemsBySource["TotemExplode"] then
+						activeGemInstance = gemsBySource["TotemExplode"]
 					else
 						activeGemInstance = {
 							skillId = "TotemExplode",
@@ -1144,7 +1151,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 							enabled = true,
 							level = 1,
 							triggered = true,
-							totemExplodeSource = totemExplodeSource,
+							totemExplodeSource = "TotemExplode",
 						}
 					end
 					t_insert(group.gemList, activeGemInstance)

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1756,12 +1756,15 @@ local explodeFunc = function(chance, amount, type, specialType, ...)
 	if not amountNumber then
 		return
 	end
-	local amounts = {}
-	amounts[type] = amountNumber
 	if specialType and specialType == "Totem" then
 		return {
 			mod("TotemExplodeMod", "LIST", { type = firstToUpper(type), chance = chance / 100, amount = amountNumber, keyOfScaledMod = "chance" }, ...),
 			flag("TotemExplodes")
+		}
+	elseif specialType and specialType == "Dot" then
+		return {
+			mod("ExplodeModDot", "LIST", { type = firstToUpper(type), chance = chance / 100, amount = amountNumber, keyOfScaledMod = "chance" }, ...),
+			flag("CanExplode")
 		}
 	end
 	return {
@@ -1817,6 +1820,9 @@ local specialModList = {
 	end,
 	["enemies taunted by your warcries explode on death, dealing (%d+)%% of their maximum life as (.+) damage"] = function(amount, _, type)	-- Al Dhih
 		return explodeFunc(100, amount, type, nil, { type = "ActorCondition", actor = "enemy", var = "Taunted" }, { type = "Condition", var = "UsedWarcryRecently" })
+	end,
+	["(%d+)%% chance when you kill a scorched enemy to burn each surrounding enemy for 4 seconds, dealing (%d+)%% of the killed enemy's life as (.+) damage per second"] = function(chance, _, amount, type)	-- Al Dhih
+		return explodeFunc(chance, amount, type, "Dot", { type = "ActorCondition", actor = "enemy", var = "Scorched" })
 	end,
 	["totems explode on death, dealing (%d+)%% of their life as (.+) damage"] = function(amount, _, type)	-- Crucible weapon mod
 		return explodeFunc(100, amount, type, "Totem")

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -1751,13 +1751,19 @@ local function triggerExtraSkill(name, level, noSupports, sourceSkill)
 	end
 end
 
-local explodeFunc = function(chance, amount, type, ...)
+local explodeFunc = function(chance, amount, type, specialType, ...)
 	local amountNumber = tonumber(amount) or (amount == "tenth" and 10) or (amount == "quarter" and 25)
 	if not amountNumber then
 		return
 	end
 	local amounts = {}
 	amounts[type] = amountNumber
+	if specialType and specialType == "Totem" then
+		return {
+			mod("TotemExplodeMod", "LIST", { type = firstToUpper(type), chance = chance / 100, amount = amountNumber, keyOfScaledMod = "chance" }, ...),
+			flag("TotemExplodes")
+		}
+	end
 	return {
 		mod("ExplodeMod", "LIST", { type = firstToUpper(type), chance = chance / 100, amount = amountNumber, keyOfScaledMod = "chance" }, ...),
 		flag("CanExplode")
@@ -1768,52 +1774,52 @@ end
 local specialModList = {
 	-- Explode mods
 	["enemies you kill have a (%d+)%% chance to explode, dealing a (.+) of their maximum life as (.+) damage"] = function(chance, _, amount, type)	-- Obliteration, Unspeakable Gifts (chaos cluster), synth implicit mod, current crusader body mod
-		return explodeFunc(chance, amount, type)
+		return explodeFunc(chance, amount, type, nil)
 	end,
 	["enemies you kill while using pride have (%d+)%% chance to explode, dealing a (.+) of their maximum life as (.+) damage"] = function(chance, _, amount, type)	-- Sublime Vision
-		return explodeFunc(chance, amount, type, { type = "Condition", var = "AffectedByPride" })
+		return explodeFunc(chance, amount, type, nil, { type = "Condition", var = "AffectedByPride" })
 	end,
 	["enemies you kill during effect have a (%d+)%% chance to explode, dealing a (.+) of their maximum life as damage of a random element"] = function(chance, _, amount)	-- Oriath's End
-		return explodeFunc(chance, amount, "randomElement", { type = "Condition", var = "UsingFlask" })
+		return explodeFunc(chance, amount, "randomElement", nil, { type = "Condition", var = "UsingFlask" })
 	end,
 	["enemies you kill while affected by glorious madness have a (%d+)%% chance to explode, dealing a (.+) of their life as (.+) damage"] = function(chance, _, amount, type)	-- Beacon of Madness
-		return explodeFunc(chance, amount, type, { type = "Condition", var = "AffectedByGloriousMadness" })
+		return explodeFunc(chance, amount, type, nil, { type = "Condition", var = "AffectedByGloriousMadness" })
 	end,
 	["enemies killed with attack hits have a (%d+)%% chance to explode, dealing a (.+) of their life as (.+) damage"] = explodeFunc,	-- Devastator (attack clusters)
 	["enemies killed with wand hits have a (%d+)%% chance to explode, dealing a (.+) of their life as (.+) damage"] = function(chance, _, amount, type)	-- Explosive Force (wand clusters)
-		return explodeFunc(chance, amount, type, { type = "Condition", var = "UsingWand" })
+		return explodeFunc(chance, amount, type, nil, { type = "Condition", var = "UsingWand" })
 	end,
 	["cursed enemies you or your minions kill have a (%d+)%% chance to explode, dealing a (.+) of their maximum life as (.+) damage"] = function(chance, _, amount, type)	-- Profane Bloom
-		return explodeFunc(chance, amount, type, { type = "ActorCondition", actor = "enemy", var = "Cursed" })
+		return explodeFunc(chance, amount, type, nil, { type = "ActorCondition", actor = "enemy", var = "Cursed" })
 	end,
 	["enemies you kill explode, dealing (%d+)%% of their life as (.+) damage"] = function(amount, _, type)	-- legacy synth, legacy crusader
-		return explodeFunc(100, amount, type)
+		return explodeFunc(100, amount, type, nil)
 	end,
 	["enemies killed explode dealing (%d+)%% of their life as (.+) damage"] = function(amount, _, type)	-- Quecholli
-		return explodeFunc(100, amount, type)
+		return explodeFunc(100, amount, type, nil)
 	end,
 	["enemies on fungal ground you kill explode, dealing (%d+)%% of their life as (.+) damage"] = function(amount, _, type)	-- Sporeguard
-		return explodeFunc(100, amount, type, { type = "ActorCondition", actor = "enemy", var = "OnFungalGround" })
+		return explodeFunc(100, amount, type, nil, { type = "ActorCondition", actor = "enemy", var = "OnFungalGround" })
 	end,
 	["enemies killed with attack or spell hits explode, dealing (%d+)%% of their life as (.+) damage"] = function(amount, _, type)	-- Shaper 2H mace mod
-		return explodeFunc(100, amount, type)
+		return explodeFunc(100, amount, type, nil)
 	end,
 	["shocked enemies you kill explode, dealing (%d+)%% of their life as (.+) damage which cannot shock"] = function(amount, _, type)	-- Inpulsa's Broken Heart
-		return explodeFunc(100, amount, type, { type = "ActorCondition", actor = "enemy", var = "Shocked" })
+		return explodeFunc(100, amount, type, nil, { type = "ActorCondition", actor = "enemy", var = "Shocked" })
 	end,
 	["bleeding enemies you kill explode, dealing (%d+)%% of their maximum life as (.+) damage"] = function(amount, _, type)	-- Haemophilia
-		return explodeFunc(100, amount, type, { type = "ActorCondition", actor = "enemy", var = "Bleeding" })
+		return explodeFunc(100, amount, type, nil, { type = "ActorCondition", actor = "enemy", var = "Bleeding" })
 	end,
 	["non-aura curses you inflict are not removed from dying enemies"] = {},
 	["enemies near corpses affected by your curses are blinded"] = { mod("EnemyModifier", "LIST", { mod = flag("Condition:Blinded") }, { type = "MultiplierThreshold", var = "NearbyCorpse", threshold = 1 }, { type = "ActorCondition", actor = "enemy", var = "Cursed" }) },
 	["enemies killed near corpses affected by your curses explode, dealing (%d+)%% of their life as (.+) damage"] = function(amount, _, type)	-- Asenath's Gentle Touch
-		return explodeFunc(100, amount, type, { type = "MultiplierThreshold", var = "NearbyCorpse", threshold = 1 }, { type = "ActorCondition", actor = "enemy", var = "Cursed" })
+		return explodeFunc(100, amount, type, nil, { type = "MultiplierThreshold", var = "NearbyCorpse", threshold = 1 }, { type = "ActorCondition", actor = "enemy", var = "Cursed" })
 	end,
 	["enemies taunted by your warcries explode on death, dealing (%d+)%% of their maximum life as (.+) damage"] = function(amount, _, type)	-- Al Dhih
-		return explodeFunc(100, amount, type, { type = "ActorCondition", actor = "enemy", var = "Taunted" }, { type = "Condition", var = "UsedWarcryRecently" })
+		return explodeFunc(100, amount, type, nil, { type = "ActorCondition", actor = "enemy", var = "Taunted" }, { type = "Condition", var = "UsedWarcryRecently" })
 	end,
 	["totems explode on death, dealing (%d+)%% of their life as (.+) damage"] = function(amount, _, type)	-- Crucible weapon mod
-		return explodeFunc(100, amount, type)
+		return explodeFunc(100, amount, type, "Totem")
 	end,
 	-- Keystones
 	["(%d+) rage regenerated for every (%d+) mana regeneration per second"] = function(num, _, div) return { 


### PR DESCRIPTION
Built ontop of #6158 (merge that one first)

Adds support for `{range:0.5}(30-40)% chance when you Kill a Scorched Enemy to Burn Each surrounding Enemy for 4 seconds, dealing 8% of the Killed Enemy's Life as Fire Damage per second`
![image](https://user-images.githubusercontent.com/49933620/235338637-d0b2006f-3274-4781-bd61-1e234e6ab28a.png)


This still has a few issues to fix before merging

- enemy life %, 
- showing hit damage on the dot only source, 
- should dot damage be scaled by explode chance?, it doesnt on the base versions becouse its a dot