### PR TITLE
Fix extended hash in exported url

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -129,7 +129,12 @@ function PassiveSpecClass:Load(xml, dbFileName)
 		end
 		local hashList = { }
 		for hash in xml.attrib.nodes:gmatch("%d+") do
-			t_insert(hashList, tonumber(hash))
+			hash = tonumber(hash)
+			-- if 									cluster node    and  old node flag is true
+			if not self.oldClusterGeneration and (hash >= 65536) and (band(hash, 0x8000) == 0) then 
+				self.oldClusterGeneration = true
+			end
+			t_insert(hashList, hash)
 		end
 		local masteryEffects = { }
 		if xml.attrib.masteryEffects then
@@ -476,8 +481,9 @@ function PassiveSpecClass:EncodeURL(prefix)
 	local clusterCount = 0
 	local masteryCount = 0
 
+	local nodeIds = {}
 	local clusterNodeIds = {}
-	local masteryNodeIds = {}
+	local masteryNodes = {}
 	
 	local computeClusterId = function(id, oidx)
 		local socketType = band(b_rshift(id, 11), 3) -- 0 if socketed into large socket, 1 for medium, 2 for small
@@ -485,7 +491,7 @@ function PassiveSpecClass:EncodeURL(prefix)
 		local largeIndex = band(b_rshift(id, 6), 7)
 		local mediumIndex = band(b_rshift(id, 9), 3)
 		local nodeIndex
-		if socketType == 2 and groupSize > 0 then
+		if socketType == 0 and groupSize > 0 then
 			nodeIndex = ({[0] = 0, 1, 1, 2, 3, 4, 4, 5, 6, 7, 7,  8,  9, 10, 10, 11})[oidx]
 		elseif socketType == 1 and groupSize == 1 then
 			nodeIndex = ({[0] = 0, 0, 0, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5, 5, 5})[oidx] -- index mapping for 2 and 10 are estimated, could not figure out mapping based on testing
@@ -514,34 +520,42 @@ function PassiveSpecClass:EncodeURL(prefix)
 
 	for id, node in pairs(self.allocNodes) do
 		if node.type ~= "ClassStart" and node.type ~= "AscendClassStart" and id < 65536 and nodeCount < 255 and not node.hashId then
-			t_insert(a, m_floor(id / 256))
-			t_insert(a, id % 256)
+			t_insert(nodeIds, id)
 			nodeCount = nodeCount + 1
 			if self.masterySelections[node.id] then
-				local effect_id = self.masterySelections[node.id]
-				t_insert(masteryNodeIds, m_floor(effect_id / 256))
-				t_insert(masteryNodeIds, effect_id % 256)
-				t_insert(masteryNodeIds, m_floor(node.id / 256))
-				t_insert(masteryNodeIds, node.id % 256)
+				t_insert(masteryNodes, {nodeId = node.id, effectId = self.masterySelections[node.id]})
 				masteryCount = masteryCount + 1
 			end
 		elseif id >= 65536 or node.hashId then
 			local clusterId = computeClusterId(node.hashId or id, node.oidx)
-			t_insert(clusterNodeIds, m_floor(clusterId / 256))
-			t_insert(clusterNodeIds, clusterId % 256)
+			t_insert(clusterNodeIds, clusterId)
 			clusterCount = clusterCount + 1
 		end
 	end
-	t_insert(a, 7, nodeCount)
+	
+	-- Sort ids to ensure generated URL is the same as PoE
+	table.sort(nodeIds)
+	table.sort(masteryNodes, function(a, b) return a.nodeId < b.nodeId end)
+	table.sort(clusterNodeIds)
+	
+	t_insert(a, nodeCount)
+	for _, id in pairs(nodeIds) do
+		t_insert(a, m_floor(id / 256))
+		t_insert(a, id % 256)
+	end
 
 	t_insert(a, clusterCount)
 	for _, id in pairs(clusterNodeIds) do
-		t_insert(a, id)
+		t_insert(a, m_floor(id / 256))
+		t_insert(a, id % 256)
 	end
 
 	t_insert(a, masteryCount)
-	for _, id in pairs(masteryNodeIds) do
-		t_insert(a, id)
+	for _, node in pairs(masteryNodes) do
+		t_insert(a, m_floor(node.effectId / 256))
+		t_insert(a, node.effectId % 256)
+		t_insert(a, m_floor(node.nodeId / 256))
+		t_insert(a, node.nodeId % 256)
 	end
 
 	return (prefix or "")..common.base64.encode(string.char(unpack(a))):gsub("+","-"):gsub("/","_")
@@ -1404,9 +1418,15 @@ function PassiveSpecClass:BuildSubgraph(jewel, parentSocket, id, upSize, importe
 	-- 9-10: Medium index (0-2)
 	-- 11-12: Socket type - 0 for large, 1 for medium, or 2 for small
 	-- This is to differentiate between a small/medium cluster jewel socketed into a large/medium/small cluster socket
-	-- 13-15: Unused
+	-- 13-14: Unused
+	-- 15: 1 since version 2.38.5? to be used for backwards compatibility, 0 otherwise
+	-- This bit is used to check when builds are later imported to see if the old method of generating nodeIds need to be applied
 	-- 16: 1 (signal bit, to prevent conflict with node hashes)
-	id = (id and id + 0x00800) or 0x10000 -- Increment the socket type when called with an existing id
+	if self.oldClusterGeneration then
+		id = id or 0x10000
+	else
+		id = (id and id + 0x00800) or 0x18000 -- Increment the socket type when called with an existing id
+	end
 	if expansionJewel.size == 2 then
 		id = id + b_lshift(expansionJewel.index, 6)
 	elseif expansionJewel.size == 1 then


### PR DESCRIPTION
Fixes #6736 .

### Description of the problem being solved:
Currently the passive URL generated during export is different to the one from the official site.
This is because PoB generates the extended hashes using by converting an internal nodeId and doesn't sort the hashes before encoding. 
This PR aligns the extended hashes with what is exported from the official site, as well as ensuring the same sorting of the hashes to generate the same URL as the official site.

### Whats changed?
- The internal `nodeId` for cluster nodes has been updated to include 2 bits which determine the type of socket the cluster jewel is a part of. This will be 0 if the node belongs to a cluster jewel socketed into a large cluster socket, 1 if socketed into a medium cluster socket and 2 if socketed into a small cluster socket.
- This `nodeId` also includes a new bit flag to indicate if it's using the new version to allow for backwards compatibility. This means that previously saved builds will still load correctly.
- Added sorting of hashes in `PassiveSpecClass:EncodeURL()` 

### Steps taken to verify a working solution:
- Will test further before unmarking as draft, has worked so far with the handful of builds that I've tested. 
