### PR TITLE
Fix “MAX” effect ruthless calculation

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2620,7 +2620,6 @@ function calcs.offence(env, actor, activeSkill)
 					output.RuthlessBlowChance = round(100 / output.RuthlessBlowMaxCount)
 				elseif ruthlessEffect == "MAX" then
 					output.RuthlessBlowChance = 100
-					skillData.dpsMultiplier = skillData.dpsMultiplier / (output.RuthlessBlowMaxCount or 1)
 				end
 			else
 				output.RuthlessBlowChance = 0


### PR DESCRIPTION
Fixes incorrect calculation of ruthless “MAX” effect.

### Description of the problem being solved:
Issue: when choosing max effect mode for ruthless calculation the damage is less than with average. This prevents player from understanding the bleed damage from ruthless hit, which basically is indifferent from attack speed

### Steps taken to verify a working solution:
- Remove the unnecessary dpsMultiplier

### Link to a build that showcases this PR:
https://pobb.in/R3766WkE8XHi

### Before screenshot:
![image](https://github.com/user-attachments/assets/9af52b4c-0af1-4eb9-bbbf-3148740922c2)
![image](https://github.com/user-attachments/assets/12adc56d-116c-4933-91f2-fc4fee09bb25)

### After screenshot:
![image](https://github.com/user-attachments/assets/672eef6a-be03-422b-b729-75a6544496b8)
![image](https://github.com/user-attachments/assets/7d020138-f59b-4a1d-ab17-1d838945848c)
