### PR TITLE
Add support for catalyst quality on imported items

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -810,8 +810,13 @@ function ImportTabClass:ImportItem(itemData, slotName)
 	end
 	if itemData.properties then
 		for _, property in pairs(itemData.properties) do
-			if property.name == "Quality" then
-				item.quality = tonumber(property.values[1][1]:match("%d+"))
+			if property.name:match("^Quality") then
+				if property.name == "Quality" then 
+					item.quality = tonumber(property.values[1][1]:match("%d+"))
+				else
+					item.catalyst = 6
+					item.catalystQuality = tonumber(property.values[1][1]:match("%d+"))
+				end
 			elseif property.name == "Radius" then
 				item.jewelRadiusLabel = property.values[1][1]
 			elseif property.name == "Limited to" then

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -814,7 +814,7 @@ function ImportTabClass:ImportItem(itemData, slotName)
 				if property.name == "Quality" then 
 					item.quality = tonumber(property.values[1][1]:match("%d+"))
 				else
-					item.catalyst = 6
+					item.catalyst = itemLib.getCatalystId("type", property.name:match("Quality%s+%((.+)%)"))
 					item.catalystQuality = tonumber(property.values[1][1]:match("%d+"))
 				end
 			elseif property.name == "Radius" then

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -720,6 +720,7 @@ end
 
 local rarityMap = { [0] = "NORMAL", "MAGIC", "RARE", "UNIQUE", [9] = "RELIC", [10] = "RELIC" }
 local slotMap = { ["Weapon"] = "Weapon 1", ["Offhand"] = "Weapon 2", ["Weapon2"] = "Weapon 1 Swap", ["Offhand2"] = "Weapon 2 Swap", ["Helm"] = "Helmet", ["BodyArmour"] = "Body Armour", ["Gloves"] = "Gloves", ["Boots"] = "Boots", ["Amulet"] = "Amulet", ["Ring"] = "Ring 1", ["Ring2"] = "Ring 2", ["Belt"] = "Belt" }
+local catalysts = itemLib.catalysts
 
 function ImportTabClass:ImportItem(itemData, slotName)
 	if not slotName then
@@ -899,7 +900,16 @@ function ImportTabClass:ImportItem(itemData, slotName)
 		for _, line in ipairs(itemData.implicitMods) do
 			for line in line:gmatch("[^\n]+") do
 				local modList, extra = modLib.parseMod(line)
-				t_insert(item.implicitModLines, { line = line, extra = extra, mods = modList or { } })
+				local modTags = modLib.getModTagsFromModList(modList)
+				if item.catalyst and item.catalyst > 0  and modTags then
+					local catalystTags = catalysts[item.catalyst].tags
+					for _, tag in ipairs(modTags) do
+						if isValueInArray(catalystTags, tag) then
+							line = line:gsub("(%d+)", function(num) return math.ceil(num / (1 + item.catalystQuality / 100)) end)
+						end
+					end
+				end
+				t_insert(item.implicitModLines, { line = line, extra = extra, mods = modList or { }, modTags = modTags })
 			end
 		end
 	end
@@ -907,7 +917,16 @@ function ImportTabClass:ImportItem(itemData, slotName)
 		for _, line in ipairs(itemData.fracturedMods) do
 			for line in line:gmatch("[^\n]+") do
 				local modList, extra = modLib.parseMod(line)
-				t_insert(item.explicitModLines, { line = line, extra = extra, mods = modList or { }, fractured = true })
+				local modTags = modLib.getModTagsFromModList(modList)
+				if item.catalyst and item.catalyst > 0  and modTags then
+					local catalystTags = catalysts[item.catalyst].tags
+					for _, tag in ipairs(modTags) do
+						if isValueInArray(catalystTags, tag) then
+							line = line:gsub("(%d+)", function(num) return math.ceil(num / (1 + item.catalystQuality / 100)) end)
+						end
+					end
+				end
+				t_insert(item.explicitModLines, { line = line, extra = extra, mods = modList or { }, modTags = modTags, fractured = true })
 			end
 		end
 	end
@@ -915,7 +934,16 @@ function ImportTabClass:ImportItem(itemData, slotName)
 		for _, line in ipairs(itemData.explicitMods) do
 			for line in line:gmatch("[^\n]+") do
 				local modList, extra = modLib.parseMod(line)
