### PR TITLE
Default to "All" league in character import

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -454,9 +454,7 @@ function ImportTabClass:DownloadCharacterList()
 			t_insert(self.controls.charSelectLeague.list, {
 				label = "All",
 			})
-			if self.controls.charSelectLeague.selIndex > #self.controls.charSelectLeague.list then
-				self.controls.charSelectLeague.selIndex = 1
-			end
+			self.controls.charSelectLeague.selIndex = #self.controls.charSelectLeague.list
 			self.lastCharList = charList
 			self:BuildCharacterList(self.controls.charSelectLeague:GetSelValue("league"))
 


### PR DESCRIPTION
### Description of the problem being solved:
Default to the "All" league in Import/Export Build screen.  This is especially useful to allow the character list to preselect the last imported character (saved with a hash).

### Steps taken to verify a working solution:
- Import a build in a league other than the first one
- Restart PoB
- Go back to the Import screen
  - Before patch: the first character of the first league would get selected
  - After patch: the character you just imported is preselected
