### PR TITLE
Import Player's Stash to use in Items Tab

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -1273,6 +1273,16 @@ function ImportTabClass:DownloadStashTabs()
 	end, sessionID and { header = "Cookie: POESESSID=" .. sessionID })
 end
 
+local supported_stash_types = { "FlaskStash", "NormalStash", "PremiumStash", "QuadStash" }
+local function IsStashSupported (stashType)
+	for _, stype in ipairs(supported_stash_types) do
+		if stashType == stype then
+			return true
+		end
+	end
+	return false
+end
+
 function ImportTabClass:BuildStashTabList(stash)
 	self.controls.stashListHeader = new("LabelControl", {"TOPLEFT",self.controls.sectionStashImport,"TOPLEFT"}, 6, 40, 200, 16, "^7Select Stash Tab To Import:")
 	self.controls.stashListHeader.shown = function()
@@ -1281,10 +1291,12 @@ function ImportTabClass:BuildStashTabList(stash)
 
 	local tabList = {}
 	for _, tab in ipairs(stash.tabs) do
-		t_insert(tabList, {
-			label = tab.n,
-			tabIdx = tab.i,
-		})
+		if IsStashSupported(tab.type) then
+			t_insert(tabList, {
+				label = tab.n,
+				tabIdx = tab.i,
+			})
+		end
 	end
 
 	self.controls.stashList = new("DropDownControl", {"LEFT", self.controls.stashListHeader, "RIGHT"}, 8, 0, 150, 16, tabList )
@@ -1329,7 +1341,9 @@ function ImportTabClass:ImportStashTabItems(stash)
 
 		for _, itemData in ipairs(stashData.items) do
 			local item = self:ConvertItem(itemData, "stash")
-			main.stashDB.list[item.uniqueID] = item;
+			if item then
+				main.stashDB.list[item.uniqueID] = item;
+			end
 		end
 
 		self.build.itemsTab.controls.stashDB:ListBuilder()

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -232,7 +232,7 @@ local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Contro
 	-- Database selector
 	self.controls.selectDBLabel = new("LabelControl", {"TOPLEFT",self.controls.itemList,"BOTTOMLEFT"}, 0, 14, 0, 16, "^7Import from:")
 	self.controls.selectDBLabel.shown = function()
-		return self.height < 980
+		return self.height < 1200
 	end
 	self.controls.selectDB = new("DropDownControl", {"LEFT",self.controls.selectDBLabel,"RIGHT"}, 4, 0, 150, 18, { "Uniques", "Rare Templates", "Stash" })
 
@@ -257,7 +257,7 @@ local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Contro
 	-- Stash database
 	self.controls.stashDB = new("ItemDBControl", {"TOPLEFT",self.controls.itemList,"BOTTOMLEFT"}, 0, 76, 360, function(c) return m_min(244, self.maxY - select(2, c:GetPos())) end, self, main.stashDB, "UNIQUE")
 	self.controls.stashDB.y = function()
-		return self.controls.selectDBLabel:IsShown() and 118 or 96
+		return self.controls.selectDBLabel:IsShown() and 118 or 750
 	end
 	self.controls.stashDB.shown = function()
 		return not self.controls.selectDBLabel:IsShown() or self.controls.selectDB.selIndex == 3

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -234,7 +234,7 @@ local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Contro
 	self.controls.selectDBLabel.shown = function()
 		return self.height < 980
 	end
-	self.controls.selectDB = new("DropDownControl", {"LEFT",self.controls.selectDBLabel,"RIGHT"}, 4, 0, 150, 18, { "Uniques", "Rare Templates" })
+	self.controls.selectDB = new("DropDownControl", {"LEFT",self.controls.selectDBLabel,"RIGHT"}, 4, 0, 150, 18, { "Uniques", "Rare Templates", "Stash" })
 
 	-- Unique database
 	self.controls.uniqueDB = new("ItemDBControl", {"TOPLEFT",self.controls.itemList,"BOTTOMLEFT"}, 0, 76, 360, function(c) return m_min(244, self.maxY - select(2, c:GetPos())) end, self, main.uniqueDB, "UNIQUE")