-				t_insert(item.explicitModLines, { line = line, extra = extra, mods = modList or { } })
+				local modTags = modLib.getModTagsFromModList(modList)
+				if item.catalyst and item.catalyst > 0  and modTags then
+					local catalystTags = catalysts[item.catalyst].tags
+					for _, tag in ipairs(modTags) do
+						if isValueInArray(catalystTags, tag) then
+							line = line:gsub("(%d+)", function(num) return math.ceil(num / (1 + item.catalystQuality / 100)) end)
+						end
+					end
+				end
+				t_insert(item.explicitModLines, { line = line, extra = extra, mods = modList or { }, modTags = modTags })
 			end
 		end
 	end
@@ -931,7 +959,16 @@ function ImportTabClass:ImportItem(itemData, slotName)
 		for _, line in ipairs(itemData.craftedMods) do
 			for line in line:gmatch("[^\n]+") do
 				local modList, extra = modLib.parseMod(line)
-				t_insert(item.explicitModLines, { line = line, extra = extra, mods = modList or { }, crafted = true })
+				local modTags = modLib.getModTagsFromModList(modList)
+				if item.catalyst and item.catalyst > 0  and modTags then
+					local catalystTags = catalysts[item.catalyst].tags
+					for _, tag in ipairs(modTags) do
+						if isValueInArray(catalystTags, tag) then
+							line = line:gsub("(%d+)", function(num) return math.ceil(num / (1 + item.catalystQuality / 100)) end)
+						end
+					end
+				end
+				t_insert(item.explicitModLines, { line = line, extra = extra, mods = modList or { }, modTags = modTags, crafted = true })
 			end
 		end
 	end

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -11,22 +11,10 @@ local m_max = math.max
 local m_floor = math.floor
 
 local dmgTypeList = {"Physical", "Lightning", "Cold", "Fire", "Chaos"}
-local catalystList = {"Abrasive", "Accelerating", "Fertile", "Imbued", "Intrinsic", "Noxious", "Prismatic", "Tempering", "Turbulent", "Unstable"}
-local catalystTags = {
-	{ "attack" },
-	{ "speed" },
-	{ "life", "mana", "resource" },
-	{ "caster" },
-	{ "jewellery_attribute", "attribute" },
-	{ "physical_damage", "chaos_damage" },
-	{ "jewellery_resistance", "resistance" },
-	{ "jewellery_defense", "defences" },
-	{ "jewellery_elemental" ,"elemental_damage" },
-	{ "critical" },
-}
 
+local catalysts = itemLib.catalysts
 local function getCatalystScalar(catalystId, tags, quality)
-	if not catalystId or type(catalystId) ~= "number" or not catalystTags[catalystId] or not tags or type(tags) ~= "table" or #tags == 0 then
+	if not catalystId or type(catalystId) ~= "number" or not catalysts[catalystId] or not tags or type(tags) ~= "table" or #tags == 0 then
 		return 1
 	end
 	if not quality then
@@ -40,7 +28,7 @@ local function getCatalystScalar(catalystId, tags, quality)
 	end
 
 	-- Find if any of the catalyst's tags match the provided tags
-	for _, catalystTag in ipairs(catalystTags[catalystId]) do
+	for _, catalystTag in ipairs(catalysts[catalystId].tags) do
 		if tagLookup[catalystTag] then
 			return (100 + quality) / 100
 		end
@@ -557,11 +545,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 						self.clusterJewelNodeCount = m_min(m_max(num, self.clusterJewel.minNodes), self.clusterJewel.maxNodes)
 					end
 				elseif specName == "Catalyst" then
-					for i=1, #catalystList do
-						if specVal == catalystList[i] then
-							self.catalyst = i
-						end
-					end
+						self.catalyst = itemLib.getCatalystId("name", specVal)
 				elseif specName == "CatalystQuality" then
 					self.catalystQuality = specToNumber(specVal)
 				elseif specName == "Note" then
@@ -977,7 +961,7 @@ function ItemClass:BuildRaw()
 		end
 	end
 	if self.catalyst and self.catalyst > 0 then
