### PR TITLE
Fix maximum hit taken calculation when multiple hit pools are in effect

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -4829,13 +4829,13 @@ skills["FrostGlobe"] = {
 			div = 60,
 		},
 		["frost_globe_absorb_damage_%_enemy_in_bubble"] = {
-			mod("FrostGlobeDamageMitigation", "BASE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "EnemyInFrostGlobe" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Frost Shield" }),
+			mod("FrostShieldDamageMitigation", "BASE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "EnemyInFrostGlobe" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Frost Shield" }),
 		},
 		["frost_globe_absorb_damage_%_enemy_outside_bubble"] = {
-			mod("FrostGlobeDamageMitigation", "BASE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "EnemyInFrostGlobe", neg = true }, { type = "GlobalEffect", effectType = "Buff", effectName = "Frost Shield" }),
+			mod("FrostShieldDamageMitigation", "BASE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "EnemyInFrostGlobe", neg = true }, { type = "GlobalEffect", effectType = "Buff", effectName = "Frost Shield" }),
 		},
 		["frost_globe_health_per_stage"] = {
-			mod("FrostGlobeHealth", "BASE", nil, 0, 0, { type = "Multiplier", var = "FrostShieldStage", limitVar = "FrostShieldMaxStages" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Frost Shield" }),
+			mod("FrostShieldLife", "BASE", nil, 0, 0, { type = "Multiplier", var = "FrostShieldStage", limitVar = "FrostShieldMaxStages" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Frost Shield" }),
 		},
 		["frost_globe_max_stages"] = {
 			mod("Multiplier:FrostShieldMaxStages", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -1109,13 +1109,13 @@ local skills, mod, flag, skill = ...
 			div = 60,
 		},
 		["frost_globe_absorb_damage_%_enemy_in_bubble"] = {
-			mod("FrostGlobeDamageMitigation", "BASE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "EnemyInFrostGlobe" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Frost Shield" }),
+			mod("FrostShieldDamageMitigation", "BASE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "EnemyInFrostShield" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Frost Shield" }),
 		},
 		["frost_globe_absorb_damage_%_enemy_outside_bubble"] = {
-			mod("FrostGlobeDamageMitigation", "BASE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "EnemyInFrostGlobe", neg = true }, { type = "GlobalEffect", effectType = "Buff", effectName = "Frost Shield" }),
+			mod("FrostShieldDamageMitigation", "BASE", nil, 0, 0, { type = "ActorCondition", actor = "enemy", var = "EnemyInFrostShield", neg = true }, { type = "GlobalEffect", effectType = "Buff", effectName = "Frost Shield" }),
 		},
 		["frost_globe_health_per_stage"] = {
-			mod("FrostGlobeHealth", "BASE", nil, 0, 0, { type = "Multiplier", var = "FrostShieldStage", limitVar = "FrostShieldMaxStages" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Frost Shield" }),
+			mod("FrostShieldLife", "BASE", nil, 0, 0, { type = "Multiplier", var = "FrostShieldStage", limitVar = "FrostShieldMaxStages" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Frost Shield" }),
 		},
 		["frost_globe_max_stages"] = {
 			mod("Multiplier:FrostShieldMaxStages", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -118,12 +118,8 @@ function Aegis:adjustTotalHitPool(output, damageType)
 	output[damageType.."TotalHitPool"] =
 		output[damageType.."TotalHitPool"] +
 		m_max(
-			m_max(
-				output[damageType.."Aegis"],
-				output["sharedAegis"]),
-		isElemental[damageType] and
-		output[damageType.."AegisDisplay"]
-		or 0)
+			m_max(output[damageType.."Aegis"],output["sharedAegis"]),
+			isElemental[damageType] and output[damageType.."AegisDisplay"] or 0)
 end
 
 ---Helper function that reduces pools according to damage taken
@@ -160,10 +156,7 @@ function calcs.reducePoolsByDamage(poolTable, damageTable, actor)
 	end
 	
 	local PoolsLost = poolTbl.PoolsLost or { }
-	local aegis = poolTbl.Aegis
-	if not aegis then
-		aegis = Aegis:new(output)
-	end
+	local aegis = poolTbl.Aegis or Aegis:new(output)
 	local guard = poolTbl.Guard
 	if not guard then
 		guard = { shared = output.sharedGuardAbsorb or 0 }

--- a/src/Modules/CalcHitPools.lua
+++ b/src/Modules/CalcHitPools.lua
@@ -11,7 +11,7 @@ local s_format = string.format
 ---@param percentage float percentage of damage the pool will take on behalf of the player. Should be between 0 and 1
 ---@param type string name of the type of damage to be absorbed. Must be a key in the pool table
 ---@return number the remaining amount of damage after pool has absorbed what it can
-local function genereicTakeDamage(pool, amount, percentage, type)
+local function genericTakeDamage(pool, amount, percentage, type)
 	if pool[type] > 0 then
 		local temp = m_min(amount*percentage, pool[type])
 		pool[type] = pool[type] - temp
@@ -83,11 +83,11 @@ function Aegis:new(output)
 end
 
 function Aegis:takeDamage(damageType, damage)
-	damage = genereicTakeDamage(self, damage, 1, damageType)
+	damage = genericTakeDamage(self, damage, 1, damageType)
 	if isElemental[damageType] then
-		damage = genereicTakeDamage(self, damage, 1, "sharedElemental")
+		damage = genericTakeDamage(self, damage, 1, "sharedElemental")
 	end
-	damage = genereicTakeDamage(self, damage, 1, "shared")
+	damage = genericTakeDamage(self, damage, 1, "shared")
 	return damage
 end
 
@@ -171,8 +171,8 @@ end
 
 
 function Guard:takeDamage(damageType, damage)
-	damage = genereicTakeDamage(self, damage, self[damageType.."Rate"], damageType)
-	damage = genereicTakeDamage(self, damage, self.sharedRate, "shared")
+	damage = genericTakeDamage(self, damage, self[damageType.."Rate"], damageType)
+	damage = genericTakeDamage(self, damage, self.sharedRate, "shared")
 	return damage
 end
 
@@ -290,7 +290,7 @@ end
 function AlliesTakenBeforeYou:takeDamage(damageType, damage)
 	for _, allyValues in ipairs(self) do
 		if not allyValues.damageType or allyValues.damageType == damageType then
-			damage = genereicTakeDamage(allyValues, damage, allyValues.percent, "remaining")
+			damage = genericTakeDamage(allyValues, damage, allyValues.percent, "remaining")
 		end
 	end
 	return damage

--- a/src/Modules/CalcHitPools.lua
+++ b/src/Modules/CalcHitPools.lua
@@ -275,7 +275,7 @@ end
 function AlliesTakenBeforeYou:new(output)
     local alliesTakenBeforeYou = {}
 	for _, allyNames in pairs(namingPairs) do
-		if output[allyNames.poolName] then
+		if output[allyNames.poolName] and output[allyNames.poolName] > 0 then
 			t_insert(alliesTakenBeforeYou,{
 				remaining = output[allyNames.poolName],
 				percent = output[allyNames.percentName] / 100,

--- a/src/Modules/CalcHitPools.lua
+++ b/src/Modules/CalcHitPools.lua
@@ -1,0 +1,214 @@
+local m_min = math.min
+local m_max = math.max
+local isElemental = { Fire = true, Cold = true, Lightning = true }
+local t_insert = table.insert
+local s_format = string.format
+
+--- Calculates how much damage a given hit pool will absorb
+---@param pool table representing the hit pool taking damage
+---@param amount number the magnitude of the incoming damage
+---@param percentage float percentage of damage the pool will take on behalf of the player. Should be between 0 and 1
+---@param type string name of the type of damage to be absorbed. Must be a key in the pool table
+---@return number the remaining amount of damage after pool has absorbed what it can
+local function genereicTakeDamage(pool, amount, percentage, type)
+	if pool[type] > 0 then
+		local temp = m_min(amount*percentage, pool[type])
+		pool[type] = pool[type] - temp
+		return amount - temp
+	else
+		return amount
+	end
+end
+
+local function maxHitBreakdown(output, breakdown, remainder, poolName, display, color)
+	t_insert(
+		breakdown,
+		s_format(
+			"\t%d "..colorCodes[color]..display.." ^7(%d remaining)",
+			output[poolName] - remainder,
+			remainder
+		)
+	)
+end
+
+Aegis = {}
+function Aegis:new(output)
+	local aegis = {
+		shared = output.sharedAegis or 0,
+		sharedElemental = output.sharedElementalAegis or 0,
+		Physical = output["PhysicalAegis"] or 0,
+		Lightning = output["LightningAegis"] or 0,
+		Cold = output["ColdAegis"] or 0,
+		Fire = output["FireAegis"] or 0,
+		Chaos = output["ChaosAegis"] or 0
+	}
+	self.__index = self
+	return setmetatable(aegis, self)
+end
+
+function Aegis:takeDamage(damageType, damage)
+	damage = genereicTakeDamage(self, damage, 1, damageType)
+	if isElemental[damageType] then
+		damage = genereicTakeDamage(self, damage, 1, "sharedElemental")
+	end
+	damage = genereicTakeDamage(self, damage, 1, "shared")
+	return damage
+end
+
+function Aegis.adjustTotalHitPool(output, damageType)
+	output[damageType.."TotalHitPool"] =
+		output[damageType.."TotalHitPool"] +
+		m_max(
+			output[damageType.."Aegis"],
+			output["sharedAegis"],
+			isElemental[damageType] and output[damageType.."AegisDisplay"] or 0
+		)
+end
+
+function Aegis:displayMaxHit(output, breakdown, takenDamages)
+	if output.sharedAegis and output.sharedAegis > 0 then
+		maxHitBreakdown(output, breakdown, self.shared, "sharedAegis",   "Shared Aegis charge", "GEM")
+	end
+	local receivedElemental = false
+	for takenType in pairs(takenDamages) do
+		receivedElemental = receivedElemental or isElemental[takenType]
+		if output[takenType.."Aegis"] and output[takenType.."Aegis"] > 0 then
+			maxHitBreakdown(output, breakdown, self[takenType], takenType.."Aegis", takenType.." Aegis charge", "GEM")
+		end
+	end
+	if receivedElemental and output.sharedElementalAegis and output.sharedElementalAegis > 0 then
+		maxHitBreakdown(output, breakdown, self.sharedElemental,  "sharedElementalAegis", "Elemental Aegis charge", "GEM")
+	end
+end
+
+local function protectPool(output, pool, mitigation, damageType)
+	local mitigationPercent = mitigation / 100
+	local poolProtected = pool / mitigationPercent * (1 - mitigationPercent)
+	local hitPool = damageType.."TotalHitPool"
+	output[hitPool] =
+		m_max(output[hitPool]-poolProtected, 0) +
+		m_min(output[hitPool], poolProtected) / (1 - mitigationPercent)
+end
+
+Guard = {}
+function Guard:new(output)
+	local guard = {
+		shared = output.sharedGuardAbsorb or 0,
+		Physical = output["PhysicalGuardAbsorb"] or 0,
+		Lightning = output["LightningGuardAbsorb"] or 0,
+		Cold = output["ColdGuardAbsorb"] or 0,
+		Fire = output["FireGuardAbsorb"] or 0,
+		Chaos = output["ChaosGuardAbsorb"] or 0,
+		sharedRate = output["sharedGuardAbsorbRate"] / 100 or 0,
+		PhysicalRate = output["PhysicalGuardAbsorbRate"] / 100 or 0,
+		LightningRate = output["LightningGuardAbsorbRate"] / 100 or 0,
+		ColdRate = output["ColdGuardAbsorbRate"] / 100 or 0,
+		FireRate = output["FireGuardAbsorbRate"] / 100 or 0,
+		ChaosRate = output["ChaosGuardAbsorbRate"] / 100 or 0,
+	}
+	self.__index = self
+	return setmetatable(guard, self)
+end
+
+
+function Guard:takeDamage(damageType, damage)
+	damage = genereicTakeDamage(self, damage, self[damageType.."Rate"], damageType)
+	damage = genereicTakeDamage(self, damage, self.sharedRate, "shared")
+	return damage
+end
+
+function Guard.adjustTotalHitPool(output, damageType)
+	local GuardAbsorbRate = output["sharedGuardAbsorbRate"] or 0 + output[damageType.."GuardAbsorbRate"] or 0
+	if GuardAbsorbRate > 0 then
+		local GuardAbsorb = output["sharedGuardAbsorb"] or 0 + output[damageType.."GuardAbsorb"] or 0
+		if GuardAbsorbRate >= 100 then
+			output[damageType.."TotalHitPool"] = output[damageType.."TotalHitPool"] + GuardAbsorb
+		else
+			protectPool(output, GuardAbsorb, GuardAbsorbRate, damageType)
+		end
+	end
+end
+
+function Guard:displayMaxHit(output, breakdown, takenDamages)
+	if output.sharedGuardAbsorb and output.sharedGuardAbsorb > 0 then
+		maxHitBreakdown(output, breakdown, self.shared, "sharedGuardAbsorb", "Shared Guard charge", "SCOURGE")
+	end
+	for takenType in pairs(takenDamages) do
+		if output[takenType.."GuardAbsorb"] and output[takenType.."GuardAbsorb"] > 0 then
+			maxHitBreakdown(output, breakdown, self[takenType], takenType.."GuardAbsorb", takenType.." Guard charge", "SCOURGE")
+		end
+	end
+end
+
+local namingPairs = { -- Order is important, best known order: https://www.pathofexile.com/forum/view-thread/3123794
+	{
+		poolName = "AlliedEnergyShield",
+		percentName = "SoulLinkMitigation",
+		displayName = "Total Allied Energy Shield"
+	};
+	{
+		poolName = "TotalRadianceSentinelLife",
+		percentName = "RadianceSentinelAllyDamageMitigation",
+		displayName = "Total Sentinel of Radiance Life"
+	};
+	{
+		poolName = "TotalVaalRejuvenationTotemLife",
+		percentName = "VaalRejuvenationTotemAllyDamageMitigation",
+		displayName = "Total Vaal Rejuvenation Totem Life"
+	};
+	{
+		poolName = "TotalTotemLife",
+		percentName = "TotemAllyDamageMitigation",
+		displayName = "Total Totem Life"
+	};
+	{
+		poolName = "TotalSpectreLife",
+		percentName = "SpectreAllyDamageMitigation",
+		displayName = "Total Spectre Life"
+	};
+	{
+		poolName = "FrostShieldLife",
+		percentName = "FrostShieldDamageMitigation",
+		displayName = "Frost Shield Life"
+	};
+}
+
+AlliesTakenBeforeYou = {}
+function AlliesTakenBeforeYou:new(output)
+    local alliesTakenBeforeYou = {}
+	for _, allyNames in pairs(namingPairs) do
+		if output[allyNames.poolName] then
+			t_insert(alliesTakenBeforeYou,{
+				remaining = output[allyNames.poolName],
+				percent = output[allyNames.percentName] / 100,
+				names = allyNames
+			})
+		end
+	end
+    self.__index = self
+	return setmetatable(alliesTakenBeforeYou, self)
+end
+
+function AlliesTakenBeforeYou:takeDamage(damageType, damage)
+	for _, allyValues in ipairs(self) do
+		if not allyValues.damageType or allyValues.damageType == damageType then
+			damage = genereicTakeDamage(allyValues, damage, allyValues.percent, "remaining")
+		end
+	end
+	return damage
+end
+
+function AlliesTakenBeforeYou.adjustTotalHitPool(output, damageType) 
+	for i,_ in ipairs(namingPairs) do
+		local allyNames = namingPairs[#namingPairs-i+1] -- hit pools are adjusted in reverse order
+		if output[allyNames.poolName] and output[allyNames.poolName] > 0 then
+			protectPool(output, output[allyNames.poolName], output[allyNames.percentName], damageType)
+		end
+	end
+end
+
+function AlliesTakenBeforeYou:displayMaxHit(output, breakdown)
+	for _, ally in ipairs(self) do
+		maxHitBreakdown(output, breakdown, ally.remaining, ally.names.poolName, ally.names.displayName, "GEM")
+	end
+end

--- a/src/Modules/CalcHitPools.lua
+++ b/src/Modules/CalcHitPools.lua
@@ -1,6 +1,7 @@
 local m_min = math.min
 local m_max = math.max
 local isElemental = { Fire = true, Cold = true, Lightning = true }
+local dmgTypeList = {"Physical", "Lightning", "Cold", "Fire", "Chaos"}
 local t_insert = table.insert
 local s_format = string.format
 
@@ -31,7 +32,42 @@ local function maxHitBreakdown(output, breakdown, remainder, poolName, display, 
 	)
 end
 
+local function protectPool(output, pool, mitigation, damageType)
+	local mitigationPercent = mitigation / 100
+	local poolProtected = pool / mitigationPercent * (1 - mitigationPercent)
+	local hitPool = damageType.."TotalHitPool"
+	output[hitPool] =
+		m_max(output[hitPool]-poolProtected, 0) +
+		m_min(output[hitPool], poolProtected) / (1 - mitigationPercent)
+end
+
 Aegis = {}
+function Aegis.init(output, modDB)
+	output.AnyAegis = false
+	output["sharedAegis"] = modDB:Max(nil, "AegisValue") or 0
+	output["sharedElementalAegis"] = modDB:Max(nil, "ElementalAegisValue") or 0
+	if output["sharedAegis"] > 0 then
+		output.AnyAegis = true
+	end
+	if output["sharedElementalAegis"] > 0 then
+		output.ehpSectionAnySpecificTypes = true
+		output.AnyAegis = true
+	end
+	for _, damageType in ipairs(dmgTypeList) do
+		local aegisValue = modDB:Max(nil, damageType.."AegisValue") or 0
+		if aegisValue > 0 then
+			output.ehpSectionAnySpecificTypes = true
+			output.AnyAegis = true
+			output[damageType.."Aegis"] = aegisValue
+		else
+			output[damageType.."Aegis"] = 0
+		end
+		if isElemental[damageType] then
+			output[damageType.."AegisDisplay"] = output[damageType.."Aegis"] + output["sharedElementalAegis"]
+		end
+	end
+end
+
 function Aegis:new(output)
 	local aegis = {
 		shared = output.sharedAegis or 0,
@@ -67,7 +103,7 @@ end
 
 function Aegis:displayMaxHit(output, breakdown, takenDamages)
 	if output.sharedAegis and output.sharedAegis > 0 then
-		maxHitBreakdown(output, breakdown, self.shared, "sharedAegis",   "Shared Aegis charge", "GEM")
+		maxHitBreakdown(output, breakdown, self.shared, "sharedAegis", "Shared Aegis charge", "GEM")
 	end
 	local receivedElemental = false
 	for takenType in pairs(takenDamages) do
@@ -81,16 +117,39 @@ function Aegis:displayMaxHit(output, breakdown, takenDamages)
 	end
 end
 
-local function protectPool(output, pool, mitigation, damageType)
-	local mitigationPercent = mitigation / 100
-	local poolProtected = pool / mitigationPercent * (1 - mitigationPercent)
-	local hitPool = damageType.."TotalHitPool"
-	output[hitPool] =
-		m_max(output[hitPool]-poolProtected, 0) +
-		m_min(output[hitPool], poolProtected) / (1 - mitigationPercent)
+Guard = {}
+function Guard.init(output, modDB, breakdown)
+	local function display_breakdown(name)
+		local GuardAbsorb = output[name.."GuardAbsorb"]
+		local GuardAbsorbRate = output[name.."GuardAbsorbRate"] / 100
+		local lifeProtected = GuardAbsorb / GuardAbsorbRate * (1 - GuardAbsorbRate)
+		breakdown["sharedGuardAbsorb"] = {
+			s_format("Total life protected:"),
+			s_format("%d ^8(guard limit)", GuardAbsorb),
+			s_format("/ %.2f ^8(portion taken from guard)", GuardAbsorbRate),
+			s_format("x %.2f ^8(portion taken from life and energy shield)", 1 - GuardAbsorbRate),
+			s_format("= %d", lifeProtected)
+		}
+	end
+	output.AnyGuard = false
+	output["sharedGuardAbsorbRate"] = m_min(modDB:Sum("BASE", nil, "GuardAbsorbRate"), 100)
+	if output["sharedGuardAbsorbRate"] > 0 then
+		output.OnlySharedGuard = true
+		output["sharedGuardAbsorb"] = calcLib.val(modDB, "GuardAbsorbLimit")
+		if breakdown then display_breakdown("shared") end
+	end
+	for _, damageType in ipairs(dmgTypeList) do
+		output[damageType.."GuardAbsorbRate"] = m_min(modDB:Sum("BASE", nil, damageType.."GuardAbsorbRate"), 100)
+		if output[damageType.."GuardAbsorbRate"] > 0 then
+			output.ehpSectionAnySpecificTypes = true
+			output.AnyGuard = true
+			output.OnlySharedGuard = false
+			output[damageType.."GuardAbsorb"] = calcLib.val(modDB, damageType.."GuardAbsorbLimit")
+			if breakdown then display_breakdown(damageType) end
+		end
+	end
 end
 
-Guard = {}
 function Guard:new(output)
 	local guard = {
 		shared = output.sharedGuardAbsorb or 0,
@@ -144,36 +203,75 @@ local namingPairs = { -- Order is important, best known order: https://www.patho
 	{
 		poolName = "AlliedEnergyShield",
 		percentName = "SoulLinkMitigation",
+		takenFromName = "TakenFromParentESBeforeYou",
 		displayName = "Total Allied Energy Shield"
 	};
 	{
 		poolName = "TotalRadianceSentinelLife",
 		percentName = "RadianceSentinelAllyDamageMitigation",
+		takenFromName = "takenFromRadianceSentinelBeforeYou",
 		displayName = "Total Sentinel of Radiance Life"
 	};
 	{
 		poolName = "TotalVaalRejuvenationTotemLife",
 		percentName = "VaalRejuvenationTotemAllyDamageMitigation",
+		takenFromName = "takenFromVaalRejuvenationTotemsBeforeYou",
 		displayName = "Total Vaal Rejuvenation Totem Life"
 	};
 	{
 		poolName = "TotalTotemLife",
 		percentName = "TotemAllyDamageMitigation",
+		takenFromName = "takenFromTotemsBeforeYou",
 		displayName = "Total Totem Life"
 	};
 	{
 		poolName = "TotalSpectreLife",
 		percentName = "SpectreAllyDamageMitigation",
+		takenFromName = "takenFromSpectresBeforeYou",
 		displayName = "Total Spectre Life"
 	};
 	{
 		poolName = "FrostShieldLife",
 		percentName = "FrostShieldDamageMitigation",
+		takenFromName = "FrostShieldDamageMitigation",
 		displayName = "Frost Shield Life"
 	};
 }
 
 AlliesTakenBeforeYou = {}
+function AlliesTakenBeforeYou.init(output, modDB, breakdown, actor)
+	for _,ally in ipairs(namingPairs) do
+		output[ally.percentName] = modDB:Sum("BASE", nil, ally.takenFromName)
+		if output[ally.percentName] ~= 0 then
+			output[ally.poolName] = modDB:Sum("BASE", nil, ally.poolName)
+		end
+	end
+	output["FrostShieldLife"] = output["FrostShieldLife"] or 0
+	local frostShieldMitigation = output["FrostShieldDamageMitigation"] / 100
+	local lifeProtected = output["FrostShieldLife"] / frostShieldMitigation * (1 - frostShieldMitigation)
+	if breakdown then
+		breakdown["FrostShieldLife"] = {
+			s_format("Total life protected:"),
+			s_format("%d ^8(frost shield limit)", output["FrostShieldLife"]),
+			s_format("/ %.2f ^8(portion taken from frost shield)", frostShieldMitigation),
+			s_format("x %.2f ^8(portion taken from life and energy shield)", 1 - frostShieldMitigation),
+			s_format("= %d", lifeProtected),
+		}
+	end
+	-- Vaal Rejuv. Totem stacks with regular totem mitigation
+	output["VaalRejuvenationTotemAllyDamageMitigation"] =
+		output["VaalRejuvenationTotemAllyDamageMitigation"] +
+		output["TotemAllyDamageMitigation"]
+	
+	-- from Allied Energy Shield / Soul Link
+	if output["SoulLinkMitigation"] == 0 then
+		output["SoulLinkMitigation"] = modDB:Sum("BASE", nil, "TakenFromPartyMemberESBeforeYou")
+		if output["SoulLinkMitigation"] ~= 0 then
+			output["AlliedEnergyShield"] = actor.partyMembers.output.EnergyShieldRecoveryCap or 0
+		end
+	end
+end
+
 function AlliesTakenBeforeYou:new(output)
     local alliesTakenBeforeYou = {}
 	for _, allyNames in pairs(namingPairs) do
@@ -199,7 +297,7 @@ function AlliesTakenBeforeYou:takeDamage(damageType, damage)
 end
 
 function AlliesTakenBeforeYou.adjustTotalHitPool(output, damageType) 
-	for i,_ in ipairs(namingPairs) do
+	for i=1, #namingPairs do
 		local allyNames = namingPairs[#namingPairs-i+1] -- hit pools are adjusted in reverse order
 		if output[allyNames.poolName] and output[allyNames.poolName] > 0 then
 			protectPool(output, output[allyNames.poolName], output[allyNames.percentName], damageType)

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -1962,7 +1962,7 @@ return {
 	{ label = "Frost Shield", haveOutput = "FrostShieldLife",
 		{ format = "{0:output:FrostShieldLife}",
 			{ breakdown = "FrostShieldLife" },
-			{ modName = { "FrostGlobeHealth", "FrostGlobeDamageMitigation" } },
+			{ modName = { "FrostShieldLife", "FrostShieldDamageMitigation" } },
 		},
 	},
 	{ label = "Spectre Ally", haveOutput = "TotalSpectreLife",


### PR DESCRIPTION
This is mainly a refactor of *some* hit pools, but also fixes a related calculation bug.

# Bugfix

### Description of the problem being solved:
The calculation for maximum sustainable hit relies on applying the hit pools in reverse order from how they take damage.
Best known order here: https://www.pathofexile.com/forum/view-thread/3123794
This reverse order was not being done for aegis+guard or the allies who can take damage for you, so mixing aegis, a guard skill or an ally could lead to incorrect max hit and weird breakdown values.

### Steps taken to verify a working solution:
- Comparing 2 builds using as many hit pools as possible, checking for crashes and value changes.
- Build A uses: Frost shield, Vaal Rejuv. Totem, Primal Aegis and Molten Shell.
- Build B uses: Frost shield, Spectres, Totem Mastery, Vaal Rejuv. Totem, Sentinel of Radiance and Molten Shell.

### Link to a build that showcases this PR:
Build A:
```
eNrVW1tv47YSfl7_CsJAgR50E9-dJkhaOHFuB8muaye7p08FLdE2G0r0SlQSt-h_PzOkZMteU5YtPZyzXXR1mfk4MxwOZ4by-a_vniCvLAi59C-qjeN6lTDfkS73pxfV56ebo5-rv_5SOR9QNfs8uYy4wDe_VD6c62si2CsTwFcligZTpr4kSK0_AGlOfTVj0n-kf8rgVroX1U_SZ1Uypr7LVXLnCBqGn6jHLqpfuXJmVUJDh_nu1er5tWAe8xUVPFTAMKMBdRQLHnD0XqTko3SBSgURwHmU-yPpvDB1G8horoV75ezN0Nw_Dj4Pn1KicT8tGmj24Xwg6IIFI0UVCeF_F9Ur6Y25z9z-YARYVEQAVK_WthOPVLAkarRtVEP2bY3w5MRG2Wfv-fDShK2ujfDeVyuqZgZcmrDTtEv3KhXM-G67PEmYv-u7wZKy3anXj086NvrBbBFyh4pH-s69yLvj6om-sNVAjcZJw8b7wKcz5YOn2pg7nVMb7w0P2AFsV1K4h7DNqAxtfGAhu4YTtsK3O-OcOWdIe-87u6cICZ_9gIUseGVuDnhkGDJHQgChY8FycqyGGLAAVvrKzxr1HUNNmR-Pt1hZqXls9fZH6tOVVN1MMyFtLjMh4RYzNX_Ox7CpdCdzoO06Wz3_2mfBdDGacSbc3ZqkqZMxrug8R5BDg6W5cxlufbhteh01ulburzTIodKQTi1-YhfrlYbpENboZKttyPO5ChOMAYPLYKH7DtvNMQjkn8xRXOzH1gs8Ga32k9N2PXvuDH0uHZJA3Keetq0bOWsR_9TKeSlgH86rAYglxF4cPaWo89KX7pTtNcj-HKNoPofli9Oelw-3kSELdcIS03Z3034Gj821AHG7yQu_os0Nv9xA846xwZBfD9z_NgbJQ5x7gOvJBJfTK3uEaIBJJEwocyEZXLEen1oX_E0E7pIn69OEUuWiHcg3EH6GCXO4HzUkCqvkzSpKwPy_Frnx18hzDXDtu1GAqyD3GJscuYbp6WmDtJF5D9zj6rvN74l7EF7DsE8VJW6ciH6hAYfcvqnz_pDRwJk9gL_cUCHGEC0uqumn-k7XCjdcQEHRh2coJqqyidhIBj6v6doHr-69uQwUYe_4z4AGanFRnVARMkOonwBOqLhPla6LekJUyWgm33ruK470JKUIEyZC53MofNYwngLGCNWmwMCNQmjl8SZdKN0DWxOrnxD0WBivD1E_H-oeuGifNk4-wu7abH3stNvtk4_dOmT1RAF8qmhrNuN6DOFaeqQP58_DB33xYabUPDyr1d7e3o7nUBHKCXuHjerYkV5tDkwg41H4woU4QthaD_5cTh-verPHxk33N7i7uNCAtQTx3BRqYc3c4aIOOIhr5reGOmqDoxHw4hM4Q4jv8GFycz7CIUOYyEDdMi-8XMAqvMEcY6Nyi62I1COmjIOkeZIK0mUTGgl8_lsEJSdOaj399MEUvVA4esvyBKBgUnGfMIhPizlavffwYN70hIrBcLhkhs1MxgIR7iazGz_UtWxvJfUVFU6o5ea-IyIXsvo4QC09SNAxyoaaRQE6MpruDCcfC3tM0t10oZwCX4794RxEjIlvhRxT0VzBG9Wb9eoaQSPB1LOPvjMIOBinx6YcwsM3ozk-7xsrLp9p024I5sjIN9PjQ_VvvN7gEQMYu0tNy12SvYoYx7Dssk0JVvgf13yXUzxKCLL-aMYwCG4zx5R5mo4p6kJQr91D7A9ruGKMxnC1DSOv-QwvMcy1srS6CWSo8CU7WCkNkRRteyqleUnMvFMpLfUj9yHebzhKXnW_UCqG7M_olZk9TW_Q3wNrzAPNYRliT8MgCknDkO9FhQg9DqWI9CjMmwsa_DuC6uD_NMQsJ6nPIAvw4qzj4HnYjpLX_uvcJXhmPY9rrsWHsp1yd_CJ59zqj2sh6DBPjC8hY9C5kcl-8FJbTFPc-_NI6aEvqh4PnT_G0WSCDXAYUgW6t399c3N99XT_5TpOptMsWqw__MgbswA00P-u0u4R0_U_CaNxaC5BN87etCAw6ZSLEC0gBJ2HKZtgehNLLoAvA01T3XFlOg42rBWBHen6nQWQfE-_QsYfcGaVa_l-h1BmQOwrYfFhQ4NCMAPItC2uIFEfUmXF0GVqBspVwJVVHXyZwQtlCxXWkeO3OyyhMMEFv-YT7mDRlj3lmA4bqgy7OA4Uic4iY77j5osd41Kg1SwA5qWdeSB5iHFuO3f8NsOqU5_b5zN-a2fvM4dadTcv7cwPjDmzW9hQpH-HlfJ2lCVVBtIn6Wsnh0XT4wIbJtaZvRZsSWIH_KxmLIjrURvSI8SohCRz4QR8HCn7Mk5RZNhKH51YLITv7KzmOMGiA77LiERrjXmLQdM0dijTCLcGsixW0zyz2i9uxGVMQdxmtpjfvM0wQtJpt-gfv85YJDr-9l4ld00b1rJcNsiyAoZ0XorD6JZycZjNZnNxxBtBwxfrfMdv7ezPimOOswXFpF65QHBRFUPAtVUMYbiZSKx4h9kphI5fkCgyMHRmAFvSZMyvivw-bHIqY25zQmmxti-ElWp7YZlQvlXTvRGNg8an2Vk-bEh2AMFedJeR7eRDWh4E3DEq1GwgpSgG-N2pfSE9pQqp7_bx5LKgonjwGc0BLJHs87Z0dTWlm6jntaSQ0M1nTO3jlvlIBVjH_iWl9zueW7fMddwPbcU9UEjz-hyMHWgnSUZCwv_gAW_bfMNyrkusuCeL10lLNgoZaCV99yujc6jb8HGqW4qk5NW05HW3ItU1HcJjtTgjz5_uf3u-rjzNGLkMaBiSvvRY5VZQl1MlAzIQkHhXzG51RtqN05_jm0sasvh4ngt2RhqVuPl_RgYBI63jRve4vnp2FQWgpKqYgoa5ZPmmWYm7vXBZr8Rd7jMyPFr-V9FWG7JvZ6TbqUDOLbjDkaZe-TtW76zxz98B9afsrH7c-efHbr1-1O3U__UDthoCBqK6xIi94miucbQ69aN2PZuj8U-r_gMJ8FQX3poEmyhJ9MZITK1CwJmI3puIcZY0eyPFnpyxEV29pKk69bQQoxmCJ5GQwN_fZVRBFyS-JNfvKqDxSGQSSI9gPYNH0AQ8kL-w0KLwTz82jjqgLYhPdatGL1Cy_HqMmPwGVVyDAFTmT9WMzAP5iucPKMVY-lGIUPE6J7iN6VIcCukhjkn0yHiA2EncMC7WrRTNnRStnRTtnRSdnRTdnRQnOymSz110s2S5NvEgw76E1884hFQEiiJvMH4ePuizKt1-uBXgRhAE8RV2ZeqJKDYGMwxp7MFyKSHgkt54EYboVnqBks4-AEyoTf7mHvw6YyGtA7Qkozc63xy6fQhQAfVjjGYJGNsV6pagULcEhQ7C2KZQYe9slWCRZlna7ONvdwwyS1XIHlsWW7ewBM29EQoP2SrL_p0SnKFRwvJolCBHe09PKCvENIuuyHYJBtx_zygtxLaK6t8suIT3E8BdxMlrER80uUURhO0Lu1MYoVvWtDbKijH7u2ZxO7YLz2WnHKfaR_meFwmmSoiErRICSqvgomwX5G-UY_-Dd8q9nba9N8chWVRBq3aKxuqSpqVdVnApLa8-uITag2_I_eleU7g9NDXLmYPSdooyCr72YTqtuBq5jF98jy8p2egUFqT4FtfdNxgUDR7fD2i6Psk3KLqXqz9Bkf6ET7_7oET_9m_rV13mMDb5xGT5U6g082T1cdxIUf29-eYnKWnyYNnjG8BAQi1W5Knv0x02k8JlQczEfOYtzCcXS-qT-g76-AcxUgjdIEtzZjMmSyChbzaz6bH9mfzuZGmq3SzJ5zMJS2uHWMvT2YShe5LNsP7LoJT-yTlC7A3ntc3fD_8XtoZhOQ==
```

Build B:
```
eNrVXFtz27YSfo5_BUczPdPO8YVXXXzsnpHvTu3YleykPS8ZiIQkJCChkKBtNZP_fhYAKVESSZGS-tA8JBKx34fdBbBYLKic_PfNp9oLDiPCgtOGcag3NBy4zCPB6LTx_HR10G7899e9k0fExw_Ds5hQ0fLr3rsT-Vmj-AXT04ZpNjSOwhHmH1Mq6zNQTVDAx5gF9-gLC6-Zd9r4wALc0AYo8AhPv7kURdEH5OPTxhP2JxSFDQ1FLg6883nLdYxCj6AAxMcoRC7H4Z3ovBtzds88kOBhDGQ-IkGfuV8xvw5ZPAGbGtoLwa9K5vb-8aH3lFGMBFnFwLB3J48UTXHY54hrEfx12uiCf9AI3xAOVIjGwKM3jkplz-Iw4hfIh4_rMf0Jxt5MzDi0sn-KQI8hvhwOscvJCz4PCT8fo8Cdd9Y8bDWLoBuI38eUkwklOMzo6RQhblb4Db3Q-ifGEb147K_3k5JkFUbhE-HjMwpercQrpG9HAeG4svgjIxELamldSfg8phQWWCXZHo5w-II4qajIOfMHJKjok3sUoHMWzX1tl4o-4hDWK19ArAP0sctgiWchjnVYZe5nesznKez6jgxxdclaViWAutpsZsdlv6pcbeLNFOpBpKsm2WcxrSjJ59HGNKzidfAtK2k4hXHpAr_N57NdwpcVbLaLBG-DzMxtl9BlBUvVe2FiNVeMKZc3jxnWpmMfOqapW03DLOzhcTyNiIvoPXojfuxDnH5CX_G8Q0u3OsWTdTTmAQSnIrDZdgr3kCsS4k1w54x6G-HGiEWFVnYMs2xJzueIaZbs2e6xEL4N3GoL_TkIZcDObPUl_ALRg_Un0okBxVUh806SZVxlB1Z9jXCQdDidg4xmswx1h7E7voaMq4c4rhb459wdp9S5QriSc4VgjnNL-BcRNTwlgPmesg-NMlBNR10GOBxN-2OCqVdPOlXsHE0qJZ7ucRad9bdTrbs8Zxy0rErK1vTKJzgBVNuJ8tUq1ukFRdm4azTLPabEq01ODGkoADy8lBHrxYk9-yLSeloP1g19Fs93wU6rXWqDEs-aYNjrdg11nulhL3YXtql2YUg6o3ASq2oB6EVpLUSXc-R-vWDeCNfqpD6iH08mEC_EsFfFiS0PUnRSJdOZyz7AjK20dsXOWJV-LluZfrbbV-1jCVDdDrFTL3VitipIV-5hdky-h3DgQ6SX5-17ltkqCscFjmOVjktSsOIZ75G9guZjUS6J6klDQjNPYgpVCXHw17Qy_4J4pQ4uAy8OxRqo3McyolI3XTlmkOli_474mdpLOlr3JIDluFp7WSq72G2r1TrsWKZjdqxWEXaxBqPDMbRl2R2r03I6kFLvFrVS8TCalqkfms2m1XFspxyWU_5Ykcwtf1TrJL8WUh27WhipZ1zeCloRLqmSrMiuqZKscudUSaqZsHB0sNptyyyTXJtw56LKM6YVSGkeWSpdnkGVQst1fCI-pERRdIE40rzkxPsRhQQF3JTV2gij0B3fQYi_QpQOYIc_bWSfym-ywntFKMfhBTwTwUX0scxopOHi5EgWrMWnW3_CQq7hN_HPIwr59LQxRDTCSlA-AZ6Ik0BOGwgslDa0_pi9dr0X0dMTYzRKQRqaTHDgLXA8hRhrSAYwkW0JJaTx4ku2tH3riQCo-SgCO6ZqowLi745jOOa-Ybbs1o-GFjDQBhJy3Wnp-1bTtvdNu2PY-7bdsfcNiDf6vqmbZntfwWy9AwJ629q3bFvXhZgObQBzTMuCZt3Q95tWy7T2W612c79pmE1z3-l0BIMOB0x44pgOiJhtc99yHKe5D6HTsaC1DZJWp2OIJwY8cJp2u6FxMDdT-Be3AW5qniMtf3fy3LuTH96NOZ9Ex0dHr6-vhxPEx2yI3yDZPXSZfzQBEPjsIPpKKD0QtEdd-HM2er64dj_9dvHlbfw8vn54oO8fzz54r3-MH67__K0TdUn32f3f228HDzBL4s5Dc_zlsvPiTkncm35zUewfvN796dFRt3v5Nu14r1Kho1SjE3VdEB2pbyKvCAl4XM3XIzFmcgKJQRUfPsCWFIk28TD9ctIXKkcwMUN-jf3obAoB5Eosh6WQkswKId3HXE34LCa9x_DwEMVUPP89RpSISapnn96pm5eAhf6sngNUMElFrqoYn6YTMXG6d3eqpUt5Qia6S2esmpmJQhrx0tmaPJQ3Kt251ueIupHUmwQujT18GyRp0mxFUDQQugnL4lAsTOG6YzFdxe2SqGd42euaDPms73cnoGIifE3ZAFFzRi9nRxKCFjXKtCQP02ujPuR9MAawjtMrK72xQG-kGkkOMXP7se8zCGICzuf45d5lx9-UWwXsQg3R7JkctyWrXRYHauwD5CchQnWnpR1pbKipvt1Fk3NsSmbukdRnR0O3zTgpSGVHX4Us4qIR5ztyhH3x_R5z5MGucXQLKWF0JKawshg-SYp0n6vpeInVEvDROquKJ19lez8iRHv4S_yC1QYjc9waE6uCPwq6qOkZwaJlabRVVSG8DCJGY9mLur19H8Pxer0nK_vrnsE2H_THWGzDGzokj6OqGxRWU-C_da0lDX_nYrvAkGr4SWqzsTvzWao6dBH9D49ePUQiaRekKxv7M5ekqjslWEvR_3B3dmG_izgLZaTpU-Rv7FPFFCL6SZwcCB7WduyMQZtRrHg3-Qipk0wSVRooPkr_SonbYBJzSXva8Enkfh7Ew6F4HwXM5qF80-by6ury_On242VySspCpGs-B7E_EG9fqH_nVZA-lsVYLYoHkfoIcZvgV6kILDREaCSsoxRNokyMEXleojkFXAmblLohs9dZ8rnmAsVMl284hIxlJLwZElyo16x9jVKqQ3FEFafKIjZRMikmUjXkcziBqeNqgadkoaeYRbwjU2iOaCzBwnkU0cKek9Y1nuAi04c5S4bEFcfy8iEX5wIlVeIX141D5E5LxjuphBdzyBpUEYFqLAarSlIROmkt8aosYhV6VbUWwy-wiwptV43F4FkFhAXypbF8lplUCdMHFshJDoumS6goXheO7CXFM5Fiwgc-xmFSaChiuocYlYqULpyQDGJevIwzEiW-klWzAg-JtmKouk4usEG0lUSihcJYgUOzMsVU6layMJCVQdVFRqH_kluRkiFI7vwK3K9aS5yQXnsW2J80lywSGX-7L4x46phasFyWxMoCBnO_bk8j7_e2p1m--due8Yqi6GvheCetxfBnTkT6ksOicphKJGJRbccg1tZ2DL3lRGKO7ZWnEDJ-QRaIRWpWFsBmMiXjy-PgAjY5XjK2FamkWvkLYW5aLS4VynMtrc2oJmjyElTZHFYia4hgL7opyXaqMc0uZW8wouLaiNHtCFde9trKTsYjFHgX4hJkS0PFHUo8AbJUs4e8dHU-pMusJ0fpQULeKojUPrkL6fNQnM3-Ysz_87RxYFit5qHu6K22rR4mFeJOUhWGfO-CgNdDOVvSLoXgH3Aus5uHtuOYHXX7dCKPU0mtWnxOS9UxnFLlW6GfMJqwQD7OVJGFqPairl7kzUammtyDx3x6rD1_uP39-XLvaYy19yR4w572Pv4S750TcRTCWtePKeZ7yf3NsfYYYs06NMC05Wemnn12HodgGd9TxxlgnbVYe9ITPfztWLPbe5BQU-LCBD7WjL3vHI2i4y_4FSI9DqefUZqy_PgeomCEj_VD58e_fzaaB6b9i8aZBk7HwYiPNRhR7QK_cSysqspj6Qe2LnluAw6iZCQGYwUdyo1fRJJFuGkdWMYvPwm8fBFC680EEw5X3iT9-J6MwbGRJfjZ0A8MB_Bw4A8xgomnqWUoas1TyBWEEyMcFXCZC1zOgaFXoZppsm-t0QXPCCDrPZB4rQvhOdKGIfMVqzpe71XVqQalof8k5NTyU80iymkk0rhYjFmEqrRE_4IlEP1HExuqNsBDBrMS2vd-FlPbUzwQyqcSr72KEswAGsgL8YRqLzigU3jCXzGwg6D_iywt3DOvJ0zSpGHirQInXUdJ8aFQwlwrYa2VsNdKOGslmmslWmsl0tfXZGVnFlzEDVVxDFq8vKKMa3DI8x8Hz707ESlVOeWashexoYomUULSU1WKAKobzagBOWOwgWjdwTSKENXU_aLm1CHAlC_jzRp4mYFp1gZWav1XNFnu2t6EaAvzEw5zBxz5BjV3YFBzBwZtxJFn0Naz09qBR8xdWVNnvt1gyJT5Vv7IWWzNrTUwazNs3aW1K_87O5gMxg6Wh7EDPeyaM2FXIcbcdkXaO3Bg_T1jZyHW2tZ-c8slXE8Bb6qpgtk2c1DlFtsw5C9sZ2uG5q6G1dhVjKk_Nbf3o731WDq7mVR1jFcn4jnA2DQSWjsIKNaWi9LeEm_sxv8b75S1J61dG7FJFrWlV51tY_WOhsXeVXDZWV698RGqBq5HglGtIcwPTeZuxmBnO8UuDnz2ZjbVdf72e_yOkg1na0W23-KadYPBtsFjtUNV9UnfqZHFaPlKDQuGZLTygoz87UjuG4_qcjl9Zabt6Dmv10h0-qZt-krtItDQi5FJMXAR0HJyxIfzd1T7HMkfTqXyZhF7jhXNPFVEOYwIs29Q8puphjZgjGIUJJX-Vcy8yvwIPqN8Ou8j80suF48Z9XCYgHCA_Wnys6eZtfoa-eSHo4xSWevLIsuB6Wqe-clulgOy_7VNCnLWQ9JXm1KItUav2c35bFCsdjli8Te0c6Btprc8ydw-OVr-v5b-D-NtiKs=
```

### Before screenshot:
Build B:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/48551928/8d81ed0e-fea5-4767-9f1b-f9b9d81adc17)

### After screenshot:
Build B:
![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/48551928/344b3a87-ea1b-4a89-9edd-bd6132c4d949)


# Refactor
### Scope
The refactor concerns three health pools: `Aegis`, `Guard` and `AlliesTakenBeforeYou`. The refactor is a continuation of #6391 

### Design choices
The three hit pools have been moved into their own new file `CalcHitPools.lua`. The behaviour of the pools are implemented using metatables, with each metatable sharing 5 functions / behaviours:
- `init`: Initializes values related to the pool in the `output` table.
- `new`: Acts as a construcor, creating a new instance of the hit pool, able to take damage for the player, based on the values found in `output`.
- `takeDamage`: Reduces the size of the hit pool, depending on the type of the damage taken. Only reduces values local to the pool instance.
- `adjustTotalHitPool`: Increases the players effective hit pool, depending on the values in `output`.
- `displayMaxHit`: Inserts the local values of a pool instance into a breakdown table.

A lot of behavior was duplicated across hit pools, especially allies. I have tried generalizing by extracting the keys / names used in calculations, and then looping over those keys and applying the calculation, rather than doing each key manually. My hope is that this reduces the chance of errors, and makes adding new hit pools easier in the future.