### PR TITLE
Add option to strip advanced copy paste info out

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1173,21 +1173,22 @@ function ItemsTabClass:Draw(viewPort, inputEvents)
 				if newItem then
 					if newItem:find("{ ", 0, true) then
 						local controls = { }
-						controls.label = new("LabelControl", nil, {0, 30, 0, 16}, "^7\"Advanced Item Descriptions\" (Ctrl+Alt+c) are unsupported.\n\nIf this is not an advanced item copy paste or if you wish to procced anyway click proceed.\n\nOr you can removed the advanced info from the item and paste as a normal item.")
-						controls.close = new("ButtonControl", nil, {-175, 140, 150, 20}, "^7Proceed Anyway", function()
+						controls.label = new("LabelControl", nil, {0, 40, 0, 16}, "^7\"Advanced Item Descriptions\" (Ctrl+Alt+c) are unsupported.") 
+								-- \n\nIf this is not an advanced item copy paste or if you wish to proceed anyway click proceed.\n\nOr you can remove the advanced info from the item and paste as a normal item.
+						controls.close = new("ButtonControl", nil, {-175, 90, 150, 20}, "^7Proceed Anyway", function()
 							self:CreateDisplayItemFromRaw(newItem, true)
 							main:ClosePopup()
 						end)
-						controls.strip = new("ButtonControl", nil, {0, 140, 150, 20}, "^7Remove Advanced Info", function()
+						controls.strip = new("ButtonControl", nil, {0, 90, 150, 20}, "^7Remove Advanced Info", function()
 							newItem = itemLib.stripAdvancedCopyPaste(newItem)
 							self:CreateDisplayItemFromRaw(newItem, true)
 							main:ClosePopup()
 						end)
-						controls.abort = new("ButtonControl", nil, {175, 140, 150, 20}, "^7Abort", function()
+						controls.abort = new("ButtonControl", nil, {175, 90, 150, 20}, "^7Abort", function()
 							self:SetDisplayItem()
 							main:ClosePopup()
 						end)
-						main:OpenPopup(570, 170, "Warning", controls)
+						main:OpenPopup(560, 120, "Warning", controls)
 					else
 						self:CreateDisplayItemFromRaw(newItem, true)
 					end

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1170,13 +1170,27 @@ function ItemsTabClass:Draw(viewPort, inputEvents)
 		if event.type == "KeyDown" then	
 			if event.key == "v" and IsKeyDown("CTRL") then
 				local newItem = Paste()
-				if newItem:find("{ ", 0, true) then
-					main:OpenConfirmPopup("Warning", "\"Advanced Item Descriptions\" (Ctrl+Alt+c) are unsupported.\n\nAbort paste?", "OK", function()
-						self:SetDisplayItem()
-					end)
-				end
 				if newItem then
-					self:CreateDisplayItemFromRaw(newItem, true)
+					if newItem:find("{ ", 0, true) then
+						local controls = { }
+						controls.label = new("LabelControl", nil, {0, 30, 0, 16}, "^7\"Advanced Item Descriptions\" (Ctrl+Alt+c) are unsupported.\n\nIf this is not an advanced item copy paste or if you wish to procced anyway click proceed.\n\nOr you can removed the advanced info from the item and paste as a normal item.")
+						controls.close = new("ButtonControl", nil, {-175, 140, 150, 20}, "^7Proceed Anyway", function()
+							self:CreateDisplayItemFromRaw(newItem, true)
+							main:ClosePopup()
+						end)
+						controls.strip = new("ButtonControl", nil, {0, 140, 150, 20}, "^7Remove Advanced Info", function()
+							newItem = itemLib.stripAdvancedCopyPaste(newItem)
+							self:CreateDisplayItemFromRaw(newItem, true)
+							main:ClosePopup()
+						end)
+						controls.abort = new("ButtonControl", nil, {175, 140, 150, 20}, "^7Abort", function()
+							self:SetDisplayItem()
+							main:ClosePopup()
+						end)
+						main:OpenPopup(570, 170, "Warning", controls)
+					else
+						self:CreateDisplayItemFromRaw(newItem, true)
+					end
 				end
 			elseif event.key == "e" then
 				local mOverControl = self:GetMouseOverControl()

--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -126,6 +126,37 @@ function itemLib.formatModLine(modLine, dbMode)
 	return colorCode..line
 end
 
+function itemLib.stripAdvancedCopyPaste(rawItem)
+	local rawLines = {}
+	for line in rawItem:gmatch("%s*([^\n]*%S)") do
+		t_insert(rawLines, line)
+	end
+	local line = 1
+	local newItem = ""
+	while rawLines[line] do
+		if rawLines[line]:match("^{ .*}") and rawLines[line+1] then
+			local line2 = line + 1
+			while rawLines[line2] and not rawLines[line2]:match("^{ .*}") and not (rawLines[line2] == "--------") do
+				if rawLines[line2]:match("^%(.*%)") then
+					rawLines[line2] = ""
+				else
+					rawLines[line2] = rawLines[line2]:gsub(" — Unscalable Value", ""):gsub(" %- Unscalable Value", "")
+					local val, range = rawLines[line2]:gsub("%-","%%%-"):match("(.*)%((.*)%)[ %%]")
+					while range do
+						rawLines[line2] = rawLines[line2]:gsub("%("..range.."%)","")
+						val, range = rawLines[line2]:gsub("%-","%%%-"):match("(.*)%((.*)%)[ %%]")
+					end
+				end
+				line2 = line2 + 1
+			end
+		else
+			newItem = newItem..rawLines[line]..(rawLines[line+1] and "\n" or "")
+		end
+		line = line + 1
+	end
+	return newItem
+end
+
 itemLib.wiki = {
 	key = "F1",
 	openGem = function(gemData)


### PR DESCRIPTION
This fixes 2 issues, it fixes the issue that items are still added to the display and parsed even if you dont want them to, which can cause crashes, and this allows you to strip the advanced info out so you dont need to go recopy the item.

The UI could use work (better wording/spacing/sizing of elements), and it might be a good idea to move the popup code out of Items Tab `inputEvents` to its own class function.

I also want to add an option in future that converts an advanced copy paste to a pseudo crafted item, where you can easily adjust the mods or the roll ranges, but that is out of scope for this.