### PR TITLE
Reduced Precision Number Display

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1104,6 +1104,9 @@ function buildMode:OnFrame(inputEvents)
 	if main.thousandsSeparator ~= self.lastShowThousandsSeparator then
 		self:RefreshStatList()
 	end
+	if main.lowerPrecisionDisplay ~= self.lastLowerPrecisionDisplay then
+		self:RefreshStatList()
+	end
 	if main.decimalSeparator ~= self.lastShowDecimalSeparator then
 		self:RefreshStatList()
 	end
@@ -1464,6 +1467,7 @@ function buildMode:FormatStat(statData, statVal, overCapStatVal, colorOverride)
 	end
 	self.lastShowThousandsSeparators = main.showThousandsSeparators
 	self.lastShowThousandsSeparator = main.thousandsSeparator
+	self.lastLowerPrecisionDisplay = main.lowerPrecisionDisplay
 	self.lastShowDecimalSeparator = main.decimalSeparator
 	self.lastShowTitlebarName = main.showTitlebarName
 	return valStr

--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -658,7 +658,7 @@ function formatNumSep(str)
 		local x, y, minus, integer, fraction = str:find("(-?)(%d+)(%.?%d*)")
 		if main.lowerPrecisionDisplay and #integer > 3 then
 			if fraction == "" then
-				fraction = "."..integer:sub(-2)
+				fraction = "."..integer:sub(-1)
 			else
 				fraction = "."..integer:sub(-#(fraction or "  ") + 1)
 			end

--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -656,7 +656,22 @@ function formatNumSep(str)
 			return m
 		end
 		local x, y, minus, integer, fraction = str:find("(-?)(%d+)(%.?%d*)")
-		if main.showThousandsSeparators then
+		if main.lowerPrecisionDisplay and #integer > 3 then
+			if fraction == "" then
+				fraction = "."..integer:sub(-2)
+			else
+				fraction = "."..integer:sub(-#(fraction or "  ") + 1)
+			end
+			if #integer > 12 then
+				return colour..minus..integer:sub(1, #integer - 12)..fraction:gsub("%.", main.decimalSeparator).." T"
+			elseif #integer > 9 then
+				return colour..minus..integer:sub(1, #integer - 9)..fraction:gsub("%.", main.decimalSeparator).." B"
+			elseif #integer > 6 then
+				return colour..minus..integer:sub(1, #integer - 6)..fraction:gsub("%.", main.decimalSeparator).." M"
+			else
+				return colour..minus..integer:sub(1, #integer - 3)..fraction:gsub("%.", main.decimalSeparator).." k"
+			end
+		elseif main.showThousandsSeparators then
 			integer = integer:reverse():gsub("(%d%d%d)", "%1"..main.thousandsSeparator):reverse()
 			-- There will be leading separators if the number of digits are divisible by 3
 			-- This checks for their presence and removes them

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -96,6 +96,7 @@ function main:Init()
 	self.showThousandsSeparators = true
 	self.edgeSearchHighlight = true
 	self.thousandsSeparator = ","
+	self.lowerPrecisionDisplay = false
 	self.decimalSeparator = "."
 	self.defaultItemAffixQuality = 0.5
 	self.showTitlebarName = true
@@ -575,6 +576,9 @@ function main:LoadSettings(ignoreBuild)
 				if node.attrib.thousandsSeparator then
 					self.thousandsSeparator = node.attrib.thousandsSeparator
 				end
+				if node.attrib.lowerPrecisionDisplay then
+					self.lowerPrecisionDisplay = node.attrib.lowerPrecisionDisplay == "true"
+				end
 				if node.attrib.decimalSeparator then
 					self.decimalSeparator = node.attrib.decimalSeparator
 				end
@@ -714,6 +718,7 @@ function main:SaveSettings()
 		colorHighlight = self.colorHighlight,
 		showThousandsSeparators = tostring(self.showThousandsSeparators),
 		thousandsSeparator = self.thousandsSeparator,
+		lowerPrecisionDisplay = tostring(self.lowerPrecisionDisplay),
 		decimalSeparator = self.decimalSeparator,
 		showTitlebarName = tostring(self.showTitlebarName),
 		betaTest = tostring(self.betaTest),
@@ -922,6 +927,12 @@ function main:OpenOptionsPopup()
 	controls.thousandsSeparatorLabel = new("LabelControl", { "RIGHT", controls.thousandsSeparator, "LEFT" }, { defaultLabelSpacingPx, 0, 92, 16 }, "^7Thousands separator:")
 
 	nextRow()
+	controls.lowerPrecisionDisplay = new("CheckBoxControl", { "TOPLEFT", nil, "TOPLEFT"}, { defaultLabelPlacementX, currentY, 20 }, "^7Reduce Display Precision:", function(state)
+		self.lowerPrecisionDisplay = state
+	end)
+	controls.lowerPrecisionDisplay.state = self.lowerPrecisionDisplay
+
+	nextRow()
 	controls.decimalSeparator = new("EditControl", { "TOPLEFT", nil, "TOPLEFT" }, { defaultLabelPlacementX, currentY, 30, 20 }, self.decimalSeparator, nil, "%w", 1, function(buf)
 		self.decimalSeparator = buf
 	end)
@@ -995,6 +1006,7 @@ function main:OpenOptionsPopup()
 	local initialThousandsSeparatorDisplay = self.showThousandsSeparators
 	local initialTitlebarName = self.showTitlebarName
 	local initialThousandsSeparator = self.thousandsSeparator
+	local initialLowerPrecisionDisplay = self.lowerPrecisionDisplay
 	local initialDecimalSeparator = self.decimalSeparator
 	local initialBetaTest = self.betaTest
 	local initialEdgeSearchHighlight = self.edgeSearchHighlight


### PR DESCRIPTION
This reduces the number of digits shown, and instead opts to show `SI prefixes` (k, M, B, T)
![image](https://github.com/user-attachments/assets/ee63361f-8a27-4701-873a-b222e8f1afd8)


I just ended up applying this to everything for now, its much harder to only apply it to dps becouse then I need to tag what does and does not get it applied to, I kept the same level of precision as the base number if it had any, (and 2 decimals if it didnt), I can standardise this to 2 if we want it.

This does not modify the values stored in the xml, only the values displayed in PoB itself.

This does have issues above 15 digits, I can either add more prefixes, or can let it continue in the function through `showThousandsSeparators` to still get separated, but people shouldnt have numbers that big so I think this is fine

I can cleanup code to not use if statements, but it shouldnt change much, so up to maintainer what they prefer for style