@@ -253,6 +253,16 @@ local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Contro
 	self.controls.rareDB.shown = function()
 		return not self.controls.selectDBLabel:IsShown() or self.controls.selectDB.selIndex == 2
 	end
+
+	-- Stash database
+	self.controls.stashDB = new("ItemDBControl", {"TOPLEFT",self.controls.itemList,"BOTTOMLEFT"}, 0, 76, 360, function(c) return m_min(244, self.maxY - select(2, c:GetPos())) end, self, main.stashDB, "UNIQUE")
+	self.controls.stashDB.y = function()
+		return self.controls.selectDBLabel:IsShown() and 118 or 96
+	end
+	self.controls.stashDB.shown = function()
+		return not self.controls.selectDBLabel:IsShown() or self.controls.selectDB.selIndex == 3
+	end
+
 	-- Create/import item
 	self.controls.craftDisplayItem = new("ButtonControl", {"TOPLEFT",main.portraitMode and self.controls.setManage or self.controls.itemList,"TOPRIGHT"}, 20, main.portraitMode and 0 or -20, 120, 20, "Craft item...", function()
 		self:CraftItem()

--- a/src/Launch.lua
+++ b/src/Launch.lua
@@ -15,6 +15,13 @@ launch = { }
 SetMainObject(launch)
 
 function launch:OnInit()
+	package.cpath = package.cpath .. ";C:/Users/Mike/.vscode/extensions/tangzx.emmylua-0.5.14/debugger/emmy/windows/x86/?.dll"
+	local dbg = require("emmy_core")
+	-- This port must match the Visual Studio Code configuration. Default is 9966.
+	dbg.tcpListen("localhost", 9966)
+	-- Uncomment the next line if you want Path of Building to block until the debugger is attached
+	--dbg.waitIDE()
+
 	self.devMode = false
 	self.installedMode = false
 	self.versionNumber = "?"

--- a/src/Launch.lua
+++ b/src/Launch.lua
@@ -15,13 +15,6 @@ launch = { }
 SetMainObject(launch)
 
 function launch:OnInit()
-	package.cpath = package.cpath .. ";C:/Users/Mike/.vscode/extensions/tangzx.emmylua-0.5.14/debugger/emmy/windows/x86/?.dll"
-	local dbg = require("emmy_core")
-	-- This port must match the Visual Studio Code configuration. Default is 9966.
-	dbg.tcpListen("localhost", 9966)
-	-- Uncomment the next line if you want Path of Building to block until the debugger is attached
-	--dbg.waitIDE()
-
 	self.devMode = false
 	self.installedMode = false
 	self.versionNumber = "?"

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -113,6 +113,7 @@ function main:Init()
 	self:LoadTree(latestTreeVersion)
 
 	ConPrintf("Loading item databases...")
+	self.stashDB = { list = { } }
 	self.uniqueDB = { list = { } }
 	for type, typeList in pairs(data.uniques) do
 		for _, raw in pairs(typeList) do


### PR DESCRIPTION
Note: This is an initial prototype of the feature and not intended to be a final design.  The purpose of this PR is for feedback and discussion of design and implementation.

Overview of feature:

On the Import screen there is a third section at the bottom to import a player stash.  An account name, session id, and league selection is needed and after this is completed a list of stash tabs supported is given.   The session id used is the same storage value as the "trade for items" value, so if you've entered in one place it will be in the other and persist when closing and opening PoB.

You can import multiple tabs, and importing a previous tab will not duplication items (items are indexed by their id).

On the Items screen is a new option in the Unique / Rare Templates section for Stash and this currently uses the Unique item DB control for filtering and sorting.

The Stash is not saved to disk and is only in memory.  To keep an item use normal "add to build" process you would for a Unique or Rare Template item.  On the import screen you can clear the in memory stash DB anytime.

Currently supported stash types are the normal, premium, quad, and flask.