-		t_insert(rawLines, "Catalyst: " .. catalystList[self.catalyst])
+		t_insert(rawLines, "Catalyst: " .. catalysts[self.catalyst].name)
 	end
 	if self.catalystQuality then
 		t_insert(rawLines, "CatalystQuality: " .. self.catalystQuality)

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -34,18 +34,7 @@ local baseSlots = { "Weapon 1", "Weapon 2", "Helmet", "Body Armour", "Gloves", "
 
 local influenceInfo = itemLib.influenceInfo
 
-local catalystQualityFormat = {
-	"^x7F7F7FQuality (Attack Modifiers): "..colorCodes.MAGIC.."+%d%% (augmented)",
-	"^x7F7F7FQuality (Speed Modifiers): "..colorCodes.MAGIC.."+%d%% (augmented)",
-	"^x7F7F7FQuality (Life and Mana Modifiers): "..colorCodes.MAGIC.."+%d%% (augmented)",
-	"^x7F7F7FQuality (Caster Modifiers): "..colorCodes.MAGIC.."+%d%% (augmented)",
-	"^x7F7F7FQuality (Attribute Modifiers): "..colorCodes.MAGIC.."+%d%% (augmented)",
-	"^x7F7F7FQuality (Physical and Chaos Modifiers): "..colorCodes.MAGIC.."+%d%% (augmented)",
-	"^x7F7F7FQuality (Resistance Modifiers): "..colorCodes.MAGIC.."+%d%% (augmented)",
-	"^x7F7F7FQuality (Defense Modifiers): "..colorCodes.MAGIC.."+%d%% (augmented)",
-	"^x7F7F7FQuality (Elemental Modifiers): "..colorCodes.MAGIC.."+%d%% (augmented)",
-	"^x7F7F7FQuality (Critical Modifiers): "..colorCodes.MAGIC.."+%d%% (augmented)",
-}
+local catalysts = itemLib.catalysts
 
 local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Control", function(self, build)
 	self.UndoHandler()
@@ -3266,8 +3255,8 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 		end
 	end
 	
-	if item.catalyst and item.catalyst > 0 and item.catalyst <= #catalystQualityFormat and item.catalystQuality and item.catalystQuality > 0 then
-		tooltip:AddLine(16, s_format(catalystQualityFormat[item.catalyst], item.catalystQuality))
+	if item.catalyst and item.catalyst > 0 and item.catalyst <= #catalysts and item.catalystQuality and item.catalystQuality > 0 then
+		tooltip:AddLine(16, s_format("^x7F7F7FQuality ("..catalysts[item.catalyst].type.."): "..colorCodes.MAGIC.."+%d%% (augmented)", item.catalystQuality))
 		tooltip:AddSeparator(10)
 	end
 

--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -153,3 +153,64 @@ itemLib.wiki = {
 	end,
 	triggered = false
 }
+
+itemLib.catalysts = {
+	{
+		name = "Abrasive",
+		type = "Attack Modifiers",
+		tags = { "attack" },
+	},
+	{
+		name = "Accelerating",
+		type = "Speed Modifiers",
+		tags = { "speed" },
+	},
+	{
+		name = "Fertile",
+		type = "Life and Mana Modifiers",
+		tags = { "life", "mana", "resource" },
+	},
+	{
+		name = "Imbued",
+		type = "Caster Modifiers",
+		tags = { "caster" }
+	},
+	{
+		name = "Intrinsic",
+		type = "Attribute Modifiers",
+		tags = { "jewellery_attribute", "attribute" },
+	},
+	{
+		name = "Noxious",
+		type = "Physical and Chaos Damage Modifiers",
+		tags = { "physical_damage", "chaos_damage" },
+	},
+	{
+		name = "Prismatic",
+		type = "Resistance Modifiers",
+		tags = { "jewellery_resistance", "resistance" },
+	},
+	{
+		name = "Tempering",
+		type = "Defense Modifiers",
+		tags = { "jewellery_defense", "defences" },
+	},
+	{
+		name = "Turbulent",
+		type = "Elemental Modifiers",
+		tags = { "jewellery_elemental", "elemental_damage" },
+	},
+	{
+		name = "Unstable",
+		type = "Critical Modifiers",
+		tags = { "critical" },
+	},
+}
+
+itemLib.getCatalystId = function(key, val)
+	for id, catalyst in ipairs(itemLib.catalysts) do
+		if val == catalyst[key] then
+			return id
+		end
+	end
+end

--- a/src/Modules/ModTools.lua
+++ b/src/Modules/ModTools.lua
@@ -217,3 +217,122 @@ function modLib.setSource(mod, source)
 	end
 	return mod
 end
+
+function modLib.getModTagsFromModList(modList)
+	if not modList then
+		return
+	end
+	local modTags = { }
+	for _, mod in ipairs(modList) do
+		if mod.name == "MinionModifier" then
+			mod = mod.value.mod
+		end
+		if isValueInArray({"Str", "Dex", "Int", "StrDex", "StrInt", "DexInt", "All"}, mod.name) then
+			table.insert(modTags, "attribute")
+		elseif isValueInArray( {
+			"Life", 
+			"LifeRegen", 
+			"LifeRecoup",
+			"LifeOnKill",
+			"LifeOnHit",
+			"LifeLeech",
+			"LifeLeechRate",
+			"FlaskLifeRecovery",
+			"LifeReservationEfficiency",
+			"LifeRecoveryRate",
+		}, mod.name) then
+			table.insert(modTags, "life")
+		elseif isValueInArray({
+			"Mana", 
+			"ManaRegen", 
+			"ManaCost", 
+			"ManaRecoup",
+			"ManaOnKill",
+			"ManaOnHit",
+			"ManaLeech",
+			"ManaRecoveryRate",
+			"ManaReservationEfficiency",
+			"FlaskManaRecoveryRate",
+		}, mod.name) then
+			table.insert(modTags, "mana")
+		elseif isValueInArray({
+			"EnergyShield", 
+			"EnergyShieldRegenPercent",
+			"EnergyShieldRecoveryRate",
+			"EnergyShieldLeech",
+			"MaxEnergyShieldLeechRate",
+			"Armour", 
+			"ArmourDefense",
+			"Evasion", 
+			"EvadeChance",
+			"ArmourAndEvasion",
+			"ArmourAndEnergyShield",
+			"EvasionAndEnergyShield",
+		}, mod.name) then
+			table.insert(modTags, "defences")
+		elseif isValueInArray({
+			"FireResist",
+			"ColdResist", 
+			"LightningResist", 
+			"ChaosResist",
+			"ElementalResist",
+		}, mod.name) then
+			table.insert(modTags, "resistance")
+		elseif isValueInArray({
+			"PhysicalDamage",
+			"HeartboundLoopSelfDamage",
+		}, mod.name) then
+			table.insert(modTags, "physical_damage")
+		-- TODO Figure out Poison Damage
+		-- Figure out gain as
+		elseif isValueInArray({
+			"ChaosDamage",
+			"EnemyPoisonDuration",
+		}, mod.name) then
+			table.insert(modTags, "chaos_damage")
+		-- TODO Figure out elemental leech
+		--  Figure out Gain as 
+		elseif isValueInArray({
+			"ElementalDamage",
+			"FireDamage",
+			"ColdDamage",
+			"LightningDamage",
+		}, mod.name) then
+			table.insert(modTags, "elemental_damage")
+		elseif mod.flags == ModFlag.Attack or mod.flags == ModFlag.Melee 
+			or mod.keywordFlags == KeywordFlag.Attack or mod.keywordFlags == KeywordFlag.Bleed
+			or isValueInArray({
+			"Accuracy",
+			"MeleeWeaponRange",
+			"MeleeWeaponRangeMetre",
+			"UnarmedRange",
+			"UnarmedRangeMetre",
+			"ImpaleChance",
+		}, mod.name) then
+			table.insert(modTags, "attack")
+		elseif mod.flags == ModFlag.Spell or mod.Flags == ModFlag.Cast 
+			or mod.keywordFlags == KeywordFlag.Spell or mod.keywordFlags == KeywordFlag.Curse
+			or isValueInArray({
+			"BrandAttachmentRange",
+			"CurseEffectOnSelf",
+		}, mod.name) then
+			table.insert(modTags, "caster")
+		elseif isValueInArray({
+			"ProjectileSpeed",
+			"Speed",
+			"TrapThrowingSpeed",
+			"MineLayingSpeed",
+			"TotemPlacementSpeed",
+			"MovementSpeed",
+			"WarcrySpeed",
+		}, mod.name) then
+			table.insert(modTags, "speed")
+		elseif isValueInArray({
+			"CritChance",
+			"CritMultiplier",
+		}, mod.name) then
+			table.insert(modTags, "critical")
+		end
+	end
+	return modTags
+end


### PR DESCRIPTION
Fixes #4662  .

### Description of the problem being solved:
Currently when importing jewellery there is no way to catalyst the items.
This PR implements this feature by the following flow:
- Use the quality property on the extracted data to set the `catalyst` property on the item instance.
- Add `modTags` to the implicit, explicit, fractured and crafted lines of the item by iterating through the `modList` returned by `modParse`. 
  This steps checks against a predefined list of mods and flags that would count as the tag.
- Reverse the quality to affected lines by dividing through the increase to obtain the base values. This is required because the extracted data has the quality increased baked into the value.

### Steps taken to verify a working solution:
- [x] Tested a few of my own characters

### TODO
- [ ] Test scenarios where `modTags` might get the same tag twice e.g. `16% increased fire and lightning resistance`
- [ ] Test the predefined list for errors
- [ ] Add less straightforwards mods such as elemental gain as, chaos gain as, poison duration
- [ ] Add support for unique item mods

### Other
- Ideally add support for pasted items as well

