### PR TITLE
Proposal API contract

### DIFF
--- a/docs/APIContract.md
+++ b/docs/APIContract.md
@@ -9,6 +9,7 @@ The base URL for an API should be: _baseURL_/_apiVersion_/ meaning even somethin
 In order to provide a consistent API a metadata endpoint should be provided under _baseURL_/.well-known/pathofbuilding this endpoint should provide information about the API and the version of the API.
 Furthermore this may allow having custom endpoints for the API.
 
+<details><summary><b>Specification</b></summary>
 | Feature          | Field         | Type             | Description                                                                          |
 | ---------------- | ------------- | ---------------- | ------------------------------------------------------------------------------------ |
 | League Filtering | league_filter | bool             | This can  be used to indicate whether the API supports filtering based on leagues    |
@@ -16,9 +17,11 @@ Furthermore this may allow having custom endpoints for the API.
 | Streams          | streams       | StreamInfo[]     | A list of streams available to be queried against                                    |
 | Update Builds    | update_builds | UpdateBuildsInfo | Indicates if the API supports updating builds via PoB and which fields are supported |
 
+</details>
+
 ### Types
 
-#### StreamInfo
+<details><summary><b>StreamInfo</b></summary>
 
 | Field   | Type   | Description                     |
 | ------- | ------ | ------------------------------- |
@@ -26,9 +29,9 @@ Furthermore this may allow having custom endpoints for the API.
 | apiPath | string | API path to the stream endpoint |
 
 apiPath might be changed to a generic endpoint such as `/v1/{stream}/builds`
+</details>
 
-#### UpdateBuildsInfo
-
+<details><summary><b>UpdateBuildsInfo</b></summary>
 | Field      | Type     | Description                                            |
 | ---------- | -------- | ------------------------------------------------------ |
 | hasSupport | bool     | indicates if the API supports updating external builds |
