### PR TITLE
Add option to only compare stats for same jewel types.

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -3548,17 +3548,20 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 		for _, compareSlot in pairs(compareSlots) do
 			if not main.slotOnlyTooltips or (slot and (slot.nodeId == compareSlot.nodeId or slot.slotName == compareSlot.slotName)) or not slot or slot == compareSlot then
 				local selItem = self.items[compareSlot.selItemId]
-				local storedGlobalCacheDPSView = GlobalCache.useFullDPS
-				GlobalCache.useFullDPS = GlobalCache.numActiveSkillInFullDPS > 0
-				local output = calcFunc({ repSlotName = compareSlot.slotName, repItem = item ~= selItem and item }, {})
-				GlobalCache.useFullDPS = storedGlobalCacheDPSView
-				local header
-				if item == selItem then
-					header = "^7Removing this item from "..compareSlot.label.." will give you:"
-				else
-					header = string.format("^7Equipping this item in %s will give you:%s", compareSlot.label, selItem and "\n(replacing "..colorCodes[selItem.rarity]..selItem.name.."^7)" or "")
+
+				if not (main.compareJewelsOfSameType and item.type == "Jewel" and not self:IsSameBase(item, selItem)) then
+					local storedGlobalCacheDPSView = GlobalCache.useFullDPS
+					GlobalCache.useFullDPS = GlobalCache.numActiveSkillInFullDPS > 0
+					local output = calcFunc({ repSlotName = compareSlot.slotName, repItem = item ~= selItem and item }, {})
+					GlobalCache.useFullDPS = storedGlobalCacheDPSView
+					local header
+					if item == selItem then
+						header = "^7Removing this item from "..compareSlot.label.." will give you:"
+					else
+						header = string.format("^7Equipping this item in %s will give you:%s", compareSlot.label, selItem and "\n(replacing "..colorCodes[selItem.rarity]..selItem.name.."^7)" or "")
+					end
+					self.build:AddStatComparesToTooltip(tooltip, calcBase, output, header)
 				end
-				self.build:AddStatComparesToTooltip(tooltip, calcBase, output, header)
 			end
 		end
 	end
@@ -3570,6 +3573,26 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 			tooltip:AddLine(14, "^7"..modLib.formatMod(mod))
 		end
 	end
+end
+
+function ItemsTabClass:IsSameBase(firstItem, secondItem)
+	if not secondItem then
+		return false
+	end
+
+	if not firstItem.base or not secondItem.base then
+		return firstItem.type == secondItem.type
+	end
+
+	if not firstItem.base.subType and not secondItem.base.subType then
+		return firstItem.base.type == secondItem.base.type
+	end
+
+	if firstItem.base.subType == secondItem.base.subType then
+		return true
+	end
+
+	return false
 end
 
 function ItemsTabClass:CreateUndoState()

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -823,6 +823,13 @@ function main:OpenOptionsPopup()
 	controls.invertSliderScrollDirection.tooltipText = "Default scroll direction is:\nScroll Up = Move right\nScroll Down = Move left"
 	controls.invertSliderScrollDirection.state = self.invertSliderScrollDirection
 	
+	nextRow()
+	controls.compareJewelsOfSameType = new("CheckBoxControl", { "TOPLEFT", nil, "TOPLEFT" }, defaultLabelPlacementX, currentY, 20, "^7Compare jewels of the same type:", function(state)
+		self.compareJewelsOfSameType = state
+	end)
+	controls.compareJewelsOfSameType.tooltipText = "Enabling this option will force comparing jewels only jewels of the same type."
+	controls.compareJewelsOfSameType.state = self.compareJewelsOfSameType
+	
 	if launch.devMode then
 		nextRow()
 		controls.disableDevAutoSave = new("CheckBoxControl", { "TOPLEFT", nil, "TOPLEFT" }, defaultLabelPlacementX, currentY, 20, "^7Disable Dev AutoSave:", function(state)


### PR DESCRIPTION
Fixes #6275 .

### Description of the problem being solved:
When hovering on non-restricted (like timeless jewels) and non-cluster jewels in POB the tooltip that compares the benefits and drawbacks of adding the jewel to the build compares them to cluster jewels as well as per the image below:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/8795161/72f67450-ffc0-4403-87f9-9b33330238e9)

### Steps taken to verify a working solution:
- Tested enabling and disabling new option
- Tested with hovering on existing jewels on the build with new option enabled and disabled
- Tested with adding new jewel to the build with the option enabled and disabled:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/8795161/fa7f77df-9578-4311-b424-883535e423e2)
Tooltip with option enabled.

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/8795161/f3f89604-a91f-465a-a488-8e597de0d4af)
Tooltip with option disabled.

### Link to a build that showcases this PR:
https://pobb.in/fX8QA_1MH4ve

### Before screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/8795161/876d1355-047b-4556-8602-82db11263ab9)
Cluster jewels present in tooltip.
### After screenshot:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/8795161/98cc9188-cabe-402b-8991-eb2524969d6b)
New option added to the options screen.

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/8795161/e3945f51-1718-4bbe-a588-565521931dec)
Cluster jewels no longer present in toolip.