### PR TITLE
Remove left panel EHP, saner Vaal/Guard skill defaults, better disabled gem readability

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -1039,16 +1039,29 @@ function ImportTabClass:ImportSocketedItems(item, socketedItems, slotName)
 		else
 			local normalizedBasename, qualityType = self.build.skillsTab:GetBaseNameAndQuality(socketedItem.typeLine, nil)
 			local gemId = self.build.data.gemForBaseName[normalizedBasename:lower()]
+			local enable1 = true
+			local enable2 = false
 			if socketedItem.hybrid then
 				-- Used by transfigured gems and dual-skill gems (currently just Stormbind) 
 				normalizedBasename, qualityType  = self.build.skillsTab:GetBaseNameAndQuality(socketedItem.hybrid.baseTypeName, nil)
 				gemId = self.build.data.gemForBaseName[normalizedBasename:lower()]
 				if gemId and socketedItem.hybrid.isVaalGem then
 					gemId = self.build.data.gemGrantedEffectIdForVaalGemId[self.build.data.gems[gemId].grantedEffectId]
+					
+					-- Turn off Vaal skills by default on import
+					enable1 = false
+					enable2 = true
 				end
 			end
 			if gemId then
-				local gemInstance = { level = 20, quality = 0, enabled = true, enableGlobal1 = true, gemId = gemId }
+				-- if the gem is a guard gem, disable by default
+				local isGuard = false
+				if self.build.data.gems[gemId].tags.guard then
+					isGuard = true
+				end
+				local gemInstance = {
+					level = 20, quality = 0, enabled = not isGuard, enableGlobal1 = enable1, enableGlobal2 = enable2, gemId = gemId
+				}
 				gemInstance.nameSpec = self.build.data.gems[gemId].name
 				gemInstance.support = socketedItem.support
 				gemInstance.qualityId = qualityType

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -456,7 +456,6 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild, importLin
 		{ },
 		{ stat = "Devotion", label = "Devotion", color = colorCodes.RARE, fmt = "d" },
 		{ },
-		{ stat = "TotalEHP", label = "Effective Hit Pool", fmt = ".0f", compPercent = true },
 		{ stat = "PvPTotalTakenHit", label = "PvP Hit Taken", fmt = ".1f", flag = "isPvP", lowerIsBetter = true },
 		{ stat = "PhysicalMaximumHitTaken", label = "Phys Max Hit", fmt = ".0f", color = colorCodes.PHYS, compPercent = true,  },
 		{ stat = "LightningMaximumHitTaken", label = "Elemental Max Hit", fmt = ".0f", color = colorCodes.LIGHTNING, compPercent = true, condFunc = function(v,o) return o.LightningMaximumHitTaken == o.ColdMaximumHitTaken and o.LightningMaximumHitTaken == o.FireMaximumHitTaken end },

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -456,6 +456,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild, importLin
 		{ },
 		{ stat = "Devotion", label = "Devotion", color = colorCodes.RARE, fmt = "d" },
 		{ },
+		{ stat = "TotalEHP", label = "Effective Hit Pool", fmt = ".0f", compPercent = true},
 		{ stat = "PvPTotalTakenHit", label = "PvP Hit Taken", fmt = ".1f", flag = "isPvP", lowerIsBetter = true },
 		{ stat = "PhysicalMaximumHitTaken", label = "Phys Max Hit", fmt = ".0f", color = colorCodes.PHYS, compPercent = true,  },
 		{ stat = "LightningMaximumHitTaken", label = "Elemental Max Hit", fmt = ".0f", color = colorCodes.LIGHTNING, compPercent = true, condFunc = function(v,o) return o.LightningMaximumHitTaken == o.ColdMaximumHitTaken and o.LightningMaximumHitTaken == o.FireMaximumHitTaken end },
@@ -1321,6 +1322,9 @@ function buildMode:OnFrame(inputEvents)
 	if main.decimalSeparator ~= self.lastShowDecimalSeparator then
 		self:RefreshStatList()
 	end
+	if main.showEHPInBuildPanel ~= self.showEHPInBuildPanel then
+		self:RefreshStatList()
+	end
 	if main.showTitlebarName ~= self.lastShowTitlebarName then
 		self.spec:SetWindowTitleWithBuildClass()
 	end
@@ -1679,6 +1683,7 @@ function buildMode:FormatStat(statData, statVal, overCapStatVal, colorOverride)
 	self.lastShowThousandsSeparators = main.showThousandsSeparators
 	self.lastShowThousandsSeparator = main.thousandsSeparator
 	self.lastShowDecimalSeparator = main.decimalSeparator
+	self.showEHPInBuildPanel = main.showEHPInBuildPanel
 	self.lastShowTitlebarName = main.showTitlebarName
 	return valStr
 end
@@ -1700,6 +1705,11 @@ function buildMode:AddDisplayStatList(statList, actor)
 				end
 				if statVal and ((statData.condFunc and statData.condFunc(statVal,actor.output)) or (not statData.condFunc and statVal ~= 0)) then
 					local overCapStatVal = actor.output[statData.overCapStat] or nil