@@ -42,11 +45,13 @@ Example:
     "fields": ["description", "youtubeUrl"]
 }
 ```
+</details>
+
 ## Version 1
 
 ### Response and Request types
 
-#### BuildInfo
+<details><summary><b>BuildInfo</b></summary>
 
 | Field        | Type    | Description                         |
 | ------------ | ------- | ----------------------------------- |
@@ -54,6 +59,7 @@ Example:
 | name         | string  | The name of the build               |
 | lastModified | integer | The last modification timestamp     |
 | buildId      | string  | The unique identifier for the build |
+</details>
 
 ### Endpoints
 

--- a/docs/APIContract.md
+++ b/docs/APIContract.md
@@ -9,11 +9,12 @@ The base URL for an API should be: _baseURL_/_apiVersion_/ meaning even somethin
 In order to provide a consistent API a metadata endpoint should be provided under _baseURL_/.well-known/pathofbuilding this endpoint should provide information about the API and the version of the API.
 Furthermore this may allow having custom endpoints for the API.
 
-| Feature          | Field         | Type         | Description                                                                       |
-| ---------------- | ------------- | ------------ | --------------------------------------------------------------------------------- |
-| League Filtering | league_filter | bool         | This can  be used to indicate whether the API supports filtering based on leagues |
-| Gem Filtering    | gem_filter    | bool         | This can  be used to indicate whether the API supports filtering based on gems    |
-| Streams          | streams       | StreamInfo[] | A list of streams available to be queried against                                 |
+| Feature          | Field         | Type             | Description                                                                          |
+| ---------------- | ------------- | ---------------- | ------------------------------------------------------------------------------------ |
+| League Filtering | league_filter | bool             | This can  be used to indicate whether the API supports filtering based on leagues    |
+| Gem Filtering    | gem_filter    | bool             | This can  be used to indicate whether the API supports filtering based on gems       |
+| Streams          | streams       | StreamInfo[]     | A list of streams available to be queried against                                    |
+| Update Builds    | update_builds | UpdateBuildsInfo | Indicates if the API supports updating builds via PoB and which fields are supported |
 
 ### Types
 
@@ -26,6 +27,21 @@ Furthermore this may allow having custom endpoints for the API.
 
 apiPath might be changed to a generic endpoint such as `/v1/{stream}/builds`
 
+#### UpdateBuildsInfo
+
+| Field      | Type     | Description                                            |
+| ---------- | -------- | ------------------------------------------------------ |
+| hasSupport | bool     | indicates if the API supports updating external builds |
+| fields     | string[] | list of fields that can be updated                     |
+
+Example:
+
+```json
+{
+    "hasSupport": true,
+    "fields": ["description", "youtubeUrl"]
+}
+```
 ## Version 1
 
 ### Response and Request types
@@ -42,7 +58,7 @@ apiPath might be changed to a generic endpoint such as `/v1/{stream}/builds`
 ### Endpoints
 
 <details>
- <summary><code>GET</code> <code><b>/v1/{stream}/builds</b></code> <code>(Lists multiple builds)</code></summary>
+ <summary><code>GET</code> <code><b>/v1/builds</b></code> <code>(Lists multiple builds)</code></summary>
 
 #### Parameters
 > Query Parameters
@@ -74,6 +90,39 @@ Example values:
 | http code | content-type       | response           |
 | --------- | ------------------ | ------------------ |
 | `200`     | `application/json` | `BuildInfo object` |
+
+</details>
+
+
+<details>
+ <summary><code>POST</code> <code><b>/v1/builds/{buildId}</b></code> <code>(Update a single build on the source)</code></summary>
+
+#### Parameters
+> Path Parameters
+
+| name    | type     | data type | description                                                |
+| ------- | -------- | --------- | ---------------------------------------------------------- |
+| buildId | required | string    | The build in question on the source that should be updated |
+
+#### Request
+
+| Field      | Type     | Description                        |
+| ---------- | -------- | ---------------------------------- |
+| pobdata    | string   | The Path of Building data          |
+| name       | string   | The name of the build              |
+| customData | string[] | A list of custom data to be stored |
+
+customData will be describable fields via the metadata endpoint, if customData is empty it is expected to be ignored and no changes should be made.
+
+#### Responses
+
+| http code | content-type               | response              | Description            |
+| --------- | -------------------------- | --------------------- | ---------------------- |
+| `200`     | `application/json`         | None                  | Update succesful       |
+| `201`     | `application/json`         | None                  | Succesful creation     |
+| `400`     | `text/html; charset=utf-8` | `Reason for failure`  | Input may be incorrect |
+| `401`     | `text/html; charset=utf-8` | `Reason if necessary` | Auth incorrect         |
+| `404`     | `text/html; charset=utf-8` | None                  | Build does not exist   |
 
 </details>
 

--- a/docs/APIContract.md
+++ b/docs/APIContract.md
@@ -9,10 +9,22 @@ The base URL for an API should be: _baseURL_/_apiVersion_/ meaning even somethin
 In order to provide a consistent API a metadata endpoint should be provided under _baseURL_/.well-known/pathofbuilding this endpoint should provide information about the API and the version of the API.
 Furthermore this may allow having custom endpoints for the API.
 
-| Feature          | Field         | Type | Description                                                                       |
-| ---------------- | ------------- | ---- | --------------------------------------------------------------------------------- |
-| League Filtering | league_filter | bool | This can  be used to indicate whether the API supports filtering based on leagues |
-| Gem Filtering    | gem_filter    | bool | This can  be used to indicate whether the API supports filtering based on gems    |
+| Feature          | Field         | Type         | Description                                                                       |
+| ---------------- | ------------- | ------------ | --------------------------------------------------------------------------------- |
+| League Filtering | league_filter | bool         | This can  be used to indicate whether the API supports filtering based on leagues |
+| Gem Filtering    | gem_filter    | bool         | This can  be used to indicate whether the API supports filtering based on gems    |
+| Streams          | streams       | StreamInfo[] | A list of streams available to be queried against                                 |
+
+### Types
+
+#### StreamInfo
+
+| Field   | Type   | Description                     |
+| ------- | ------ | ------------------------------- |
+| name    | string | Name of the stream              |
+| apiPath | string | API path to the stream endpoint |
+
+apiPath might be changed to a generic endpoint such as `/v1/{stream}/builds`
 
 ## Version 1
 
@@ -30,7 +42,7 @@ Furthermore this may allow having custom endpoints for the API.
 ### Endpoints
 
 <details>
- <summary><code>GET</code> <code><b>/v1/builds</b></code> <code>(Lists multiple builds)</code></summary>
+ <summary><code>GET</code> <code><b>/v1/{stream}/builds</b></code> <code>(Lists multiple builds)</code></summary>
 
 #### Parameters
 > Query Parameters
@@ -43,19 +55,19 @@ Furthermore this may allow having custom endpoints for the API.
 
 ##### League
 
-The values should be matching what Grinding Gear Games will be using for the teaser part of the website, such as: _https://www.pathofexile.com/settlers_ or _https://www.pathofexile.com/affliction_. This allows for easier mapping of the data as neither PoB nor the API will be required to wait for either party.
+These values will just be the base patch version for the league.
 
 These links are generally available via poewiki see: https://www.poewiki.net/wiki/Necropolis_league _Official Page_.
 
 Example values:
 
-| Patch | League                 | value      | url                                    |
-| ----- | ---------------------- | ---------- | -------------------------------------- |
-| 3.25  | Settlers of Kalguur    | settlers   | https://www.pathofexile.com/settlers   |
-| 3.24  | Necropolis             | necropolis | https://www.pathofexile.com/necropolis |
-| 3.23  | Affliction             | affliction | https://www.pathofexile.com/affliction |
-| 3.22  | Trial of the Ancestors | ancestor   | https://www.pathofexile.com/ancestor   |
-| 3.4   | Delve                  | delve      | https://www.pathofexile.com/delve      |
+| Patch | League                 | value | url                                    |
+| ----- | ---------------------- | ----- | -------------------------------------- |
+| 3.25  | Settlers of Kalguur    | 3.25  | https://www.pathofexile.com/settlers   |
+| 3.24  | Necropolis             | 3.24  | https://www.pathofexile.com/necropolis |
+| 3.23  | Affliction             | 3.23  | https://www.pathofexile.com/affliction |
+| 3.22  | Trial of the Ancestors | 3.22  | https://www.pathofexile.com/ancestor   |
+| 3.4   | Delve                  | 3.4   | https://www.pathofexile.com/delve      |
 
 #### Responses
 

--- a/docs/APIContract.md
+++ b/docs/APIContract.md
@@ -9,6 +9,11 @@ The base URL for an API should be: _baseURL_/_apiVersion_/ meaning even somethin
 In order to provide a consistent API a metadata endpoint should be provided under _baseURL_/.well-known/pathofbuilding this endpoint should provide information about the API and the version of the API.
 Furthermore this may allow having custom endpoints for the API.
 
+| Feature          | Field         | Type | Description                                                                       |
+| ---------------- | ------------- | ---- | --------------------------------------------------------------------------------- |
+| League Filtering | league_filter | bool | This can  be used to indicate whether the API supports filtering based on leagues |
+| Gem Filtering    | gem_filter    | bool | This can  be used to indicate whether the API supports filtering based on gems    |
+
 ## Version 1
 
 ### Response and Request types
@@ -28,10 +33,29 @@ Furthermore this may allow having custom endpoints for the API.
  <summary><code>GET</code> <code><b>/v1/builds</b></code> <code>(Lists multiple builds)</code></summary>
 
 #### Parameters
+> Query Parameters
 
-| name | type     | data type | description         |
-| ---- | -------- | --------- | ------------------- |
-| page | optional | integer   | Used for pagination |
+| name   | type     | data type | description                             |
+| ------ | -------- | --------- | --------------------------------------- |
+| page   | optional | integer   | Used for pagination                     |
+| league | optional | string    | Used to limit builds to a league        |
+| gems   | optional | string    | Used to limit builds with specific gems |
+
+##### League
+
+The values should be matching what Grinding Gear Games will be using for the teaser part of the website, such as: _https://www.pathofexile.com/settlers_ or _https://www.pathofexile.com/affliction_. This allows for easier mapping of the data as neither PoB nor the API will be required to wait for either party.
+
+These links are generally available via poewiki see: https://www.poewiki.net/wiki/Necropolis_league _Official Page_.
+
+Example values:
+
+| Patch | League                 | value      | url                                    |
+| ----- | ---------------------- | ---------- | -------------------------------------- |
+| 3.25  | Settlers of Kalguur    | settlers   | https://www.pathofexile.com/settlers   |
+| 3.24  | Necropolis             | necropolis | https://www.pathofexile.com/necropolis |
+| 3.23  | Affliction             | affliction | https://www.pathofexile.com/affliction |
+| 3.22  | Trial of the Ancestors | ancestor   | https://www.pathofexile.com/ancestor   |
+| 3.4   | Delve                  | delve      | https://www.pathofexile.com/delve      |
 
 #### Responses
 

--- a/docs/APIContract.md
+++ b/docs/APIContract.md
@@ -1,0 +1,43 @@
+# Versions
+
+So far there is only one version
+
+The base URL for an API should be: _baseURL_/_apiVersion_/ meaning even something such as sometestbuildsforpoe.gg/something/a/b/c/ would be valid as a base URL, as long  as it has afterwards the per version required endpoints.
+
+## Metadata Endpoint
+
+In order to provide a consistent API a metadata endpoint should be provided under _baseURL_/.well-known/pathofbuilding this endpoint should provide information about the API and the version of the API.
+Furthermore this may allow having custom endpoints for the API.
+
+## Version 1
+
+### Response and Request types
+
+#### BuildInfo
+
+| Field        | Type    | Description                         |
+| ------------ | ------- | ----------------------------------- |
+| pobdata      | string  | The Path of Building data           |
+| name         | string  | The name of the build               |
+| lastModified | integer | The last modification timestamp     |
+| buildId      | string  | The unique identifier for the build |
+
+### Endpoints
+
+<details>
+ <summary><code>GET</code> <code><b>/v1/builds</b></code> <code>(Lists multiple builds)</code></summary>
+
+#### Parameters
+
+| name | type     | data type | description         |
+| ---- | -------- | --------- | ------------------- |
+| page | optional | integer   | Used for pagination |
+
+#### Responses
+
+| http code | content-type       | response           |
+| --------- | ------------------ | ------------------ |
+| `200`     | `application/json` | `BuildInfo object` |
+
+</details>
+

--- a/src/Classes/APIContractBuilds.lua
+++ b/src/Classes/APIContractBuilds.lua
@@ -81,6 +81,10 @@ local function tableToQueryParams(t)
 	local query = "?"
 	for key, value in pairs(t) do
 		if value then
+			local tempValue = value
+			if type(value) == "table" then
+				tempValue = table.concat(value, ",")
+			end
 			query = query .. key .. "=" .. value .. "&"
 		end
 	end

--- a/src/Classes/APIContractBuilds.lua
+++ b/src/Classes/APIContractBuilds.lua
@@ -180,7 +180,7 @@ function APIContractBuilds:BuildsVersion1Callback(source, response, errMsg)
 	for _, build in ipairs(parsedResponse) do
 		-- source and buildId will be used as a caching key
 		-- to avoid buildId collissions
-		self.buildList[common.sha1(source.name + "-" + build.buildId)] = buildInfoToCache(build, source)
+		self.buildList[common.sha1(source.name .. "-" .. build.buildId)] = buildInfoToCache(build, source)
 	end
 end
 

--- a/src/Classes/APIContractBuilds.lua
+++ b/src/Classes/APIContractBuilds.lua
@@ -104,11 +104,11 @@ local APIContractBuilds = newClass("APIContractBuilds",
 
 -- Switch case for GET Endpoint for Builds
 local getBuildVersions = {
-	[0] = function(...) return APIContractBuilds:GetBuildsVersion1(...) end,
+	[1] = function(...) return APIContractBuilds:GetBuildsVersion1(...) end,
 }
 -- Switch case for GET Endpoint for Builds
 local getBuildFilterVersions = {
-	[0] = function(data) return APIContractBuilds:GetBuildVersion1Filter(data) end,
+	[1] = function(data) return APIContractBuilds:GetBuildVersion1Filter(data) end,
 }
 
 ---@param data table

--- a/src/Classes/APIContractBuilds.lua
+++ b/src/Classes/APIContractBuilds.lua
@@ -1,0 +1,108 @@
+-- Path of Building
+--
+-- Class: API Contract Builds
+-- API contract proposal for builds
+--
+
+local dkjson = require "dkjson"
+
+
+---@enum EndpointType
+local EndpointType = {
+	REST = 0,
+	CSV = 1
+}
+
+--example for REST vs CSV
+-- REST:
+-- {"baseUrl": "https://mypoebuilds.gg/pob-api/", "name": "MyPoEBuilds REST", "endpointType": 0, "fallbackVersion": 1}
+-- baseUrl meaning the actual baseUrl
+-- CSV:
+-- {"baseUrl": "https://mypoebuilds.gg/pob-builds.csv", "name": "MyPoEBuilds CSV", "endpointType": 1, "fallbackVersion": 1}
+-- baseUrl means here the full URL to the actual file or endpoint that returns a CSV formatted file from a GET endpoint
+
+--- This is the required information from the enduser
+---@class APISourceInfo
+---@field name string
+---@field baseUrl string
+---@field endpointType EndpointType
+---@field fallbackVersion integer
+
+--- This data should be returned by the source
+---@class BuildInfo
+---@field pobdata string
+---@field name string
+---@field lastModified integer
+---@field buildId string
+
+--- This data is saved internally for caching
+---@class BuildInfoCache
+---@field pobdata string
+---@field name string
+---@field lastModified integer
+---@field buildId string
+---@field sourceName string
+
+---This primarily exists for the lua language server
+---@param buildInfo BuildInfo
+---@param source APISourceInfo
+---@return BuildInfoCache
+local function buildInfoToCache(buildInfo, source)
+	return {
+		pobdata = buildInfo.pobdata,
+		name = buildInfo.name,
+		lastModified = buildInfo.lastModified,
+		buildId = buildInfo.buildId,
+		sourceName = source.name
+	}
+end
+
+---@class APIContractBuilds
+---@field buildList BuildInfoCache[]
+local APIContractBuilds = newClass("APIContractBuilds",
+	function(self)
+		self.buildList = {}
+	end
+)
+
+-- Switch case for GET Endpoint for Builds
+local getBuildVersions = {
+	[0] = function(...) return APIContractBuilds:GetBuildsVersion1(...) end,
+}
+
+---comments
+---@param path string
+---@param source APISourceInfo
+function APIContractBuilds:GetBuilds(path, source)
+	local builds = getBuildVersions[source.fallbackVersion](path, source.endpointType)
+end
+
+---@param source APISourceInfo
+function APIContractBuilds:GetAPICapabilities(source)
+	-- TODO: Which features are supported?
+	-- What is the latest version that is supported?
+	-- Which endpoints are supported
+	-- Is Querying supported? (CSV won't support this probably)
+end
+
+---@param response table | BuildInfo[]
+---@param errMsg any
+---@param source APISourceInfo
+function APIContractBuilds:BuildsVersion1Callback(source, response, errMsg)
+	for _, build in ipairs(response) do
+		-- source and buildId will be used as a caching key
+		-- to avoid buildId collissions
+		self.buildList[common.sha1(source.name + "-" + build.buildId)] = buildInfoToCache(build, source)
+	end
+end
+
+---Version 1 of the API Contract for Builds
+---@param path string
+---@param source APISourceInfo
+function APIContractBuilds:GetBuildsVersion1(path, source)
+	if source.endpointType == EndpointType.REST then
+		launch:DownloadPage(source.baseUrl + path, function(...)
+			self:BuildsVersion1Callback(source, ...)
+		end, {})
+	end
+end


### PR DESCRIPTION
Fixes #7389 controversial addition by designing a common API to adhere to.

### Description of the problem being solved:
This may be used as a base for designing a common PoB API, which build sites such as: maxroll, icy-veins, pobarchives and so on should adhere to if they want to be able to display builds inside of PoB.
Furthermore it may also be possible for content creators to support this feature by providing a subset of the required API.

In this initial draft there would be an aim towards two so called endpoint types: _REST_ and _CSV_.

The REST version would be for anyone who wants to support more complex features such as filtering and possibly other features.
Whereas the CSV version would be an option for content creators who may not have the time, money or willingness to support a custom REST API for their builds. This would easily usable by them to either have a simple webserver just hosting a csv file or using GitHub in order to host the builds.

For more information and current thoughts about the API Contract the information can be found in [APIContract.md](https://github.com/gaschenk/PathOfBuilding/blob/dev/docs/APIContract.md)

### Steps taken to verify a working solution:
- TBD

### Link to a build that showcases this PR:
TBD
### Before screenshot:
TBD
### After screenshot:
TBD