### PR TITLE
[UI] Show config option as valid if any active skill has valid flags and tags, not just the main skill.

### DIFF
--- a/src/Classes/ConfigTab.lua
+++ b/src/Classes/ConfigTab.lua
@@ -417,10 +417,16 @@ local ConfigTabClass = newClass("ConfigTab", "UndoHandler", "ControlHost", "Cont
 			end
 			if varData.ifFlag then
 				t_insert(shownFuncs, listOrSingleIfOption(varData.ifFlag, function(ifOption)
-					local skillModList = self.build.calcsTab.mainEnv.player.mainSkill.skillModList
-					local skillFlags = self.build.calcsTab.mainEnv.player.mainSkill.skillFlags
-					-- Check both the skill mods for flags and flags that are set via calcPerform
-					return skillFlags[ifOption] or skillModList:Flag(nil, ifOption)
+					for _, activeSkill in ipairs(self.build.calcsTab.mainEnv.player.activeSkillList) do
+						local skillModList = activeSkill.skillModList
+						local skillFlags = activeSkill.skillFlags
+
+						-- Check both the skill mods for flags and flags that are set via calcPerform
+						if skillFlags[ifOption] or skillModList:Flag(nil, ifOption) then
+							return true
+						end
+					end
+					return false
 				end))
 			end
 			if varData.ifMod then

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -580,19 +580,29 @@ function calcs.buildOutput(build, mode)
 			end
 		end
 		for _, activeSkill in pairs(env.player.activeSkillList) do
+			local uuid = cacheSkillUUID(activeSkill, env)
+			if not GlobalCache.cachedData["CACHE"][uuid] then
+				calcs.buildActiveSkill(env, "CACHE", activeSkill)
+			end
+
 			for _, mod in ipairs(activeSkill.baseSkillModList) do
 				addModTags(env.player, mod)
 			end
-			for _, mod in ipairs(activeSkill.skillModList) do
-				addTo(env.modsUsed, mod.name, mod)
-				for _, tag in ipairs(mod) do
-					addTo(env.tagTypesUsed, tag.type, mod)
-				end
-			end
+
 			if activeSkill.minion then
 				for _, activeSkill in pairs(activeSkill.minion.activeSkillList) do
 					for _, mod in ipairs(activeSkill.baseSkillModList) do
 						addModTags(env.minion, mod)
+					end
+				end
+			end
+
+			if GlobalCache.cachedData["CACHE"][uuid] then
+				skillModList = GlobalCache.cachedData["CACHE"][uuid].ActiveSkill.skillModList
+				for _, mod in ipairs(skillModList) do
+					addTo(env.modsUsed, mod.name, mod)
+					for _, tag in ipairs(mod) do
+						addTo(env.tagTypesUsed, tag.type, mod)
 					end
 				end
 			end


### PR DESCRIPTION
Fixes #7360 .

### Description of the problem being solved:

Currently a config option in the Config tab will be set to show only if the selected main skill has both relevant tags and flags.

For instance, when using a projectile skill with Point Blank, the user can change the Projectile distance travelled config and the DPS calculation will be updated accordingly. If the user then changes the main skill dropdown to a non-projectile skill, the Projectile distance travelled config will then appear as invalid, even when still affecting the DPS calculation. 

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/58695361/92857f1b-5b4e-4feb-aa4c-dce7c5f31500)

This also happens with similarly tag-limited config like any melee skill supported by Close Combat support.

Note that if a skill with the correct tag is selected as main skill, the config will show as valid, even though the the DPS of the selected skill is not affected by the config. For instance, if a Boneshatter gem is linked to Close Combat support, the config will appear valid as long as a melee skill is selectd as main skill, even if that melee skill is not supported by Close Combat (for instance an unlinked Leap Slam).

This is confusing. 

This commit makes it so as long as any active skill has a corresponding tag, the config will show as valid. This will not affect DPS calculations as the tagTypesUsed and modsUsed arrays are only checked by the Config Tab UI code.

A possible downside is that someone could accidentally link say, Close Combat to Leap Slam, and then get confused why the config tab is appearing but not affecting their actual main skill dps. I think this is less potentially confusing for anyone who is familiar with PoE than the current state.

### Steps taken to verify a working solution:
- Create a new build.  
- Add one projectile attack to the build (for instance, Splitting Steel) and any other non-projectile skill.
- In the Item tab, equip a Beltimber Blade.
- Select the projectile attack as your main skill and go to the Configuration tab.
- Set the Projectile travel distance config to 70.
- Select smite as your main skill
- Notice the Projectile Travel Distance checkbox displays no error. 

(Alternatively you can import the linked build, open the Config tab, and select different skills as your main skill)

### Link to a build that showcases this PR:
```
https://pobb.in/BEdB7P5GZ-5p
```
### Before screenshot:

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/58695361/35b8b003-2903-4703-aa9f-83a3811976b2)

### After screenshot:

![image](https://github.com/PathOfBuildingCommunity/PathOfBuilding/assets/58695361/effd91ea-90bd-4fc1-a8a6-ceeb14dadf46)