+
+					if statData.stat == "TotalEHP" then
+						statData.hideStat = not self.showEHPInBuildPanel
+					end
+
 					if statData.stat == "SkillDPS" then
 						labelColor = colorCodes.CUSTOM
 						table.sort(actor.output.SkillDPS, function(a,b) return (a.dps * a.count) > (b.dps * b.count) end)

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1589,8 +1589,12 @@ function calcs.initEnv(build, mode, override, specEnv)
 					group.displayLabel = nil
 					for _, gemInstance in ipairs(group.gemList) do
 						local grantedEffect = gemInstance.gemData and gemInstance.gemData.grantedEffect or gemInstance.grantedEffect
-						if grantedEffect and not grantedEffect.support and gemInstance.enabled then
-							group.displayLabel = (group.displayLabel and group.displayLabel..", " or "") .. grantedEffect.name
+						if grantedEffect and not grantedEffect.support then
+							if gemInstance.enabled then
+								group.displayLabel = (group.displayLabel and group.displayLabel..", " or "") .. grantedEffect.name
+							else
+								group.displayLabel = (group.displayLabel and group.displayLabel..", " or "") .. "^x7F7F7F" .. grantedEffect.name .. " (Disabled)^xFFFFFF"
+							end
 						end
 					end
 					group.displayLabel = group.displayLabel or "<No active skills>"

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -103,6 +103,7 @@ function main:Init()
 	self.slotOnlyTooltips = true
 	self.POESESSID = ""
 	self.showPublicBuilds = true
+	self.showEHPInBuildPanel = false
 
 	if self.userPath then
 		self:ChangeUserPath(self.userPath, ignoreBuild)
@@ -617,6 +618,9 @@ function main:LoadSettings(ignoreBuild)
 				if node.attrib.showPublicBuilds then
 					self.showPublicBuilds = node.attrib.showPublicBuilds == "true"
 				end
+				if node.attrib.showEHPInBuildPanel then
+					self.showEHPInBuildPanel = node.attrib.showEHPInBuildPanel == "true"
+				end
 			end
 		end
 	end
@@ -727,7 +731,8 @@ function main:SaveSettings()
 		POESESSID = self.POESESSID,
 		invertSliderScrollDirection = tostring(self.invertSliderScrollDirection),
 		disableDevAutoSave = tostring(self.disableDevAutoSave),
-		showPublicBuilds = tostring(self.showPublicBuilds)
+		showPublicBuilds = tostring(self.showPublicBuilds),
+		showEHPInBuildPanel = tostring(self.showEHPInBuildPanel)
 	} })
 	local res, errMsg = common.xml.SaveXMLFile(setXML, self.userPath.."Settings.xml")
 	if not res then
@@ -975,6 +980,13 @@ function main:OpenOptionsPopup()
 	controls.invertSliderScrollDirection.tooltipText = "Default scroll direction is:\nScroll Up = Move right\nScroll Down = Move left"
 	controls.invertSliderScrollDirection.state = self.invertSliderScrollDirection
 	
+	nextRow()
+	controls.showEHPInBuildPanel = new("CheckBoxControl", { "TOPLEFT", nil, "TOPLEFT" }, { defaultLabelPlacementX, currentY, 20 }, "^7Show EHP In Build Panel:", function(state)
+		self.showEHPInBuildPanel = state
+	end)
+	controls.showEHPInBuildPanel.tooltipText = "Display Effective Health Pool In The Left Build Panel"
+	controls.showEHPInBuildPanel.state = self.showEHPInBuildPanel
+
 	if launch.devMode then
 		nextRow()
 		controls.disableDevAutoSave = new("CheckBoxControl", { "TOPLEFT", nil, "TOPLEFT" }, { defaultLabelPlacementX, currentY, 20 }, "^7Disable Dev AutoSave:", function(state)


### PR DESCRIPTION
EHP being so prominent in the left panel has been the source of much misinterpretation of the sturdiness of builds in PoE. While it can be a useful number to veterans, it is deceptive to folks that don't know exactly how it works. With the support of many prominent build makers, I'm hoping to remove it from the left panel display here. The number is much more useful with more clarity when taken with the context of the Calcs page.

This is configurable in the options panel for those who want to turn it back on.
![CyYZTQs](https://github.com/user-attachments/assets/f99ffdfa-e665-480c-a83b-5c11f8050bba)

Over the past couple years certain standards have arisen within the build community for what is a sane state to consider and share builds from. Chief among these is Vaal and Guard skills (both Vaal and non-Vaal) being disabled. I've made it so that this is the default upon character import. The non-Vaal version of that skill will now be enabled. This is very useful when reimporting a character multiple times so you are generally looking at the state you want the build to be configured in by default.

In addition, I've added a (Disabled) tag for the auto-generated skill labels so it's more clear what is turned on/off in a socket group at a glance.

An image of skills in a fresh import:
![PZj9jTZ](https://github.com/user-attachments/assets/cb535757-1df9-4b1c-b99c-669f737db059)
