### PR TITLE
Port Trader Changes from PoB 2 

### DIFF
--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -539,9 +539,6 @@ function TradeQueryGeneratorClass:GenerateModWeights(modsToTest)
 				modLine = entry.tradeMod.text
 			end
 
-			-- swap lines here to avoid leading to modLine's that the Item parser can't handle, 
-			-- this assume swapping will always tend to make values greater than 1 i.e. 
-			-- there are no mods where it naturally will occur for e.g. -10% reduced attack speed
 			if entry.invertOnNegative and modValue < 0 then
 				modLine = swapInverse(modLine)
 				modValue = -1 * modValue

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -301,7 +301,7 @@ function TradeQueryGeneratorClass:ProcessMod(mod, tradeQueryStatsParsed, itemCat
 		local tradeMod = nil
 		local invert
 
-		if mod.statOrder[index] == nil then -- if there isn't a mod order we have to use the trade id instead e.g. implcits.
+		if mod.statOrder[index] == nil then -- if there isn't a mod order we have to use the trade id instead e.g. implicits.
 			tradeMod, invert = getTradeMod()
 			if tradeMod == nil then
 				logToFile("Unable to match %s mod: %s", modType, modLine)
@@ -322,7 +322,7 @@ function TradeQueryGeneratorClass:ProcessMod(mod, tradeQueryStatsParsed, itemCat
 				goto nextModLine
 			end
 			self.modData[modType][uniqueIndex] = { tradeMod = tradeMod, specialCaseData = { }, invertOnNegative = invert }
-		elseif self.modData[modType][uniqueIndex].tradeMod.text:gsub("[#()0-9%-%+%.]","") == swapInverse(modLine):gsub("[#()0-9%-%+%.]","") and swapInverse(modLine) ~= modLine then -- if the swaped mod matches the inverse then consider it inverted, provide it changed.
+		elseif self.modData[modType][uniqueIndex].tradeMod.text:gsub("[#()0-9%-%+%.]","") == swapInverse(modLine):gsub("[#()0-9%-%+%.]","") and swapInverse(modLine) ~= modLine then -- if the swapped mod matches the inverse then consider it inverted, provide it changed.
 			invert = true
 		end
 
@@ -502,7 +502,7 @@ function TradeQueryGeneratorClass:InitMods()
 				end
 			end
 
-			-- mask found process implicit mod this avoids processing unimplemnted bases i.e. two handed axes.
+			-- mask found process implicit mod this avoids processing unimplemented bases and misattributing the implicits.
 			if next(maskOverride) ~= nil then
 				self:ProcessMod(mod, tradeQueryStatsParsed, regularItemMask, maskOverride)
 			end
@@ -544,7 +544,7 @@ function TradeQueryGeneratorClass:GenerateModWeights(modsToTest)
 				modValue = -1 * modValue
 			end
 
-			-- trade mod dictates a plus is used infront of postive values.
+			-- trade mod dictates a plus is used in front of positive values.
 			if modLine:find("+#") and modValue >= 0 then
 				modLine = modLine:gsub("#", modValue)
 			else

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -11,7 +11,7 @@ local s_format = string.format
 local t_insert = table.insert
 
 -- TODO generate these from data files
-local itemCategoryTags = {
+local tradeCategoryTags = {
 	["Ring"] = { ["ring"] = true, ["ring_can_roll_minion_modifiers"] = true },
 	["Amulet"] = { ["amulet"] = true },
 	["Belt"] = { ["belt"] = true },
@@ -41,7 +41,7 @@ local itemCategoryTags = {
 	["Flask"] = { ["default"] = true, ["flask"] = true, ["hybrid_flask"] = true, ["utility_flask"] = true, ["mana_flask"] = true, ["life_flask"] = true, ["expedition_flask"] = true, ["critical_utility_flask"] = true }
 }
 
-local craftedCategoryTags = {
+local tradeCategoryNames = {
 	["Ring"] = { "Ring" },
 	["Amulet"] = { "Amulet" },
 	["Belt"] = { "Belt" },
@@ -75,6 +75,7 @@ local tradeStatCategoryIndices = {
 	["Explicit"] = 2,
 	["Implicit"] = 3,
 	["Corrupted"] = 3,
+	["Talisman"] = 3,
 	["Scourge"] = 6,
 	["Eater"] = 3,
 	["Exarch"] = 3,
@@ -146,13 +147,13 @@ local function canModSpawnForItemCategory(mod, category)
 		-- return true
 	--end
 	if mod.types then -- crafted mods
-		for _, key in ipairs(craftedCategoryTags[category]) do
+		for _, key in ipairs(tradeCategoryNames[category]) do
 			if mod.types[key] then
 				return true
 			end
 		end
 	else
-		local tags = itemCategoryTags[category]
+		local tags = tradeCategoryTags[category]
 		for i, key in ipairs(mod.weightKey) do
 			local influenceStrippedKey = stripInfluenceSuffix(key)
 			if key ~= "default" and mod.affix:find("Elevated") ~= nil and tags[influenceStrippedKey] == true then
@@ -165,6 +166,24 @@ local function canModSpawnForItemCategory(mod, category)
 		end
 	end
 	return false
+end
+
+-- Swaps mod word for its antonym
+local function swapInverse(modLine)
+	if modLine:match("increased") then
+		modLine = modLine:gsub("([^ ]+) increased", "%1 reduced")
+	elseif modLine:match("reduced") then
+		modLine = modLine:gsub("([^ ]+) reduced", "%1 increased")
+	elseif modLine:match("more") then
+		modLine = modLine:gsub("([^ ]+) more", "%1 less")
+	elseif modLine:match("less") then
+		modLine = modLine:gsub("([^ ]+) less", "%1 more")
+	elseif modLine:match("expires ([^ ]+) slower") then
+		modLine = modLine:gsub("([^ ]+) slower", "%1 faster")
+	elseif modLine:match("expires ([^ ]+) faster") then
+		modLine = modLine:gsub("([^ ]+) faster", "%1 slower")
+	end
+	return modLine
 end
 
 function TradeQueryGeneratorClass.WeightedRatioOutputs(baseOutput, newOutput, statWeights)
@@ -193,25 +212,28 @@ function TradeQueryGeneratorClass.WeightedRatioOutputs(baseOutput, newOutput, st
 	return meanStatDiff
 end
 
-function TradeQueryGeneratorClass:ProcessMod(modId, mod, tradeQueryStatsParsed, itemCategoriesMask, itemCategoriesOverride)
-	if type(modId) == "string" and modId:find("HellscapeDownside") ~= nil then -- skip scourge downsides, they often don't follow standard parsing rules, and should basically never be beneficial anyways
+function TradeQueryGeneratorClass:ProcessMod(mod, tradeQueryStatsParsed, itemCategoriesMask, itemCategoriesOverride)
+	if mod.type == "ScourgeDownside" then -- skip scourge downsides, they often don't follow standard parsing rules, and should basically never be beneficial anyways
 		goto continue
 	end
+	if mod.statOrder == nil then mod.statOrder = { } end
+	if mod.group == nil then mod.group = "" end
 
 	for index, modLine in ipairs(mod) do
 		if modLine:find("Grants Level") or modLine:find("inflict Decay") then -- skip mods that grant skills / decay, as they will often be overwhelmingly powerful but don't actually fit into the build
 			goto nextModLine
 		end
 
-		local statOrder = modLine:find("Nearby Enemies have %-") ~= nil and mod.statOrder[index + 1] or mod.statOrder[index] -- hack to get minus res mods associated with the correct statOrder
-		local modType = (mod.type == "Prefix" or mod.type == "Suffix") and (type(modId) == "string" and modId:find("AfflictionNotable") and "PassiveNode" or "Explicit") or mod.type
-		if modType == "ScourgeUpside" then modType = "Scourge" end
+		local modType = (mod.group:match("AfflictionNotable") and "PassiveNode") or (mod.type == "Prefix" or mod.type == "Suffix") and "Explicit" or (mod.type == "ScourgeUpside" and "Scourge") or mod.type
 
 		-- Special cases
 		local specialCaseData = { }
-		if mod.group and (mod.group:find("Local") or mod.group:find("Shield")) and modLine:find("Chance to Block$") then
+		if mod.group and (mod.group:find("Local") or mod.group:find("Shield")) and modLine:gsub("[#()0-9%-%+%.]","") == "% Chance to Block" then
 			specialCaseData.overrideModLine = "+#% Chance to Block"
 			modLine = modLine .. " (Shields)"
+		elseif modType == "Implicit" and modLine:find("Chance to Block Attack Damage while wielding a Staff$") then
+			specialCaseData.overrideModLine = "+#% Chance to Block Attack Damage while wielding a Staff"
+			modLine = modLine .. " (Staves)"
 		elseif modLine == "You can apply an additional Curse" then
 			specialCaseData.overrideModLineSingular = "You can apply an additional Curse"
 			modLine = "You can apply 1 additional Curses"
@@ -224,6 +246,9 @@ function TradeQueryGeneratorClass:ProcessMod(modId, mod, tradeQueryStatsParsed, 
 		elseif modLine == "Has 1 Abyssal Socket" then
 			specialCaseData.overrideModLineSingular = "Has 1 Abyssal Socket"
 			modLine = "Has 1 Abyssal Sockets"
+		elseif modLine:find("Modifiers allowed") then
+			specialCaseData.overrideModLinePlural = "+# "..modLine:match(" (%a+) Modifiers allowed").." Modifiers allowed"
+			modLine = modLine:gsub("Modifiers", "Modifier")
 		end
 
 		-- If this is the first tier for this mod, find matching trade mod and init the entry
@@ -232,89 +257,94 @@ function TradeQueryGeneratorClass:ProcessMod(modId, mod, tradeQueryStatsParsed, 
 			goto continue
 		end
 
-		local function swapInverse(modLine)
-			local priorStr = modLine
-			local inverseKey
-			if modLine:match("increased") then
-				modLine = modLine:gsub("([^ ]+) increased", "-%1 reduced")
-				if modLine ~= priorStr then inverseKey = "increased" end
-			elseif modLine:match("reduced") then
-				modLine = modLine:gsub("([^ ]+) reduced", "-%1 increased")
-				if modLine ~= priorStr then inverseKey = "reduced" end
-			elseif modLine:match("more") then
-				modLine = modLine:gsub("([^ ]+) more", "-%1 less")
-				if modLine ~= priorStr then inverseKey = "more" end
-			elseif modLine:match("less") then
-				modLine = modLine:gsub("([^ ]+) less", "-%1 more")
-				if modLine ~= priorStr then inverseKey = "less" end
-			elseif modLine:match("expires ([^ ]+) slower") then
-				modLine = modLine:gsub("([^ ]+) slower", "-%1 faster")
-				if modLine ~= priorStr then inverseKey = "slower" end
-			elseif modLine:match("expires ([^ ]+) faster") then
-				modLine = modLine:gsub("([^ ]+) faster", "-%1 slower")
-				if modLine ~= priorStr then inverseKey = "faster" end
-			end
-			return modLine, inverseKey
-		end
-
-		local uniqueIndex = tostring(statOrder).."_"..mod.group
-		local inverse = false
-		local inverseKey
-		::reparseMod::
-		if self.modData[modType][uniqueIndex] == nil then
-			local tradeMod = nil
-			-- Try to match to a local mod fallback to global if no match
-			if mod.group:match("Local") then
+		-- iterate trade mod category to find mod with matching text.
+		local function getTradeMod()
+			-- first try matching local mods then try regular mods.
+			if mod.group and mod.group:match("Local") then
 				local matchLocalStr = (modLine .. " (Local)"):gsub("[#()0-9%-%+%.]","")
 				for _, entry in pairs(tradeQueryStatsParsed.localResults[tradeStatCategoryIndices[modType]].entries) do
 					if entry.text:gsub("[#()0-9%-%+%.]","") == matchLocalStr then
-						tradeMod = entry
 						specialCaseData.overrideModLine = entry.text:sub(1,-9)
-						break
+						modLine = modLine .. " (Local)"
+						return entry
 					end
 				end
-			end
-			if tradeMod == nil then
-				local matchStr = modLine:gsub("[#()0-9%-%+%.]","")
-				for _, entry in ipairs(tradeQueryStatsParsed.result[tradeStatCategoryIndices[modType]].entries) do
-					if entry.text:gsub("[#()0-9%-%+%.]","") == matchStr then
-						tradeMod = entry
-						break
-					end
-				end
-			end
-			if tradeMod == nil then
-				if inverse then
-					logToFile("Unable to match %s mod: %s", modType, modLine)
-					goto nextModLine
-				else -- try swapping increased / decreased and signed and other similar mods.
-					modLine, inverseKey = swapInverse(modLine)
-					inverse = true
-					if inverseKey then
-						goto reparseMod
-					else
-						logToFile("Unable to match %s mod: %s", modType, modLine)
-						goto nextModLine
+				-- check reverse
+				matchLocalStr = swapInverse(matchLocalStr)
+				for _, entry in ipairs(tradeQueryStatsParsed.localResults[tradeStatCategoryIndices[modType]].entries) do
+					if entry.text:gsub("[#()0-9%-%+%.]","") == matchLocalStr then
+						specialCaseData.overrideModLine = entry.text:sub(1,-9)
+						modLine = modLine .. " (Local)"
+						return entry, true
 					end
 				end
 			end
 
-			self.modData[modType][uniqueIndex] = { tradeMod = tradeMod, specialCaseData = specialCaseData, inverseKey = inverseKey }
-		elseif self.modData[modType][uniqueIndex].inverseKey and modLine:match(self.modData[modType][uniqueIndex].inverseKey) then
-			inverse = true
+			-- try matching to global mods.
+			local matchStr = modLine:gsub("[#()0-9%-%+%.]","")
+			for _, entry in ipairs(tradeQueryStatsParsed.result[tradeStatCategoryIndices[modType]].entries) do
+				if entry.text:gsub("[#()0-9%-%+%.]","") == matchStr then
+					return entry
+				end
+			end
+			-- check reverse
+			matchStr = swapInverse(matchStr)
+			for _, entry in ipairs(tradeQueryStatsParsed.result[tradeStatCategoryIndices[modType]].entries) do
+				if entry.text:gsub("[#()0-9%-%+%.]","") == matchStr then
+					return entry, true
+				end
+			end
+
+			return nil
+		end
+
+		local tradeMod = nil
+		local invert
+
+		if mod.statOrder[index] == nil then -- if there isn't a mod order we have to use the trade id instead e.g. implcits.
+			tradeMod, invert = getTradeMod()
+			if tradeMod == nil then
+				logToFile("Unable to match %s mod: %s", modType, modLine)
+				goto nextModLine
+			end
+			mod.statOrder[index] = tradeMod.id
+		end
+
+		local statOrder = modLine:find("Nearby Enemies have %-") ~= nil and mod.statOrder[index + 1] or mod.statOrder[index] -- hack to get minus res mods associated with the correct statOrder
+		local uniqueIndex = mod.group ~= "" and tostring(statOrder).."_"..mod.group or tostring(statOrder)
+
+		if self.modData[modType][uniqueIndex] == nil then
+			if tradeMod == nil then
+				tradeMod, invert = getTradeMod()
+			end
+			if tradeMod == nil then
+				logToFile("Unable to match %s mod: %s", modType, modLine)
+				goto nextModLine
+			end
+			self.modData[modType][uniqueIndex] = { tradeMod = tradeMod, specialCaseData = { }, invertOnNegative = invert }
+		elseif self.modData[modType][uniqueIndex].tradeMod.text:gsub("[#()0-9%-%+%.]","") == swapInverse(modLine):gsub("[#()0-9%-%+%.]","") and swapInverse(modLine) ~= modLine then -- if the swaped mod matches the inverse then consider it inverted, provide it changed.
+			invert = true
+		end
+
+		-- this is safe as we go to next line if the mod can't be found.
+		for key, value in pairs(specialCaseData) do
+			self.modData[modType][uniqueIndex].specialCaseData[key] = value
+		end
+
+		if invert then
 			modLine = swapInverse(modLine)
 		end
 
 		-- tokenize the numerical variables for this mod and store the sign if there is one
 		local tokens = { }
-		local poundPos, tokenizeOffset = 0, 0
+		local poundStartPos, poundEndPos, tokenizeOffset = 0, 0, 0
 		while true do
-			poundPos = self.modData[modType][uniqueIndex].tradeMod.text:find("#", poundPos + 1)
-			if poundPos == nil then
+			poundStartPos, poundEndPos = self.modData[modType][uniqueIndex].tradeMod.text:find("[%+%-]?#", poundEndPos + 1)
+			if poundStartPos == nil then
 				break
 			end
 
-			local startPos, endPos, sign, min, max = modLine:find("([%+%-]?)%(?(%d+%.?%d*)%-?(%d*%.?%d*)%)?", poundPos + tokenizeOffset)
+			local startPos, endPos, sign, min, max = modLine:find("([%+%-]?)%(?(%d+%.?%d*)%-?(%d*%.?%d*)%)?", poundStartPos + tokenizeOffset)
 
 			if endPos == nil then
 				logToFile("[GMD] Error extracting tokens from '%s' for tradeMod '%s'", modLine, self.modData[modType][uniqueIndex].tradeMod.text)
@@ -325,31 +355,24 @@ function TradeQueryGeneratorClass:ProcessMod(modId, mod, tradeQueryStatsParsed, 
 
 			tokenizeOffset = tokenizeOffset + (endPos - startPos)
 			
-			if inverse then
-				sign = nil
-				min = -min
-				max = -max
-				if min > max then
-					local temp = max
-					max = min
-					min = temp
-				end
+			-- the values are negative record its ranges as such.
+			if (invert or sign == "-") and not (invert and sign == "-") then
+				local temp = max
+				max = -min
+				min = -temp
 			end
 
 			t_insert(tokens, min)
 			t_insert(tokens, max)
-			if sign ~= nil then
-				self.modData[modType][uniqueIndex].sign = sign
-			end
 		end
 
 		if #tokens ~= 0 and #tokens ~= 2 and #tokens ~= 4 then
-			logToFile("Unexpected # of tokens found for mod: %s", mod[i])
+			logToFile("Unexpected # of tokens found for mod: %s", mod[index])
 			goto nextModLine
 		end
 
 		-- Update the min and max values available for each item category
-		for category, _ in pairs(itemCategoriesOverride or itemCategoriesMask or itemCategoryTags) do
+		for category, _ in pairs(itemCategoriesOverride or itemCategoriesMask or tradeCategoryTags) do
 			if itemCategoriesOverride or canModSpawnForItemCategory(mod, category) then
 				if self.modData[modType][uniqueIndex][category] == nil then
 					self.modData[modType][uniqueIndex][category] = { min = 999999, max = -999999 }
@@ -374,8 +397,8 @@ function TradeQueryGeneratorClass:ProcessMod(modId, mod, tradeQueryStatsParsed, 
 end
 
 function TradeQueryGeneratorClass:GenerateModData(mods, tradeQueryStatsParsed, itemCategoriesMask, itemCategoriesOverride)
-	for modId, mod in pairs(mods) do
-		self:ProcessMod(modId, mod, tradeQueryStatsParsed, itemCategoriesMask, itemCategoriesOverride)
+	for _, mod in pairs(mods) do
+		self:ProcessMod(mod, tradeQueryStatsParsed, itemCategoriesMask, itemCategoriesOverride)
 	end
 end
 
@@ -392,6 +415,7 @@ function TradeQueryGeneratorClass:InitMods()
 	self.modData = {
 		["Explicit"] = { },
 		["Implicit"] = { },
+		["Talisman"] = { },
 		["Corrupted"] = { },
 		["Scourge"] = { },
 		["Eater"] = { },
@@ -418,7 +442,7 @@ function TradeQueryGeneratorClass:InitMods()
 
 	-- explicit, corrupted, scourge, and jewel mods
 	local regularItemMask = { }
-	for category, _ in pairs(itemCategoryTags) do
+	for category, _ in pairs(tradeCategoryTags) do
 		if category ~= "Flask" and category ~= "AbyssJewel" and category ~= "BaseJewel" and category ~= "AnyJewel" then
 			regularItemMask[category] = true
 		end
@@ -432,14 +456,14 @@ function TradeQueryGeneratorClass:InitMods()
 	for _, essenceItem in pairs(data.essences) do
 		for tag, modId in pairs(essenceItem.mods) do
 			local itemCategoriesOverride = {} -- build a list of relevant categories.
-			for category, tags in pairs(craftedCategoryTags) do
+			for category, tags in pairs(tradeCategoryNames) do
 				for _, matchTag in pairs(tags) do
 					if tag == matchTag  then
 						itemCategoriesOverride[category] = tags
 					end
 				end
 			end
-			self:ProcessMod(modId, data.itemMods.Item[modId], tradeQueryStatsParsed, regularItemMask, itemCategoriesOverride)
+			self:ProcessMod(data.itemMods.Item[modId], tradeQueryStatsParsed, regularItemMask, itemCategoriesOverride)
 		end
 	end
 
@@ -456,96 +480,31 @@ function TradeQueryGeneratorClass:InitMods()
 	end
 	self:GenerateModData(clusterNotableMods, tradeQueryStatsParsed)
 
-	-- Base item implicit mods. A lot of this code is duplicated from generateModData(), but with important small logical flow changes to handle the format differences
+	-- implicit mods
 	for baseName, entry in pairs(data.itemBases) do
 		if entry.implicit ~= nil then
-			local stats = { }
+			local mod = { type = "Implicit" }
+			if entry.subType == "Talisman" then
+				mod.type = "Talisman"
+			end
 			for modLine in string.gmatch(entry.implicit, "([^".."\n".."]+)") do
-				if modLine:find("Grants Level") then -- skip mods that grant skills, as they will often be overwhelmingly powerful but don't actually fit into the build
-					goto continue
-				end
+				t_insert(mod, modLine)
+			end
 
-				local modType = "Implicit"
-
-				local tradeMod = nil
-				local matchStr = modLine:gsub("[#()0-9%-%+%.]","")
-				for _, entry in ipairs(tradeQueryStatsParsed.result[tradeStatCategoryIndices[modType]].entries) do
-					if entry.text:gsub("[#()0-9%-%+%.]","") == matchStr then
-						tradeMod = entry
+			-- create trade type mask for base type
+			local maskOverride = {}
+			for tradeName, typeNames in pairs(tradeCategoryNames) do
+				for _, typeName in ipairs(typeNames) do
+					if type(typeName) == "table" and typeName[2] == entry.subType and typeName[1] == entry.type or typeName == entry.type then
+						maskOverride[tradeName] = true;
 						break
 					end
 				end
+			end
 
-				if tradeMod == nil then
-					goto continue
-					logToFile("Unable to match %s mod: %s", modType, modLine)
-				end
-				-- base item implicits don't have stat orders, so use the trade mod id instead
-				local statOrder = tradeMod.id
-
-				-- If this is the first tier for this mod, init the entry
-				local uniqueIndex = tostring(statOrder)
-				if self.modData[modType][uniqueIndex] == nil then
-					self.modData[modType][uniqueIndex] = { tradeMod = tradeMod, specialCaseData = { } }
-				end
-
-				-- tokenize the numerical variables for this mod and store the sign if there is one
-				local tokens = { }
-				local poundPos, tokenizeOffset = 0, 0
-				while true do
-					poundPos = self.modData[modType][uniqueIndex].tradeMod.text:find("#", poundPos + 1)
-					if poundPos == nil then
-						break
-					end
-					startPos, endPos, sign, min, max = modLine:find("([%+%-]?)%(?(%d+%.?%d*)%-?(%d*%.?%d*)%)?", poundPos + tokenizeOffset)
-
-					if endPos == nil then
-						logToFile("[Init] Error extracting tokens from '%s' for tradeMod '%s'", modLine, self.modData[modType][uniqueIndex].tradeMod.text)
-						goto continue
-					end
-
-					tokenizeOffset = tokenizeOffset + (endPos - startPos)
-					t_insert(tokens, min)
-					t_insert(tokens, #max > 0 and tonumber(max) or tonumber(min))
-					if sign ~= nil then
-						self.modData[modType][uniqueIndex].sign = sign
-					end
-				end
-
-				if #tokens ~= 0 and #tokens ~= 2 and #tokens ~= 4 then
-					logToFile("Unexpected # of tokens found for mod: %s", modLine)
-					goto continue
-				end
-
-				-- Update the min and max values available for each item category
-				for category, categoryTags in pairs(itemCategoryTags) do
-					local tagMatch = false
-					for tag, value in pairs(entry.tags) do
-						if tag ~= "default" and categoryTags[tag] == true then
-							tagMatch = true
-							break
-						end
-					end
-
-					if tagMatch then
-						if self.modData[modType][uniqueIndex][category] == nil then
-							self.modData[modType][uniqueIndex][category] = { min = 999999, max = -999999, subType = entry.subType }
-						end
-
-						local modRange = self.modData[modType][uniqueIndex][category]
-						if #tokens == 0 then
-							modRange.min = 1
-							modRange.max = 1
-						elseif #tokens == 2 then
-							modRange.min = math.min(modRange.min, tokens[1])
-							modRange.max = math.max(modRange.max, tokens[2])
-						elseif #tokens == 4 then
-							modRange.min = math.min(modRange.min, (tokens[1] + tokens[3]) / 2)
-							modRange.max = math.max(modRange.max, (tokens[2] + tokens[4]) / 2)
-						end
-					end
-				end
-				::continue::
+			-- mask found process implicit mod this avoids processing unimplemnted bases i.e. two handed axes.
+			if next(maskOverride) ~= nil then
+				self:ProcessMod(mod, tradeQueryStatsParsed, regularItemMask, maskOverride)
 			end
 		end
 	end
@@ -562,24 +521,38 @@ function TradeQueryGeneratorClass:GenerateModWeights(modsToTest)
 		if entry[self.calcContext.itemCategory] ~= nil then
 			if self.alreadyWeightedMods[entry.tradeMod.id] ~= nil then -- Don't calculate the same thing twice (can happen with corrupted vs implicit)
 				goto continue
-			elseif self.calcContext.options.includeTalisman == false and entry[self.calcContext.itemCategory].subType == "Talisman" then -- Talisman implicits take up a lot of query slots, so we have an option to skip them
-				goto continue
 			end
 
-			-- Test with a value halfway (or configured default Item Affix Quality) between the min and max available for this mod in this slot. Note that this can generate slightly different values for the same mod as implicit vs explicit.
-			local modValue = math.ceil((entry[self.calcContext.itemCategory].max - entry[self.calcContext.itemCategory].min) * ( main.defaultItemAffixQuality or 0.5 ) + entry[self.calcContext.itemCategory].min)
-			local modValueStr = (entry.sign and entry.sign or "") .. tostring(modValue)
 
+			-- Test with a value halfway (or configured default Item Affix Quality) between the min and max available for this mod in this slot. Note that this can generate slightly different values for the same mod as implicit vs explicit.
+			local tradeModValue = math.ceil((entry[self.calcContext.itemCategory].max - entry[self.calcContext.itemCategory].min) * ( main.defaultItemAffixQuality or 0.5 ) + entry[self.calcContext.itemCategory].min)
+			local modValue = tradeModValue
 			-- Apply override text for special cases
 			local modLine
-			if modValue == 1 and entry.specialCaseData.overrideModLineSingular ~= nil then
+			if (modValue == 1 or modValue == -1) and entry.specialCaseData.overrideModLineSingular ~= nil then
 				modLine = entry.specialCaseData.overrideModLineSingular
+			elseif (modValue ~= 1 and modValue ~= -1) and entry.specialCaseData.overrideModLinePlural ~= nil then
+				modLine = entry.specialCaseData.overrideModLinePlural
 			elseif entry.specialCaseData.overrideModLine ~= nil then
 				modLine = entry.specialCaseData.overrideModLine
 			else
 				modLine = entry.tradeMod.text
 			end
-			modLine = modLine:gsub("#",modValueStr)
+
+			-- swap lines here to avoid leading to modLine's that the Item parser can't handle, 
+			-- this assume swapping will always tend to make values greater than 1 i.e. 
+			-- there are no mods where it naturally will occur for e.g. -10% reduced attack speed
+			if entry.invertOnNegative and modValue < 0 then
+				modLine = swapInverse(modLine)
+				modValue = -1 * modValue
+			end
+
+			-- trade mod dictates a plus is used infront of postive values.
+			if modLine:find("+#") and modValue >= 0 then
+				modLine = modLine:gsub("#", modValue)
+			else
+				modLine = modLine:gsub("+?#", modValue)
+			end
 
 			self.calcContext.testItem.explicitModLines[1] = { line = modLine, custom = true }
 			self.calcContext.testItem:BuildAndParseRaw()
@@ -591,7 +564,7 @@ function TradeQueryGeneratorClass:GenerateModWeights(modsToTest)
 			local output = self.calcContext.calcFunc({ repSlotName = self.calcContext.slot.slotName, repItem = self.calcContext.testItem })
 			local meanStatDiff = TradeQueryGeneratorClass.WeightedRatioOutputs(self.calcContext.baseOutput, output, self.calcContext.options.statWeights) * 1000 - (self.calcContext.baseStatValue or 0)
 			if meanStatDiff > 0.01 then
-				t_insert(self.modWeights, { tradeModId = entry.tradeMod.id, weight = meanStatDiff / modValue, meanStatDiff = meanStatDiff, invert = entry.sign == "-" and true or false })
+				t_insert(self.modWeights, { tradeModId = entry.tradeMod.id, weight = meanStatDiff / tradeModValue, meanStatDiff = meanStatDiff })
 			end
 			self.alreadyWeightedMods[entry.tradeMod.id] = true
 
@@ -623,7 +596,7 @@ function TradeQueryGeneratorClass:GeneratePassiveNodeWeights(nodesToTest)
 		local output = self.calcContext.calcFunc({ addNodes = { [node] = true } })
 		local meanStatDiff = TradeQueryGeneratorClass.WeightedRatioOutputs(baseOutput, output, self.calcContext.options.statWeights) * 1000 - (self.calcContext.baseStatValue or 0)
 		if meanStatDiff > 0.01 then
-			t_insert(self.modWeights, { tradeModId = entry.tradeMod.id, weight = meanStatDiff, meanStatDiff = meanStatDiff, invert = false })
+			t_insert(self.modWeights, { tradeModId = entry.tradeMod.id, weight = meanStatDiff, meanStatDiff = meanStatDiff })
 		end
 		self.alreadyWeightedMods[entry.tradeMod.id] = true
 		
@@ -822,6 +795,9 @@ function TradeQueryGeneratorClass:ExecuteQuery()
 	if self.calcContext.options.includeCorrupted then
 		self:GenerateModWeights(self.modData["Corrupted"])
 	end
+	if self.calcContext.options.includeTalisman then -- Talisman implicits take up a lot of query slots, so we have an option to skip them
+		self:GenerateModWeights(self.modData["Talisman"])
+	end
 	if self.calcContext.options.includeScourge then
 		self:GenerateModWeights(self.modData["Scourge"])
 	end
@@ -914,7 +890,7 @@ function TradeQueryGeneratorClass:FinishQuery()
 	end
 
 	for _, entry in pairs(self.modWeights) do
-		t_insert(queryTable.query.stats[1].filters, { id = entry.tradeModId, value = { weight = (entry.invert == true and entry.weight * -1 or entry.weight) } })
+		t_insert(queryTable.query.stats[1].filters, { id = entry.tradeModId, value = { weight = entry.weight } })
 		filters = filters + 1
 		if filters == MAX_FILTERS then
 			break

--- a/src/Data/QueryMods.lua
+++ b/src/Data/QueryMods.lua
@@ -16,7 +16,6 @@ return {
 				["max"] = 4, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30,7 +29,6 @@ return {
 				["max"] = 5, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44,7 +42,6 @@ return {
 				["max"] = 6, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -62,7 +59,6 @@ return {
 				["max"] = 12, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -80,7 +76,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -106,7 +101,6 @@ return {
 				["max"] = 4, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -156,7 +150,6 @@ return {
 				["max"] = 6, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -178,7 +171,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -200,7 +192,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -222,7 +213,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -244,7 +234,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -266,7 +255,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -288,7 +276,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -314,7 +301,6 @@ return {
 				["max"] = 50, 
 				["min"] = 40, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -332,7 +318,6 @@ return {
 				["max"] = 60, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -350,7 +335,6 @@ return {
 				["max"] = 60, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -364,7 +348,6 @@ return {
 				["max"] = 25, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -410,7 +393,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -472,7 +454,6 @@ return {
 				["max"] = 9.5, 
 				["min"] = 1.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Physical Damage", 
 			}, 
@@ -535,7 +516,6 @@ return {
 				["max"] = 38, 
 				["min"] = 11.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Fire Damage", 
 			}, 
@@ -598,7 +578,6 @@ return {
 				["max"] = 31.5, 
 				["min"] = 9.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Cold Damage", 
 			}, 
@@ -613,7 +592,6 @@ return {
 				["max"] = 25.5, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -627,7 +605,6 @@ return {
 				["max"] = 22, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -689,7 +666,6 @@ return {
 				["max"] = 41, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Lightning Damage", 
 			}, 
@@ -712,7 +688,6 @@ return {
 				["max"] = 11, 
 				["min"] = 1.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -774,7 +749,6 @@ return {
 				["max"] = 17, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Chaos Damage", 
 			}, 
@@ -789,7 +763,6 @@ return {
 				["max"] = 28.5, 
 				["min"] = 7.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -811,7 +784,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -873,7 +845,6 @@ return {
 				["max"] = 7, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Attack Speed", 
 			}, 
@@ -912,7 +883,6 @@ return {
 				["max"] = 15, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -926,7 +896,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -948,7 +917,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -994,7 +962,6 @@ return {
 				["max"] = 18, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1016,7 +983,6 @@ return {
 				["max"] = 30, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1034,7 +1000,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1077,7 +1042,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1091,7 +1055,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1101,7 +1064,6 @@ return {
 			}, 
 		}, 
 		["1421_MaximumEnergyShieldPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1115,7 +1077,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1137,7 +1098,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1159,7 +1119,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1173,7 +1132,6 @@ return {
 				["max"] = 2, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1195,7 +1153,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1209,7 +1166,6 @@ return {
 				["max"] = 2, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1223,7 +1179,6 @@ return {
 				["max"] = 2, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1297,7 +1252,6 @@ return {
 				["max"] = 4, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1315,7 +1269,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1333,7 +1286,6 @@ return {
 				["max"] = 25, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1407,7 +1359,6 @@ return {
 				["max"] = 0.2, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1481,7 +1432,6 @@ return {
 				["max"] = 0.2, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1555,7 +1505,6 @@ return {
 				["max"] = 0.2, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1565,7 +1514,6 @@ return {
 			}, 
 		}, 
 		["154_IncreaseSocketedDurationGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1575,7 +1523,6 @@ return {
 			}, 
 		}, 
 		["155_IncreasedSocketedAoEGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1585,7 +1532,6 @@ return {
 			}, 
 		}, 
 		["156_LocalIncreaseSocketedProjectileLevelCorrupted"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1595,7 +1541,6 @@ return {
 			}, 
 		}, 
 		["159_LocalIncreaseSocketedMinionGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1609,7 +1554,6 @@ return {
 				["max"] = 6, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1619,7 +1563,6 @@ return {
 			}, 
 		}, 
 		["160_LocalIncreaseSocketedAuraLevelCorrupted"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1629,7 +1572,6 @@ return {
 			}, 
 		}, 
 		["163_LocalIncreaseSocketedCurseLevelCorrupted"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1643,7 +1585,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1699,7 +1640,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLineSingular"] = "Bow Attacks fire an additional Arrow", 
 			}, 
@@ -1718,7 +1658,6 @@ return {
 				["max"] = 8, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1736,7 +1675,6 @@ return {
 				["max"] = 10, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1754,7 +1692,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1776,7 +1713,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1786,7 +1722,6 @@ return {
 			}, 
 		}, 
 		["166_IncreasedSocketedTrapOrMineGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1824,7 +1759,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1854,7 +1788,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1892,7 +1825,6 @@ return {
 				["max"] = 7, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1923,7 +1855,6 @@ return {
 				["max"] = 25, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1957,7 +1888,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -1991,7 +1921,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2013,7 +1942,6 @@ return {
 				["max"] = 25, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2031,7 +1959,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2053,7 +1980,6 @@ return {
 				["max"] = 25, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2075,7 +2001,6 @@ return {
 				["max"] = 25, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2085,7 +2010,6 @@ return {
 			}, 
 		}, 
 		["171_LocalSocketedWarcryGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2103,7 +2027,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2121,7 +2044,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2139,7 +2061,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2157,7 +2078,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2175,7 +2095,6 @@ return {
 				["max"] = 25, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2189,7 +2108,6 @@ return {
 				["max"] = 40, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2267,7 +2185,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2281,7 +2198,6 @@ return {
 				["max"] = 15, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2295,7 +2211,6 @@ return {
 				["max"] = 12, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2309,7 +2224,6 @@ return {
 				["max"] = 12, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2323,7 +2237,6 @@ return {
 				["max"] = 12, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2337,7 +2250,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1.6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2359,7 +2271,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2381,7 +2292,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2403,7 +2313,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2433,7 +2342,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2447,7 +2355,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2558,7 +2465,6 @@ return {
 				["max"] = 5, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2576,7 +2482,7 @@ return {
 				["max"] = -1, 
 				["min"] = -1, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2590,7 +2496,6 @@ return {
 				["max"] = 15.5, 
 				["min"] = 4.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2604,7 +2509,6 @@ return {
 				["max"] = 54, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2618,7 +2522,6 @@ return {
 				["max"] = 48.5, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2632,7 +2535,6 @@ return {
 				["max"] = 57, 
 				["min"] = 19.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2646,7 +2548,6 @@ return {
 				["max"] = 36, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2660,7 +2561,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLineSingular"] = "You can apply an additional Curse", 
 			}, 
@@ -2679,7 +2579,6 @@ return {
 				["max"] = 25, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2697,7 +2596,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2719,7 +2617,6 @@ return {
 				["max"] = 2, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2737,7 +2634,6 @@ return {
 				["max"] = 2, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2748,14 +2644,13 @@ return {
 		}, 
 		["2087_PhysicalAttackDamageTaken"] = {
 			["Amulet"] = {
-				["max"] = 17, 
-				["min"] = 10, 
+				["max"] = -10, 
+				["min"] = -17, 
 			}, 
 			["Shield"] = {
-				["max"] = 17, 
-				["min"] = 10, 
+				["max"] = -10, 
+				["min"] = -17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2769,7 +2664,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2783,7 +2677,7 @@ return {
 				["max"] = -4, 
 				["min"] = -6, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2797,7 +2691,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2811,7 +2704,6 @@ return {
 				["max"] = 5, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+#% Chance to Block", 
 			}, 
@@ -2826,7 +2718,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2853,7 +2744,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2867,7 +2757,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2881,7 +2770,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2895,7 +2783,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2917,7 +2804,6 @@ return {
 				["max"] = 6, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2943,7 +2829,6 @@ return {
 				["max"] = 20, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -2969,7 +2854,6 @@ return {
 				["max"] = 40, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3064,7 +2948,6 @@ return {
 				["max"] = 11, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3078,7 +2961,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3140,7 +3022,6 @@ return {
 				["max"] = 0.2, 
 				["min"] = 0.1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3154,7 +3035,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3200,7 +3080,6 @@ return {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3246,7 +3125,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3260,7 +3138,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3274,7 +3151,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3321,7 +3197,6 @@ return {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3368,7 +3243,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3390,7 +3264,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3412,7 +3285,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3434,7 +3306,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3472,7 +3343,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3490,7 +3360,6 @@ return {
 				["max"] = 7, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3529,7 +3398,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3547,7 +3415,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3565,7 +3432,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3583,7 +3449,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3601,7 +3466,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3619,7 +3483,6 @@ return {
 				["max"] = 100, 
 				["min"] = 60, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3633,7 +3496,6 @@ return {
 				["max"] = 12, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3647,7 +3509,6 @@ return {
 				["max"] = 12, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3669,7 +3530,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3691,7 +3551,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3713,7 +3572,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3735,7 +3593,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3757,7 +3614,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3779,7 +3635,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3814,7 +3669,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3828,7 +3682,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3842,7 +3695,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3884,7 +3736,6 @@ return {
 				["max"] = 12, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3902,7 +3753,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3920,7 +3770,6 @@ return {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3958,7 +3807,6 @@ return {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3976,7 +3824,6 @@ return {
 				["max"] = 12, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -3994,7 +3841,6 @@ return {
 				["max"] = 12, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4020,7 +3866,6 @@ return {
 				["max"] = 6, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4082,7 +3927,6 @@ return {
 				["max"] = 12, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4124,7 +3968,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4142,7 +3985,6 @@ return {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4160,7 +4002,6 @@ return {
 				["max"] = 15, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4195,7 +4036,6 @@ return {
 				["max"] = 25, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4213,7 +4053,6 @@ return {
 				["max"] = 14, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4231,7 +4070,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4249,7 +4087,6 @@ return {
 				["max"] = 12, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4291,7 +4128,6 @@ return {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4305,7 +4141,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4319,7 +4154,6 @@ return {
 				["max"] = 322, 
 				["min"] = 35, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4353,7 +4187,6 @@ return {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4371,7 +4204,6 @@ return {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4389,7 +4221,6 @@ return {
 				["max"] = 90, 
 				["min"] = 90, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4403,7 +4234,6 @@ return {
 				["max"] = 0.8, 
 				["min"] = 0.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4459,7 +4289,6 @@ return {
 				["max"] = 12, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4489,7 +4318,6 @@ return {
 				["max"] = 7, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4503,7 +4331,6 @@ return {
 				["max"] = 30, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4517,7 +4344,6 @@ return {
 				["max"] = 40, 
 				["min"] = 35, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4531,7 +4357,6 @@ return {
 				["max"] = 25, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4553,7 +4378,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4571,7 +4395,6 @@ return {
 				["max"] = 12, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4602,7 +4425,6 @@ return {
 				["max"] = 322, 
 				["min"] = 35, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4624,7 +4446,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4638,7 +4459,6 @@ return {
 				["max"] = 100, 
 				["min"] = 100, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4660,7 +4480,6 @@ return {
 				["max"] = 7, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4682,7 +4501,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4696,7 +4514,6 @@ return {
 				["max"] = 25, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4710,7 +4527,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4728,7 +4544,7 @@ return {
 				["max"] = -20, 
 				["min"] = -25, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4746,7 +4562,7 @@ return {
 				["max"] = -20, 
 				["min"] = -25, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4760,7 +4576,6 @@ return {
 				["max"] = 30, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4778,7 +4593,6 @@ return {
 				["max"] = 25, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4792,7 +4606,6 @@ return {
 				["max"] = 0.8, 
 				["min"] = 0.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4806,7 +4619,6 @@ return {
 				["max"] = 10, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4849,7 +4661,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4907,7 +4718,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4925,7 +4735,6 @@ return {
 				["max"] = 14, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4943,7 +4752,6 @@ return {
 				["max"] = 12, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4961,7 +4769,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4979,7 +4786,6 @@ return {
 				["max"] = 15, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -4997,7 +4803,6 @@ return {
 				["max"] = 12, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5015,7 +4820,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5033,7 +4837,6 @@ return {
 				["max"] = 14, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5051,7 +4854,6 @@ return {
 				["max"] = 12, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5069,7 +4871,6 @@ return {
 				["max"] = 29, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5087,7 +4888,6 @@ return {
 				["max"] = 53, 
 				["min"] = 44, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5105,7 +4905,6 @@ return {
 				["max"] = 41, 
 				["min"] = 29, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5123,7 +4922,6 @@ return {
 				["max"] = 29, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5141,7 +4939,6 @@ return {
 				["max"] = 53, 
 				["min"] = 44, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5159,7 +4956,6 @@ return {
 				["max"] = 41, 
 				["min"] = 29, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5173,7 +4969,6 @@ return {
 				["max"] = 20, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5187,7 +4982,6 @@ return {
 				["max"] = 28, 
 				["min"] = 21, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5201,7 +4995,6 @@ return {
 				["max"] = 24, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5219,7 +5012,6 @@ return {
 				["max"] = 28, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5237,7 +5029,6 @@ return {
 				["max"] = 40, 
 				["min"] = 33, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5255,7 +5046,6 @@ return {
 				["max"] = 34, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5273,7 +5063,6 @@ return {
 				["max"] = 28, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5291,7 +5080,6 @@ return {
 				["max"] = 40, 
 				["min"] = 33, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5309,7 +5097,6 @@ return {
 				["max"] = 34, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5327,7 +5114,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5345,7 +5131,6 @@ return {
 				["max"] = 29, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5363,7 +5148,6 @@ return {
 				["max"] = 23, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5381,7 +5165,6 @@ return {
 				["max"] = 26, 
 				["min"] = 21, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5399,7 +5182,6 @@ return {
 				["max"] = 32, 
 				["min"] = 29, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5417,7 +5199,6 @@ return {
 				["max"] = 29, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5431,7 +5212,6 @@ return {
 				["max"] = 12, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5445,7 +5225,6 @@ return {
 				["max"] = 16, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5459,7 +5238,6 @@ return {
 				["max"] = 14, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5473,7 +5251,6 @@ return {
 				["max"] = 0.3, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5487,7 +5264,6 @@ return {
 				["max"] = 0.5, 
 				["min"] = 0.4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5501,7 +5277,6 @@ return {
 				["max"] = 0.4, 
 				["min"] = 0.3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5519,7 +5294,6 @@ return {
 				["max"] = 12, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5537,7 +5311,6 @@ return {
 				["max"] = 18, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5555,7 +5328,6 @@ return {
 				["max"] = 15, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5569,7 +5341,6 @@ return {
 				["max"] = 12, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5583,7 +5354,6 @@ return {
 				["max"] = 16, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5597,7 +5367,6 @@ return {
 				["max"] = 14, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5611,7 +5380,6 @@ return {
 				["max"] = 36, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5625,7 +5393,6 @@ return {
 				["max"] = 60, 
 				["min"] = 49, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5639,7 +5406,6 @@ return {
 				["max"] = 48, 
 				["min"] = 34, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5653,7 +5419,6 @@ return {
 				["max"] = 12, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5667,7 +5432,6 @@ return {
 				["max"] = 16, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5681,7 +5445,6 @@ return {
 				["max"] = 14, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5695,7 +5458,6 @@ return {
 				["max"] = 16, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5709,7 +5471,6 @@ return {
 				["max"] = 28, 
 				["min"] = 21, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5723,7 +5484,6 @@ return {
 				["max"] = 22, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5737,7 +5497,6 @@ return {
 				["max"] = 0.7, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5751,7 +5510,6 @@ return {
 				["max"] = 1.1, 
 				["min"] = 0.8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5765,7 +5523,6 @@ return {
 				["max"] = 0.9, 
 				["min"] = 0.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5779,7 +5536,6 @@ return {
 				["max"] = 0.7, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5793,7 +5549,6 @@ return {
 				["max"] = 1.1, 
 				["min"] = 0.8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5807,7 +5562,6 @@ return {
 				["max"] = 0.9, 
 				["min"] = 0.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5821,7 +5575,6 @@ return {
 				["max"] = 0.7, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5835,7 +5588,6 @@ return {
 				["max"] = 1.1, 
 				["min"] = 0.8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5849,7 +5601,6 @@ return {
 				["max"] = 0.9, 
 				["min"] = 0.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5863,7 +5614,6 @@ return {
 				["max"] = 0.7, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5877,7 +5627,6 @@ return {
 				["max"] = 1.1, 
 				["min"] = 0.8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5891,7 +5640,6 @@ return {
 				["max"] = 0.9, 
 				["min"] = 0.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5905,7 +5653,6 @@ return {
 				["max"] = 0.7, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5919,7 +5666,6 @@ return {
 				["max"] = 1.1, 
 				["min"] = 0.8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5933,7 +5679,6 @@ return {
 				["max"] = 0.9, 
 				["min"] = 0.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5947,7 +5692,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLineSingular"] = "Projectiles Pierce an additional Target", 
 			}, 
@@ -5962,7 +5706,6 @@ return {
 				["max"] = 4, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5976,7 +5719,6 @@ return {
 				["max"] = 3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -5990,7 +5732,6 @@ return {
 				["max"] = 32, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6004,7 +5745,6 @@ return {
 				["max"] = 50, 
 				["min"] = 39, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6018,7 +5758,6 @@ return {
 				["max"] = 41, 
 				["min"] = 27, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6032,7 +5771,6 @@ return {
 				["max"] = 50, 
 				["min"] = 33, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6046,7 +5784,6 @@ return {
 				["max"] = 70, 
 				["min"] = 57, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6060,7 +5797,6 @@ return {
 				["max"] = 61, 
 				["min"] = 45, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6078,7 +5814,6 @@ return {
 				["max"] = 24, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6096,7 +5831,6 @@ return {
 				["max"] = 36, 
 				["min"] = 29, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6114,7 +5848,6 @@ return {
 				["max"] = 30, 
 				["min"] = 21, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6128,7 +5861,6 @@ return {
 				["max"] = 50, 
 				["min"] = 33, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6142,7 +5874,6 @@ return {
 				["max"] = 70, 
 				["min"] = 57, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6156,7 +5887,6 @@ return {
 				["max"] = 61, 
 				["min"] = 45, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6170,7 +5900,6 @@ return {
 				["max"] = 50, 
 				["min"] = 33, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6184,7 +5913,6 @@ return {
 				["max"] = 70, 
 				["min"] = 57, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6198,7 +5926,6 @@ return {
 				["max"] = 61, 
 				["min"] = 45, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6212,7 +5939,6 @@ return {
 				["max"] = 18, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6226,7 +5952,6 @@ return {
 				["max"] = 30, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6240,7 +5965,6 @@ return {
 				["max"] = 24, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6254,7 +5978,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6268,7 +5991,6 @@ return {
 				["max"] = 10, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6282,7 +6004,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6296,7 +6017,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6310,7 +6030,6 @@ return {
 				["max"] = 10, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6324,7 +6043,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6338,7 +6056,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6352,7 +6069,6 @@ return {
 				["max"] = 10, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6366,7 +6082,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6380,7 +6095,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6394,7 +6108,6 @@ return {
 				["max"] = 10, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6408,7 +6121,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6422,7 +6134,6 @@ return {
 				["max"] = 35, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6436,7 +6147,6 @@ return {
 				["max"] = 65, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6450,7 +6160,6 @@ return {
 				["max"] = 50, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6464,7 +6173,6 @@ return {
 				["max"] = 35, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6478,7 +6186,6 @@ return {
 				["max"] = 65, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6492,7 +6199,6 @@ return {
 				["max"] = 50, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6506,7 +6212,6 @@ return {
 				["max"] = 35, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6520,7 +6225,6 @@ return {
 				["max"] = 65, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6534,7 +6238,6 @@ return {
 				["max"] = 50, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6548,7 +6251,6 @@ return {
 				["max"] = 65, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6562,7 +6264,6 @@ return {
 				["max"] = 50, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6576,7 +6277,6 @@ return {
 				["max"] = 35, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6590,7 +6290,6 @@ return {
 				["max"] = 6, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6604,7 +6303,6 @@ return {
 				["max"] = 8, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6618,7 +6316,6 @@ return {
 				["max"] = 7, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6632,7 +6329,6 @@ return {
 				["max"] = 30, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6646,7 +6342,6 @@ return {
 				["max"] = 50, 
 				["min"] = 35, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6660,7 +6355,6 @@ return {
 				["max"] = 40, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6674,7 +6368,6 @@ return {
 				["max"] = 30, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6688,7 +6381,6 @@ return {
 				["max"] = 50, 
 				["min"] = 35, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6702,7 +6394,6 @@ return {
 				["max"] = 40, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6716,7 +6407,6 @@ return {
 				["max"] = 30, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6730,7 +6420,6 @@ return {
 				["max"] = 50, 
 				["min"] = 35, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6744,7 +6433,6 @@ return {
 				["max"] = 40, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6762,7 +6450,6 @@ return {
 				["max"] = 12, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6780,7 +6467,6 @@ return {
 				["max"] = 18, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6798,7 +6484,6 @@ return {
 				["max"] = 15, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6812,7 +6497,6 @@ return {
 				["max"] = 12, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6826,7 +6510,6 @@ return {
 				["max"] = 20, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6840,7 +6523,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6854,7 +6536,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6868,7 +6549,6 @@ return {
 				["max"] = 12, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6882,7 +6562,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6896,7 +6575,6 @@ return {
 				["max"] = 12, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6910,7 +6588,6 @@ return {
 				["max"] = 20, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6924,7 +6601,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6938,7 +6614,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6952,7 +6627,6 @@ return {
 				["max"] = 12, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6966,7 +6640,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6980,7 +6653,6 @@ return {
 				["max"] = 12, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -6994,7 +6666,6 @@ return {
 				["max"] = 20, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7008,7 +6679,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7022,7 +6692,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7036,7 +6705,6 @@ return {
 				["max"] = 12, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7050,7 +6718,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7064,7 +6731,6 @@ return {
 				["max"] = 12, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7078,7 +6744,6 @@ return {
 				["max"] = 20, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7092,7 +6757,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7106,7 +6770,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7120,7 +6783,6 @@ return {
 				["max"] = 12, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7134,7 +6796,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7148,7 +6809,6 @@ return {
 				["max"] = 30, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7162,7 +6822,6 @@ return {
 				["max"] = 50, 
 				["min"] = 35, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7176,7 +6835,6 @@ return {
 				["max"] = 40, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7190,7 +6848,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7204,7 +6861,6 @@ return {
 				["max"] = 16, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7218,7 +6874,6 @@ return {
 				["max"] = 13, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7232,7 +6887,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7246,7 +6900,6 @@ return {
 				["max"] = 29, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7260,7 +6913,6 @@ return {
 				["max"] = 23, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7278,7 +6930,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7296,7 +6947,6 @@ return {
 				["max"] = 10, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7314,7 +6964,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7332,7 +6981,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7350,7 +6998,6 @@ return {
 				["max"] = 10, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7368,7 +7015,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7386,7 +7032,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7404,7 +7049,6 @@ return {
 				["max"] = 10, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7422,7 +7066,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7436,7 +7079,6 @@ return {
 				["max"] = 30, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7450,7 +7092,6 @@ return {
 				["max"] = 50, 
 				["min"] = 35, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7464,7 +7105,6 @@ return {
 				["max"] = 40, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7478,7 +7118,6 @@ return {
 				["max"] = 32, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7492,7 +7131,6 @@ return {
 				["max"] = 50, 
 				["min"] = 39, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7506,7 +7144,6 @@ return {
 				["max"] = 41, 
 				["min"] = 27, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7520,7 +7157,6 @@ return {
 				["max"] = 26, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7534,7 +7170,6 @@ return {
 				["max"] = 34, 
 				["min"] = 27, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7548,7 +7183,6 @@ return {
 				["max"] = 30, 
 				["min"] = 21, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7562,7 +7196,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7576,7 +7209,6 @@ return {
 				["max"] = 29, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7590,7 +7222,6 @@ return {
 				["max"] = 23, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7604,7 +7235,6 @@ return {
 				["max"] = 36, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7618,7 +7248,6 @@ return {
 				["max"] = 60, 
 				["min"] = 49, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7632,7 +7261,6 @@ return {
 				["max"] = 48, 
 				["min"] = 34, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7646,7 +7274,6 @@ return {
 				["max"] = 36, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7660,7 +7287,6 @@ return {
 				["max"] = 60, 
 				["min"] = 49, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7674,7 +7300,6 @@ return {
 				["max"] = 48, 
 				["min"] = 34, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7688,7 +7313,6 @@ return {
 				["max"] = 36, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7702,7 +7326,6 @@ return {
 				["max"] = 60, 
 				["min"] = 49, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7716,7 +7339,6 @@ return {
 				["max"] = 48, 
 				["min"] = 34, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7730,7 +7352,6 @@ return {
 				["max"] = 36, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7744,7 +7365,6 @@ return {
 				["max"] = 60, 
 				["min"] = 49, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7758,7 +7378,6 @@ return {
 				["max"] = 48, 
 				["min"] = 34, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7772,7 +7391,6 @@ return {
 				["max"] = 36, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7786,7 +7404,6 @@ return {
 				["max"] = 60, 
 				["min"] = 49, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7800,7 +7417,6 @@ return {
 				["max"] = 48, 
 				["min"] = 34, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7814,7 +7430,6 @@ return {
 				["max"] = 36, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7828,7 +7443,6 @@ return {
 				["max"] = 60, 
 				["min"] = 49, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7842,7 +7456,6 @@ return {
 				["max"] = 48, 
 				["min"] = 34, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7856,7 +7469,6 @@ return {
 				["max"] = 36, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7870,7 +7482,6 @@ return {
 				["max"] = 60, 
 				["min"] = 49, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7884,7 +7495,6 @@ return {
 				["max"] = 48, 
 				["min"] = 34, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7898,7 +7508,6 @@ return {
 				["max"] = 36, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7912,7 +7521,6 @@ return {
 				["max"] = 60, 
 				["min"] = 49, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7926,7 +7534,6 @@ return {
 				["max"] = 48, 
 				["min"] = 34, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7940,7 +7547,6 @@ return {
 				["max"] = 36, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7954,7 +7560,6 @@ return {
 				["max"] = 60, 
 				["min"] = 49, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7968,7 +7573,6 @@ return {
 				["max"] = 48, 
 				["min"] = 34, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7982,7 +7586,6 @@ return {
 				["max"] = 36, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -7996,7 +7599,6 @@ return {
 				["max"] = 60, 
 				["min"] = 49, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8010,7 +7612,6 @@ return {
 				["max"] = 48, 
 				["min"] = 34, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8024,7 +7625,6 @@ return {
 				["max"] = 36, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8038,7 +7638,6 @@ return {
 				["max"] = 60, 
 				["min"] = 49, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8052,7 +7651,6 @@ return {
 				["max"] = 48, 
 				["min"] = 34, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8066,7 +7664,6 @@ return {
 				["max"] = 32, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8080,7 +7677,6 @@ return {
 				["max"] = 50, 
 				["min"] = 39, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8094,7 +7690,6 @@ return {
 				["max"] = 41, 
 				["min"] = 27, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8108,7 +7703,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8122,7 +7716,6 @@ return {
 				["max"] = 29, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8136,7 +7729,6 @@ return {
 				["max"] = 23, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8150,7 +7742,6 @@ return {
 				["max"] = 50, 
 				["min"] = 33, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8164,7 +7755,6 @@ return {
 				["max"] = 70, 
 				["min"] = 57, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8178,7 +7768,6 @@ return {
 				["max"] = 61, 
 				["min"] = 45, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8192,7 +7781,6 @@ return {
 				["max"] = 70, 
 				["min"] = 45, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8206,7 +7794,6 @@ return {
 				["max"] = 100, 
 				["min"] = 85, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8220,7 +7807,6 @@ return {
 				["max"] = 85, 
 				["min"] = 65, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8234,7 +7820,6 @@ return {
 				["max"] = 32, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8248,7 +7833,6 @@ return {
 				["max"] = 50, 
 				["min"] = 39, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8262,7 +7846,6 @@ return {
 				["max"] = 41, 
 				["min"] = 27, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8276,7 +7859,6 @@ return {
 				["max"] = 72, 
 				["min"] = 61, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8290,7 +7872,6 @@ return {
 				["max"] = 66, 
 				["min"] = 52, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8304,7 +7885,6 @@ return {
 				["max"] = 60, 
 				["min"] = 43, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8318,7 +7898,6 @@ return {
 				["max"] = 30, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8332,7 +7911,6 @@ return {
 				["max"] = 50, 
 				["min"] = 35, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8346,7 +7924,6 @@ return {
 				["max"] = 40, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8360,7 +7937,6 @@ return {
 				["max"] = 35, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8374,7 +7950,6 @@ return {
 				["max"] = 47, 
 				["min"] = 38, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8388,7 +7963,6 @@ return {
 				["max"] = 41, 
 				["min"] = 29, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8402,7 +7976,6 @@ return {
 				["max"] = 50, 
 				["min"] = 33, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8416,7 +7989,6 @@ return {
 				["max"] = 70, 
 				["min"] = 57, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8430,7 +8002,6 @@ return {
 				["max"] = 61, 
 				["min"] = 45, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8444,7 +8015,6 @@ return {
 				["max"] = 30, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8458,7 +8028,6 @@ return {
 				["max"] = 50, 
 				["min"] = 35, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8472,7 +8041,6 @@ return {
 				["max"] = 40, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8486,7 +8054,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8500,7 +8067,6 @@ return {
 				["max"] = 16, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8514,7 +8080,6 @@ return {
 				["max"] = 13, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8528,7 +8093,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8542,7 +8106,6 @@ return {
 				["max"] = 29, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8556,7 +8119,6 @@ return {
 				["max"] = 23, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8570,7 +8132,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8584,7 +8145,6 @@ return {
 				["max"] = 29, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8598,7 +8158,6 @@ return {
 				["max"] = 23, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8612,7 +8171,6 @@ return {
 				["max"] = 230, 
 				["min"] = 180, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8626,7 +8184,6 @@ return {
 				["max"] = 170, 
 				["min"] = 140, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8640,7 +8197,6 @@ return {
 				["max"] = 200, 
 				["min"] = 160, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8654,7 +8210,6 @@ return {
 				["max"] = 230, 
 				["min"] = 180, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8668,7 +8223,6 @@ return {
 				["max"] = 170, 
 				["min"] = 140, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8682,7 +8236,6 @@ return {
 				["max"] = 200, 
 				["min"] = 160, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8696,7 +8249,6 @@ return {
 				["max"] = 230, 
 				["min"] = 180, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8710,7 +8262,6 @@ return {
 				["max"] = 170, 
 				["min"] = 140, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8724,7 +8275,6 @@ return {
 				["max"] = 200, 
 				["min"] = 160, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8735,10 +8285,9 @@ return {
 		}, 
 		["5407_ColdExposureEffectOnHit"] = {
 			["Gloves"] = {
-				["max"] = 16, 
-				["min"] = 11, 
+				["max"] = -11, 
+				["min"] = -16, 
 			}, 
-			["sign"] = "-", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8749,10 +8298,9 @@ return {
 		}, 
 		["5407_ColdExposureEffectOnHitPinnaclePresence"] = {
 			["Gloves"] = {
-				["max"] = 22, 
-				["min"] = 19, 
+				["max"] = -19, 
+				["min"] = -22, 
 			}, 
-			["sign"] = "-", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8763,10 +8311,9 @@ return {
 		}, 
 		["5407_ColdExposureEffectOnHitUniquePresence"] = {
 			["Gloves"] = {
-				["max"] = 19, 
-				["min"] = 15, 
+				["max"] = -15, 
+				["min"] = -19, 
 			}, 
-			["sign"] = "-", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8780,7 +8327,6 @@ return {
 				["max"] = 4, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8794,7 +8340,6 @@ return {
 				["max"] = 6, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8808,7 +8353,6 @@ return {
 				["max"] = 5, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8822,7 +8366,6 @@ return {
 				["max"] = 4, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8836,7 +8379,6 @@ return {
 				["max"] = 6, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8850,7 +8392,6 @@ return {
 				["max"] = 5, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8864,7 +8405,6 @@ return {
 				["max"] = 4, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8878,7 +8418,6 @@ return {
 				["max"] = 6, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8892,7 +8431,6 @@ return {
 				["max"] = 5, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8906,7 +8444,6 @@ return {
 				["max"] = 36, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8920,7 +8457,6 @@ return {
 				["max"] = 60, 
 				["min"] = 49, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8934,7 +8470,6 @@ return {
 				["max"] = 48, 
 				["min"] = 34, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8948,7 +8483,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8962,7 +8496,6 @@ return {
 				["max"] = 29, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8976,7 +8509,6 @@ return {
 				["max"] = 23, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -8990,7 +8522,6 @@ return {
 				["max"] = 35, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9004,7 +8535,6 @@ return {
 				["max"] = 47, 
 				["min"] = 38, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9018,7 +8548,6 @@ return {
 				["max"] = 41, 
 				["min"] = 29, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9032,7 +8561,6 @@ return {
 				["max"] = 82, 
 				["min"] = 65, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9046,7 +8574,6 @@ return {
 				["max"] = 100, 
 				["min"] = 89, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9060,7 +8587,6 @@ return {
 				["max"] = 91, 
 				["min"] = 77, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9074,7 +8600,6 @@ return {
 				["max"] = 50, 
 				["min"] = 33, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9088,7 +8613,6 @@ return {
 				["max"] = 70, 
 				["min"] = 57, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9102,7 +8626,6 @@ return {
 				["max"] = 61, 
 				["min"] = 45, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9116,7 +8639,6 @@ return {
 				["max"] = 50, 
 				["min"] = 33, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9130,7 +8652,6 @@ return {
 				["max"] = 70, 
 				["min"] = 57, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9144,7 +8665,6 @@ return {
 				["max"] = 61, 
 				["min"] = 45, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9158,7 +8678,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9172,7 +8691,6 @@ return {
 				["max"] = 16, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9186,7 +8704,6 @@ return {
 				["max"] = 13, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9200,7 +8717,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9214,7 +8730,6 @@ return {
 				["max"] = 16, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9228,7 +8743,6 @@ return {
 				["max"] = 13, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9239,10 +8753,9 @@ return {
 		}, 
 		["6109_FireExposureEffectOnHit"] = {
 			["Gloves"] = {
-				["max"] = 16, 
-				["min"] = 11, 
+				["max"] = -11, 
+				["min"] = -16, 
 			}, 
-			["sign"] = "-", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9253,10 +8766,9 @@ return {
 		}, 
 		["6109_FireExposureEffectOnHitPinnaclePresence"] = {
 			["Gloves"] = {
-				["max"] = 22, 
-				["min"] = 19, 
+				["max"] = -19, 
+				["min"] = -22, 
 			}, 
-			["sign"] = "-", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9267,10 +8779,9 @@ return {
 		}, 
 		["6109_FireExposureEffectOnHitUniquePresence"] = {
 			["Gloves"] = {
-				["max"] = 19, 
-				["min"] = 15, 
+				["max"] = -15, 
+				["min"] = -19, 
 			}, 
-			["sign"] = "-", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9284,7 +8795,6 @@ return {
 				["max"] = 32, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9298,7 +8808,6 @@ return {
 				["max"] = 50, 
 				["min"] = 39, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9312,7 +8821,6 @@ return {
 				["max"] = 41, 
 				["min"] = 27, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9326,7 +8834,6 @@ return {
 				["max"] = 50, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9340,7 +8847,6 @@ return {
 				["max"] = 78, 
 				["min"] = 61, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9354,7 +8860,6 @@ return {
 				["max"] = 63, 
 				["min"] = 46, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9368,7 +8873,6 @@ return {
 				["max"] = 32, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9382,7 +8886,6 @@ return {
 				["max"] = 50, 
 				["min"] = 39, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9396,7 +8899,6 @@ return {
 				["max"] = 41, 
 				["min"] = 27, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9410,7 +8912,6 @@ return {
 				["max"] = 32, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9424,7 +8925,6 @@ return {
 				["max"] = 50, 
 				["min"] = 39, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9438,7 +8938,6 @@ return {
 				["max"] = 41, 
 				["min"] = 27, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9449,10 +8948,9 @@ return {
 		}, 
 		["6912_LightningExposureEffectOnHit"] = {
 			["Gloves"] = {
-				["max"] = 16, 
-				["min"] = 11, 
+				["max"] = -11, 
+				["min"] = -16, 
 			}, 
-			["sign"] = "-", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9463,10 +8961,9 @@ return {
 		}, 
 		["6912_LightningExposureEffectOnHitPinnaclePresence"] = {
 			["Gloves"] = {
-				["max"] = 22, 
-				["min"] = 19, 
+				["max"] = -19, 
+				["min"] = -22, 
 			}, 
-			["sign"] = "-", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9477,10 +8974,9 @@ return {
 		}, 
 		["6912_LightningExposureEffectOnHitUniquePresence"] = {
 			["Gloves"] = {
-				["max"] = 19, 
-				["min"] = 15, 
+				["max"] = -15, 
+				["min"] = -19, 
 			}, 
-			["sign"] = "-", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9494,7 +8990,6 @@ return {
 				["max"] = 40, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9508,7 +9003,6 @@ return {
 				["max"] = 95, 
 				["min"] = 85, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9522,7 +9016,6 @@ return {
 				["max"] = 70, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9536,7 +9029,6 @@ return {
 				["max"] = 70, 
 				["min"] = 45, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9550,7 +9042,6 @@ return {
 				["max"] = 100, 
 				["min"] = 85, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9564,7 +9055,6 @@ return {
 				["max"] = 85, 
 				["min"] = 65, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9582,7 +9072,6 @@ return {
 				["max"] = 29, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9600,7 +9089,6 @@ return {
 				["max"] = 41, 
 				["min"] = 32, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9618,7 +9106,6 @@ return {
 				["max"] = 35, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9632,7 +9119,6 @@ return {
 				["max"] = 36, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9646,7 +9132,6 @@ return {
 				["max"] = 60, 
 				["min"] = 49, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9660,7 +9145,6 @@ return {
 				["max"] = 48, 
 				["min"] = 34, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9674,7 +9158,6 @@ return {
 				["max"] = 35, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9688,7 +9171,6 @@ return {
 				["max"] = 47, 
 				["min"] = 38, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9702,7 +9184,6 @@ return {
 				["max"] = 41, 
 				["min"] = 29, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9716,7 +9197,6 @@ return {
 				["max"] = 50, 
 				["min"] = 33, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9730,7 +9210,6 @@ return {
 				["max"] = 70, 
 				["min"] = 57, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9744,7 +9223,6 @@ return {
 				["max"] = 61, 
 				["min"] = 45, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9758,7 +9236,6 @@ return {
 				["max"] = 40, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9772,7 +9249,6 @@ return {
 				["max"] = 95, 
 				["min"] = 85, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9786,7 +9262,6 @@ return {
 				["max"] = 70, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9800,7 +9275,7 @@ return {
 				["max"] = -10, 
 				["min"] = -24, 
 			}, 
-			["inverseKey"] = "slower", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9814,7 +9289,7 @@ return {
 				["max"] = -34, 
 				["min"] = -45, 
 			}, 
-			["inverseKey"] = "slower", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9828,7 +9303,7 @@ return {
 				["max"] = -22, 
 				["min"] = -33, 
 			}, 
-			["inverseKey"] = "slower", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9842,7 +9317,6 @@ return {
 				["max"] = 36, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9856,7 +9330,6 @@ return {
 				["max"] = 60, 
 				["min"] = 49, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9870,7 +9343,6 @@ return {
 				["max"] = 48, 
 				["min"] = 34, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9886,7 +9358,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9900,7 +9371,6 @@ return {
 				["max"] = 29, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9914,7 +9384,6 @@ return {
 				["max"] = 23, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9928,7 +9397,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9942,7 +9410,6 @@ return {
 				["max"] = 29, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9956,7 +9423,6 @@ return {
 				["max"] = 23, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9970,7 +9436,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9984,7 +9449,6 @@ return {
 				["max"] = 29, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -9998,7 +9462,6 @@ return {
 				["max"] = 23, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10016,7 +9479,6 @@ return {
 				["max"] = 30, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10034,7 +9496,6 @@ return {
 				["max"] = 42, 
 				["min"] = 33, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10052,7 +9513,6 @@ return {
 				["max"] = 36, 
 				["min"] = 24, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10070,7 +9530,6 @@ return {
 				["max"] = 20, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10088,7 +9547,6 @@ return {
 				["max"] = 38, 
 				["min"] = 29, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10106,7 +9564,6 @@ return {
 				["max"] = 29, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10124,7 +9581,6 @@ return {
 				["max"] = 20, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10142,7 +9598,6 @@ return {
 				["max"] = 38, 
 				["min"] = 29, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10160,7 +9615,6 @@ return {
 				["max"] = 29, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10178,7 +9632,6 @@ return {
 				["max"] = 20, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10196,7 +9649,6 @@ return {
 				["max"] = 38, 
 				["min"] = 29, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10214,7 +9666,6 @@ return {
 				["max"] = 29, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10232,7 +9683,6 @@ return {
 				["max"] = 20, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10250,7 +9700,6 @@ return {
 				["max"] = 38, 
 				["min"] = 29, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10268,7 +9717,6 @@ return {
 				["max"] = 29, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10282,7 +9730,6 @@ return {
 				["max"] = 10.5, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10296,7 +9743,6 @@ return {
 				["max"] = 21.5, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10310,7 +9756,6 @@ return {
 				["max"] = 14, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10328,7 +9773,6 @@ return {
 				["max"] = 30, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10346,7 +9790,6 @@ return {
 				["max"] = 42, 
 				["min"] = 33, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10364,7 +9807,6 @@ return {
 				["max"] = 36, 
 				["min"] = 24, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10378,7 +9820,6 @@ return {
 				["max"] = 18.5, 
 				["min"] = 9.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10392,7 +9833,6 @@ return {
 				["max"] = 38, 
 				["min"] = 20.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10406,7 +9846,6 @@ return {
 				["max"] = 25, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10424,7 +9863,6 @@ return {
 				["max"] = 30, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10442,7 +9880,6 @@ return {
 				["max"] = 42, 
 				["min"] = 33, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10460,7 +9897,6 @@ return {
 				["max"] = 36, 
 				["min"] = 24, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10474,7 +9910,6 @@ return {
 				["max"] = 17, 
 				["min"] = 8.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10488,7 +9923,6 @@ return {
 				["max"] = 34, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10502,7 +9936,6 @@ return {
 				["max"] = 22.5, 
 				["min"] = 12.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10520,7 +9953,6 @@ return {
 				["max"] = 30, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10538,7 +9970,6 @@ return {
 				["max"] = 42, 
 				["min"] = 33, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10556,7 +9987,6 @@ return {
 				["max"] = 36, 
 				["min"] = 24, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10570,7 +10000,6 @@ return {
 				["max"] = 21, 
 				["min"] = 11.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10584,7 +10013,6 @@ return {
 				["max"] = 43, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10598,7 +10026,6 @@ return {
 				["max"] = 28, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10616,7 +10043,6 @@ return {
 				["max"] = 30, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10634,7 +10060,6 @@ return {
 				["max"] = 42, 
 				["min"] = 33, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10652,7 +10077,6 @@ return {
 				["max"] = 36, 
 				["min"] = 24, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10666,7 +10090,6 @@ return {
 				["max"] = 14, 
 				["min"] = 7.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10680,7 +10103,6 @@ return {
 				["max"] = 28.5, 
 				["min"] = 15.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10694,7 +10116,6 @@ return {
 				["max"] = 19, 
 				["min"] = 10.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10708,7 +10129,6 @@ return {
 				["max"] = 22.5, 
 				["min"] = 11.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10722,7 +10142,6 @@ return {
 				["max"] = 46, 
 				["min"] = 24.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10736,7 +10155,6 @@ return {
 				["max"] = 30.5, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10750,7 +10168,6 @@ return {
 				["max"] = 28, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10764,7 +10181,6 @@ return {
 				["max"] = 56, 
 				["min"] = 30.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10778,7 +10194,6 @@ return {
 				["max"] = 37.5, 
 				["min"] = 21.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10792,7 +10207,6 @@ return {
 				["max"] = 25, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10806,7 +10220,6 @@ return {
 				["max"] = 50.5, 
 				["min"] = 27.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10820,7 +10233,6 @@ return {
 				["max"] = 33.5, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10834,7 +10246,6 @@ return {
 				["max"] = 32.5, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10848,7 +10259,6 @@ return {
 				["max"] = 65, 
 				["min"] = 37.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10862,7 +10272,6 @@ return {
 				["max"] = 43, 
 				["min"] = 26, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10876,7 +10285,6 @@ return {
 				["max"] = 21, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10890,7 +10298,6 @@ return {
 				["max"] = 43, 
 				["min"] = 23.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10904,7 +10311,6 @@ return {
 				["max"] = 28, 
 				["min"] = 15.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10918,7 +10324,6 @@ return {
 				["max"] = 13, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10932,7 +10337,6 @@ return {
 				["max"] = 21, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10946,7 +10350,6 @@ return {
 				["max"] = 17, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10960,7 +10363,6 @@ return {
 				["max"] = 13, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10974,7 +10376,6 @@ return {
 				["max"] = 21, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -10988,7 +10389,6 @@ return {
 				["max"] = 17, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11006,7 +10406,6 @@ return {
 				["max"] = 45, 
 				["min"] = 28, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11024,7 +10423,6 @@ return {
 				["max"] = 69, 
 				["min"] = 58, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11042,7 +10440,6 @@ return {
 				["max"] = 57, 
 				["min"] = 43, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11056,7 +10453,6 @@ return {
 				["max"] = 31, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11070,7 +10466,6 @@ return {
 				["max"] = 43, 
 				["min"] = 36, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11084,7 +10479,6 @@ return {
 				["max"] = 37, 
 				["min"] = 28, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11098,7 +10492,6 @@ return {
 				["max"] = 31, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11112,7 +10505,6 @@ return {
 				["max"] = 43, 
 				["min"] = 36, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11126,7 +10518,6 @@ return {
 				["max"] = 37, 
 				["min"] = 28, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11140,7 +10531,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11154,7 +10544,6 @@ return {
 				["max"] = 29, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11168,7 +10557,6 @@ return {
 				["max"] = 23, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11182,7 +10570,6 @@ return {
 				["max"] = 3, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11196,7 +10583,6 @@ return {
 				["max"] = 5, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11210,7 +10596,6 @@ return {
 				["max"] = 4, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11224,7 +10609,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11238,7 +10622,6 @@ return {
 				["max"] = 4, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11252,7 +10635,6 @@ return {
 				["max"] = 3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11266,7 +10648,6 @@ return {
 				["max"] = 24, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11280,7 +10661,6 @@ return {
 				["max"] = 36, 
 				["min"] = 29, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11294,7 +10674,6 @@ return {
 				["max"] = 30, 
 				["min"] = 21, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11308,7 +10687,6 @@ return {
 				["max"] = 3, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11322,7 +10700,6 @@ return {
 				["max"] = 5, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11336,7 +10713,6 @@ return {
 				["max"] = 4, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11350,7 +10726,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11364,7 +10739,6 @@ return {
 				["max"] = 4, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11378,7 +10752,6 @@ return {
 				["max"] = 3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11392,7 +10765,6 @@ return {
 				["max"] = 24, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11406,7 +10778,6 @@ return {
 				["max"] = 36, 
 				["min"] = 29, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11420,7 +10791,6 @@ return {
 				["max"] = 30, 
 				["min"] = 21, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11434,7 +10804,6 @@ return {
 				["max"] = 3, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11448,7 +10817,6 @@ return {
 				["max"] = 5, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11462,7 +10830,6 @@ return {
 				["max"] = 4, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11476,7 +10843,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11490,7 +10856,6 @@ return {
 				["max"] = 4, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11504,7 +10869,6 @@ return {
 				["max"] = 3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11518,7 +10882,6 @@ return {
 				["max"] = 24, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11532,7 +10895,6 @@ return {
 				["max"] = 36, 
 				["min"] = 29, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11546,7 +10908,6 @@ return {
 				["max"] = 30, 
 				["min"] = 21, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11560,7 +10921,6 @@ return {
 				["max"] = 3, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11574,7 +10934,6 @@ return {
 				["max"] = 5, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11588,7 +10947,6 @@ return {
 				["max"] = 4, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11602,7 +10960,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11616,7 +10973,6 @@ return {
 				["max"] = 29, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11630,7 +10986,6 @@ return {
 				["max"] = 23, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11648,7 +11003,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11666,7 +11020,6 @@ return {
 				["max"] = 4, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11684,7 +11037,6 @@ return {
 				["max"] = 3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11698,7 +11050,6 @@ return {
 				["max"] = 29, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11712,7 +11063,6 @@ return {
 				["max"] = 41, 
 				["min"] = 32, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11726,7 +11076,6 @@ return {
 				["max"] = 35, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11740,7 +11089,6 @@ return {
 				["max"] = 22, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11754,7 +11102,6 @@ return {
 				["max"] = 34, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11768,7 +11115,6 @@ return {
 				["max"] = 28, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11786,7 +11132,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11804,7 +11149,6 @@ return {
 				["max"] = 16, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11822,7 +11166,6 @@ return {
 				["max"] = 13, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11836,7 +11179,6 @@ return {
 				["max"] = 50, 
 				["min"] = 33, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11850,7 +11192,6 @@ return {
 				["max"] = 70, 
 				["min"] = 57, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11864,7 +11205,6 @@ return {
 				["max"] = 61, 
 				["min"] = 45, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11878,7 +11218,6 @@ return {
 				["max"] = 50, 
 				["min"] = 33, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11892,7 +11231,6 @@ return {
 				["max"] = 70, 
 				["min"] = 57, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11906,7 +11244,6 @@ return {
 				["max"] = 61, 
 				["min"] = 45, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11920,7 +11257,6 @@ return {
 				["max"] = 50, 
 				["min"] = 33, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11934,7 +11270,6 @@ return {
 				["max"] = 70, 
 				["min"] = 57, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11948,7 +11283,6 @@ return {
 				["max"] = 61, 
 				["min"] = 45, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11962,7 +11296,6 @@ return {
 				["max"] = 32, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11976,7 +11309,6 @@ return {
 				["max"] = 50, 
 				["min"] = 39, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -11990,7 +11322,6 @@ return {
 				["max"] = 41, 
 				["min"] = 27, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12008,7 +11339,6 @@ return {
 				["max"] = 18, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12026,7 +11356,6 @@ return {
 				["max"] = 30, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12044,7 +11373,6 @@ return {
 				["max"] = 24, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12058,7 +11386,6 @@ return {
 				["max"] = 13, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12072,7 +11399,6 @@ return {
 				["max"] = 21, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12086,7 +11412,6 @@ return {
 				["max"] = 17, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12100,7 +11425,6 @@ return {
 				["max"] = 13, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12114,7 +11438,6 @@ return {
 				["max"] = 21, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12128,7 +11451,6 @@ return {
 				["max"] = 17, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12146,7 +11468,6 @@ return {
 				["max"] = 29, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12164,7 +11485,6 @@ return {
 				["max"] = 53, 
 				["min"] = 44, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12182,7 +11502,6 @@ return {
 				["max"] = 41, 
 				["min"] = 29, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12196,7 +11515,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12210,7 +11528,6 @@ return {
 				["max"] = 23, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12224,7 +11541,6 @@ return {
 				["max"] = 19, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12242,7 +11558,6 @@ return {
 				["max"] = 12, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12260,7 +11575,6 @@ return {
 				["max"] = 18, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12278,7 +11592,6 @@ return {
 				["max"] = 15, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12288,7 +11601,6 @@ return {
 			}, 
 		}, 
 		["2546_DamageRemovedFromManaBeforeLife"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12298,7 +11610,6 @@ return {
 			}, 
 		}, 
 		["2546_DamageRemovedFromManaBeforeLifePinnaclePresence"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12308,7 +11619,6 @@ return {
 			}, 
 		}, 
 		["2546_DamageRemovedFromManaBeforeLifeUniquePresence"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12322,7 +11632,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12336,7 +11645,6 @@ return {
 				["max"] = 29, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12350,7 +11658,6 @@ return {
 				["max"] = 23, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12364,7 +11671,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12378,7 +11684,6 @@ return {
 				["max"] = 8, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12392,7 +11697,6 @@ return {
 				["max"] = 7, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12406,7 +11710,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12420,7 +11723,6 @@ return {
 				["max"] = 8, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12434,7 +11736,6 @@ return {
 				["max"] = 7, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12448,7 +11749,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12462,7 +11762,6 @@ return {
 				["max"] = 29, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12476,7 +11775,6 @@ return {
 				["max"] = 23, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12490,7 +11788,6 @@ return {
 				["max"] = 3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12504,7 +11801,6 @@ return {
 				["max"] = 4, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12518,7 +11814,6 @@ return {
 				["max"] = 3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12536,7 +11831,6 @@ return {
 				["max"] = 20, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12554,7 +11848,6 @@ return {
 				["max"] = 36, 
 				["min"] = 29, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12572,7 +11865,6 @@ return {
 				["max"] = 28, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12586,7 +11878,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12600,7 +11891,6 @@ return {
 				["max"] = 23, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12614,7 +11904,6 @@ return {
 				["max"] = 19, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12628,7 +11917,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12642,7 +11930,6 @@ return {
 				["max"] = 23, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12656,7 +11943,6 @@ return {
 				["max"] = 19, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12670,7 +11956,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12684,7 +11969,6 @@ return {
 				["max"] = 23, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12698,7 +11982,6 @@ return {
 				["max"] = 19, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12712,7 +11995,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12726,7 +12008,6 @@ return {
 				["max"] = 23, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12740,7 +12021,6 @@ return {
 				["max"] = 19, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12754,7 +12034,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12768,7 +12047,6 @@ return {
 				["max"] = 23, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12782,7 +12060,6 @@ return {
 				["max"] = 19, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12796,7 +12073,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12810,7 +12086,6 @@ return {
 				["max"] = 23, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12824,7 +12099,6 @@ return {
 				["max"] = 19, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12838,7 +12112,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12852,7 +12125,6 @@ return {
 				["max"] = 23, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12866,7 +12138,6 @@ return {
 				["max"] = 19, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12880,7 +12151,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12894,7 +12164,6 @@ return {
 				["max"] = 23, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12908,7 +12177,6 @@ return {
 				["max"] = 19, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12922,7 +12190,6 @@ return {
 				["max"] = 32, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12936,7 +12203,6 @@ return {
 				["max"] = 50, 
 				["min"] = 39, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12950,7 +12216,6 @@ return {
 				["max"] = 41, 
 				["min"] = 27, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12964,7 +12229,6 @@ return {
 				["max"] = 24, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12978,7 +12242,6 @@ return {
 				["max"] = 36, 
 				["min"] = 29, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -12992,7 +12255,6 @@ return {
 				["max"] = 30, 
 				["min"] = 21, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13006,7 +12268,6 @@ return {
 				["max"] = 48, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13020,7 +12281,6 @@ return {
 				["max"] = 72, 
 				["min"] = 61, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13034,7 +12294,6 @@ return {
 				["max"] = 60, 
 				["min"] = 46, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13048,7 +12307,6 @@ return {
 				["max"] = 48, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13062,7 +12320,6 @@ return {
 				["max"] = 72, 
 				["min"] = 61, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13076,7 +12333,6 @@ return {
 				["max"] = 60, 
 				["min"] = 46, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13090,7 +12346,6 @@ return {
 				["max"] = 48, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13104,7 +12359,6 @@ return {
 				["max"] = 72, 
 				["min"] = 61, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13118,7 +12372,6 @@ return {
 				["max"] = 60, 
 				["min"] = 46, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13132,7 +12385,6 @@ return {
 				["max"] = 48, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13146,7 +12398,6 @@ return {
 				["max"] = 72, 
 				["min"] = 61, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13160,7 +12411,6 @@ return {
 				["max"] = 60, 
 				["min"] = 46, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13174,7 +12424,6 @@ return {
 				["max"] = 48, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13188,7 +12437,6 @@ return {
 				["max"] = 72, 
 				["min"] = 61, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13202,7 +12450,6 @@ return {
 				["max"] = 60, 
 				["min"] = 46, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13216,7 +12463,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13230,7 +12476,6 @@ return {
 				["max"] = 8, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13244,7 +12489,6 @@ return {
 				["max"] = 7, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13262,7 +12506,6 @@ return {
 				["max"] = 36, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13280,7 +12523,6 @@ return {
 				["max"] = 60, 
 				["min"] = 49, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13298,7 +12540,6 @@ return {
 				["max"] = 48, 
 				["min"] = 34, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13312,7 +12553,6 @@ return {
 				["max"] = 30, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13326,7 +12566,6 @@ return {
 				["max"] = 42, 
 				["min"] = 35, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13340,7 +12579,6 @@ return {
 				["max"] = 36, 
 				["min"] = 27, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13354,7 +12592,6 @@ return {
 				["max"] = 48, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13368,7 +12605,6 @@ return {
 				["max"] = 72, 
 				["min"] = 61, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13382,7 +12618,6 @@ return {
 				["max"] = 60, 
 				["min"] = 46, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13396,7 +12631,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13410,7 +12644,6 @@ return {
 				["max"] = 5, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13424,7 +12657,6 @@ return {
 				["max"] = 10, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13438,7 +12670,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13452,7 +12683,6 @@ return {
 				["max"] = 5, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13466,7 +12696,6 @@ return {
 				["max"] = 10, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13480,7 +12709,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13494,7 +12722,6 @@ return {
 				["max"] = 5, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13508,7 +12735,6 @@ return {
 				["max"] = 10, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13522,7 +12748,6 @@ return {
 				["max"] = 7, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13536,7 +12761,6 @@ return {
 				["max"] = 11, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13550,7 +12774,6 @@ return {
 				["max"] = 9, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13564,7 +12787,6 @@ return {
 				["max"] = 7, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13578,7 +12800,6 @@ return {
 				["max"] = 11, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13592,7 +12813,6 @@ return {
 				["max"] = 9, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13606,7 +12826,6 @@ return {
 				["max"] = 7, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13620,7 +12839,6 @@ return {
 				["max"] = 11, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13634,7 +12852,6 @@ return {
 				["max"] = 9, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13648,7 +12865,6 @@ return {
 				["max"] = 40, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13662,7 +12878,6 @@ return {
 				["max"] = 95, 
 				["min"] = 85, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13676,7 +12891,6 @@ return {
 				["max"] = 70, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13690,7 +12904,6 @@ return {
 				["max"] = 40, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13704,7 +12917,6 @@ return {
 				["max"] = 95, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13718,7 +12930,6 @@ return {
 				["max"] = 70, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13732,7 +12943,6 @@ return {
 				["max"] = 18, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13746,7 +12956,6 @@ return {
 				["max"] = 30, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13760,7 +12969,6 @@ return {
 				["max"] = 24, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13774,7 +12982,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13788,7 +12995,6 @@ return {
 				["max"] = 8, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13802,7 +13008,6 @@ return {
 				["max"] = 7, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13816,7 +13021,6 @@ return {
 				["max"] = 19, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13830,7 +13034,6 @@ return {
 				["max"] = 31, 
 				["min"] = 24, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13844,7 +13047,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13858,7 +13060,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13872,7 +13073,6 @@ return {
 				["max"] = 23, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13886,7 +13086,6 @@ return {
 				["max"] = 19, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13900,7 +13099,6 @@ return {
 				["max"] = 40, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13914,7 +13112,6 @@ return {
 				["max"] = 100, 
 				["min"] = 85, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13928,7 +13125,6 @@ return {
 				["max"] = 70, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13942,7 +13138,6 @@ return {
 				["max"] = 18, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13956,7 +13151,6 @@ return {
 				["max"] = 30, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13970,7 +13164,6 @@ return {
 				["max"] = 24, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13984,7 +13177,6 @@ return {
 				["max"] = 32, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -13998,7 +13190,6 @@ return {
 				["max"] = 50, 
 				["min"] = 39, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14012,7 +13203,6 @@ return {
 				["max"] = 41, 
 				["min"] = 27, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14026,7 +13216,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14040,7 +13229,6 @@ return {
 				["max"] = 4, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14054,7 +13242,6 @@ return {
 				["max"] = 3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14095,7 +13282,6 @@ return {
 				["max"] = 36, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14109,7 +13295,6 @@ return {
 				["max"] = 60, 
 				["min"] = 49, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14123,7 +13308,6 @@ return {
 				["max"] = 48, 
 				["min"] = 34, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14137,7 +13321,6 @@ return {
 				["max"] = 30, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14151,7 +13334,6 @@ return {
 				["max"] = 48, 
 				["min"] = 39, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14165,7 +13347,6 @@ return {
 				["max"] = 39, 
 				["min"] = 27, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14179,7 +13360,6 @@ return {
 				["max"] = 30, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14193,7 +13373,6 @@ return {
 				["max"] = 48, 
 				["min"] = 39, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14207,7 +13386,6 @@ return {
 				["max"] = 39, 
 				["min"] = 27, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14221,7 +13399,6 @@ return {
 				["max"] = 30, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14235,7 +13412,6 @@ return {
 				["max"] = 48, 
 				["min"] = 39, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14249,7 +13425,6 @@ return {
 				["max"] = 39, 
 				["min"] = 27, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14263,7 +13438,6 @@ return {
 				["max"] = 30, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14277,7 +13451,6 @@ return {
 				["max"] = 48, 
 				["min"] = 39, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14291,7 +13464,6 @@ return {
 				["max"] = 39, 
 				["min"] = 27, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14305,7 +13477,6 @@ return {
 				["max"] = 30, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14319,7 +13490,6 @@ return {
 				["max"] = 48, 
 				["min"] = 39, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14333,7 +13503,6 @@ return {
 				["max"] = 39, 
 				["min"] = 27, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14347,7 +13516,6 @@ return {
 				["max"] = 18, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14361,7 +13529,6 @@ return {
 				["max"] = 30, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14375,7 +13542,6 @@ return {
 				["max"] = 24, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14389,7 +13555,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14403,7 +13568,6 @@ return {
 				["max"] = 18, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14417,7 +13581,6 @@ return {
 				["max"] = 30, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14431,7 +13594,6 @@ return {
 				["max"] = 24, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14445,7 +13607,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14459,7 +13620,6 @@ return {
 				["max"] = 23, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14473,7 +13633,6 @@ return {
 				["max"] = 19, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14487,7 +13646,6 @@ return {
 				["max"] = 32, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14501,7 +13659,6 @@ return {
 				["max"] = 50, 
 				["min"] = 39, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14515,7 +13672,6 @@ return {
 				["max"] = 41, 
 				["min"] = 27, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14529,7 +13685,6 @@ return {
 				["max"] = 30, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14543,7 +13698,6 @@ return {
 				["max"] = 42, 
 				["min"] = 35, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14557,7 +13711,6 @@ return {
 				["max"] = 36, 
 				["min"] = 27, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14585,7 +13738,6 @@ return {
 				["max"] = 4, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14599,7 +13751,6 @@ return {
 				["max"] = 5, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14617,7 +13768,6 @@ return {
 				["max"] = 3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14635,7 +13785,6 @@ return {
 				["max"] = 3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14649,7 +13798,6 @@ return {
 				["max"] = 2, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14675,7 +13823,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14689,7 +13836,6 @@ return {
 				["max"] = 18, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14703,7 +13849,6 @@ return {
 				["max"] = 21, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14733,7 +13878,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14751,7 +13895,6 @@ return {
 				["max"] = 3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14765,7 +13908,6 @@ return {
 				["max"] = 15, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14783,7 +13925,6 @@ return {
 				["max"] = 3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14793,7 +13934,6 @@ return {
 			}, 
 		}, 
 		["1020_BlockingBlocksSpellsUber"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14811,7 +13951,6 @@ return {
 				["max"] = 5, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14829,7 +13968,6 @@ return {
 				["max"] = 5, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14847,7 +13985,6 @@ return {
 				["max"] = 5, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14865,7 +14002,6 @@ return {
 				["max"] = 3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14875,7 +14011,6 @@ return {
 			}, 
 		}, 
 		["1023_BlockingBlocksSpells"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14885,7 +14020,6 @@ return {
 			}, 
 		}, 
 		["1023_BlockingBlocksSpellsUber"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14903,7 +14037,6 @@ return {
 				["max"] = 12, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14937,7 +14070,6 @@ return {
 				["max"] = 15, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14951,7 +14083,6 @@ return {
 				["max"] = 6, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -14969,7 +14100,6 @@ return {
 				["max"] = 3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15019,7 +14149,6 @@ return {
 				["max"] = 9, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15113,7 +14242,6 @@ return {
 				["max"] = 13, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15135,7 +14263,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15233,7 +14360,6 @@ return {
 				["max"] = 30, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15251,7 +14377,6 @@ return {
 				["max"] = 35, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15261,7 +14386,6 @@ return {
 			}, 
 		}, 
 		["1044_StrengthAndLocalItemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15283,7 +14407,6 @@ return {
 				["max"] = 16, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15381,7 +14504,6 @@ return {
 				["max"] = 30, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15399,7 +14521,6 @@ return {
 				["max"] = 35, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15409,7 +14530,6 @@ return {
 			}, 
 		}, 
 		["1045_DexterityAndLocalItemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15431,7 +14551,6 @@ return {
 				["max"] = 16, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15529,7 +14648,6 @@ return {
 				["max"] = 55, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15547,7 +14665,6 @@ return {
 				["max"] = 35, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15557,7 +14674,6 @@ return {
 			}, 
 		}, 
 		["1046_IntelligenceAndLocalItemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15579,7 +14695,6 @@ return {
 				["max"] = 16, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15641,7 +14756,6 @@ return {
 				["max"] = 28, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15687,7 +14801,6 @@ return {
 				["max"] = 35, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15709,7 +14822,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15771,7 +14883,6 @@ return {
 				["max"] = 28, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15817,7 +14928,6 @@ return {
 				["max"] = 35, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15839,7 +14949,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15885,7 +14994,6 @@ return {
 				["max"] = 35, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15907,7 +15015,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15969,7 +15076,6 @@ return {
 				["max"] = 28, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -15991,7 +15097,6 @@ return {
 				["max"] = 8, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16013,7 +15118,6 @@ return {
 				["max"] = 12, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16031,7 +15135,6 @@ return {
 				["max"] = 12, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16053,7 +15156,6 @@ return {
 				["max"] = 12, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16071,7 +15173,6 @@ return {
 				["max"] = 12, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16093,7 +15194,6 @@ return {
 				["max"] = 12, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16111,7 +15211,6 @@ return {
 				["max"] = 12, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16129,7 +15228,6 @@ return {
 				["max"] = 23, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16147,7 +15245,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16161,7 +15258,6 @@ return {
 				["max"] = 35, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16179,7 +15275,6 @@ return {
 				["max"] = 16, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16193,7 +15288,6 @@ return {
 				["max"] = 35, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16207,7 +15301,6 @@ return {
 				["max"] = 35, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16225,7 +15318,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16239,7 +15331,6 @@ return {
 				["max"] = 35, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16301,7 +15392,6 @@ return {
 				["max"] = 54, 
 				["min"] = 35, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16315,7 +15405,6 @@ return {
 				["max"] = 35, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16333,7 +15422,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16395,7 +15483,6 @@ return {
 				["max"] = 54, 
 				["min"] = 35, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16409,7 +15496,6 @@ return {
 				["max"] = 35, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16423,7 +15509,6 @@ return {
 				["max"] = 35, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16433,7 +15518,6 @@ return {
 			}, 
 		}, 
 		["1065_AttackDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16451,7 +15535,6 @@ return {
 				["max"] = 14, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16469,7 +15552,6 @@ return {
 				["max"] = 12, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16535,7 +15617,6 @@ return {
 				["max"] = 30, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16581,7 +15662,6 @@ return {
 				["max"] = 94, 
 				["min"] = 60, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16619,7 +15699,6 @@ return {
 				["max"] = 94, 
 				["min"] = 60, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16641,7 +15720,6 @@ return {
 				["max"] = 25, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16703,7 +15781,6 @@ return {
 				["max"] = 79, 
 				["min"] = 36, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16765,7 +15842,6 @@ return {
 				["max"] = 69, 
 				["min"] = 38, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16783,7 +15859,6 @@ return {
 				["max"] = 12, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16817,7 +15892,6 @@ return {
 				["max"] = 164, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16835,7 +15909,6 @@ return {
 				["max"] = 55, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16877,7 +15950,6 @@ return {
 				["max"] = 109, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16887,7 +15959,6 @@ return {
 			}, 
 		}, 
 		["1090_WeaponSpellDamageAddedAsChaos"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16913,7 +15984,6 @@ return {
 				["max"] = 39, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16923,7 +15993,6 @@ return {
 			}, 
 		}, 
 		["1090_WeaponSpellDamageArcaneSurge"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16949,7 +16018,6 @@ return {
 				["max"] = 60, 
 				["min"] = 45, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16975,7 +16043,6 @@ return {
 				["max"] = 60, 
 				["min"] = 45, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16985,7 +16052,6 @@ return {
 			}, 
 		}, 
 		["1090_WeaponSpellDamagePowerChargeOnCrit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -16995,7 +16061,6 @@ return {
 			}, 
 		}, 
 		["1090_WeaponSpellDamageReducedMana"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17005,7 +16070,6 @@ return {
 			}, 
 		}, 
 		["1090_WeaponSpellDamageTriggerSkill"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17023,7 +16087,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17041,7 +16104,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17059,7 +16121,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17073,7 +16134,6 @@ return {
 				["max"] = 22, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17091,7 +16151,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17109,7 +16168,6 @@ return {
 				["max"] = 16, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17127,7 +16185,6 @@ return {
 				["max"] = 30, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17137,7 +16194,6 @@ return {
 			}, 
 		}, 
 		["1097_SpellAddedPhysicalDamageHybrid"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17163,7 +16219,6 @@ return {
 				["max"] = 49, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17209,7 +16264,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17271,7 +16325,6 @@ return {
 				["max"] = 139, 
 				["min"] = 81, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17333,7 +16386,6 @@ return {
 				["max"] = 139, 
 				["min"] = 81, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17395,7 +16447,6 @@ return {
 				["max"] = 139, 
 				["min"] = 81, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17457,7 +16508,6 @@ return {
 				["max"] = 139, 
 				["min"] = 81, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17519,7 +16569,6 @@ return {
 				["max"] = 79, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17549,7 +16598,6 @@ return {
 				["max"] = 69, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17583,7 +16631,6 @@ return {
 				["max"] = 69, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17605,7 +16652,6 @@ return {
 				["max"] = 69, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17627,7 +16673,6 @@ return {
 				["max"] = 69, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17661,7 +16706,6 @@ return {
 				["max"] = 69, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17687,7 +16731,6 @@ return {
 				["max"] = 69, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17713,7 +16756,6 @@ return {
 				["max"] = 69, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17743,7 +16785,6 @@ return {
 				["max"] = 69, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17753,7 +16794,6 @@ return {
 			}, 
 		}, 
 		["1098_LocalIncreasedPhysicalDamagePercentFasterProjectiles"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17763,7 +16803,6 @@ return {
 			}, 
 		}, 
 		["1098_LocalIncreasedPhysicalDamagePercentIronGrip"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17773,7 +16812,6 @@ return {
 			}, 
 		}, 
 		["1098_LocalIncreasedPhysicalDamagePercentPowerChargeOnCrit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17783,7 +16821,6 @@ return {
 			}, 
 		}, 
 		["1098_LocalIncreasedPhysicalDamagePercentProjectileAttackDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17845,7 +16882,6 @@ return {
 				["max"] = 179, 
 				["min"] = 40, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17855,7 +16891,6 @@ return {
 			}, 
 		}, 
 		["1098_LocalPhysicalDamagePercentAddedAsChaos"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17909,7 +16944,6 @@ return {
 				["max"] = 134, 
 				["min"] = 101, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17959,7 +16993,6 @@ return {
 				["max"] = 134, 
 				["min"] = 101, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17969,7 +17002,6 @@ return {
 			}, 
 		}, 
 		["1098_LocalPhysicalDamagePercentEnduranceChargeOnStun"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -17979,7 +17011,6 @@ return {
 			}, 
 		}, 
 		["1098_LocalPhysicalDamagePercentFortify"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18029,7 +17060,6 @@ return {
 				["max"] = 134, 
 				["min"] = 101, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18039,7 +17069,6 @@ return {
 			}, 
 		}, 
 		["1098_LocalPhysicalDamagePercentOnslaught"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18089,7 +17118,6 @@ return {
 				["max"] = 134, 
 				["min"] = 101, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18107,7 +17135,6 @@ return {
 				["max"] = 25, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18125,7 +17152,6 @@ return {
 				["max"] = 16, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18143,7 +17169,6 @@ return {
 				["max"] = 12, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18221,7 +17246,6 @@ return {
 				["max"] = 26, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18235,7 +17259,6 @@ return {
 				["max"] = 26, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18313,7 +17336,6 @@ return {
 				["max"] = 48, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18327,7 +17349,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18405,7 +17426,6 @@ return {
 				["max"] = 38, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18419,7 +17439,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18497,7 +17516,6 @@ return {
 				["max"] = 38, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18575,7 +17593,6 @@ return {
 				["max"] = 48, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18589,7 +17606,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18651,7 +17667,6 @@ return {
 				["max"] = 59, 
 				["min"] = 37, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18665,7 +17680,6 @@ return {
 				["max"] = 9.5, 
 				["min"] = 7.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18683,7 +17697,6 @@ return {
 				["max"] = 6, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18709,7 +17722,6 @@ return {
 				["max"] = 14, 
 				["min"] = 1.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18719,7 +17731,6 @@ return {
 			}, 
 		}, 
 		["1132_SelfPhysicalDamageTaken"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18781,7 +17792,6 @@ return {
 				["max"] = 17, 
 				["min"] = 8.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Physical Damage", 
 			}, 
@@ -18820,7 +17830,6 @@ return {
 				["max"] = 40.5, 
 				["min"] = 1.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Physical Damage", 
 			}, 
@@ -18855,7 +17864,6 @@ return {
 				["max"] = 65.5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Physical Damage", 
 			}, 
@@ -18874,7 +17882,6 @@ return {
 				["max"] = 14, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18924,7 +17931,6 @@ return {
 				["max"] = 37, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18942,7 +17948,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18960,7 +17965,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18978,7 +17982,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -18996,7 +17999,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19014,7 +18016,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19032,7 +18033,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19050,7 +18050,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19112,7 +18111,6 @@ return {
 				["max"] = 109, 
 				["min"] = 36, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19130,7 +18128,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19200,7 +18197,6 @@ return {
 				["max"] = 30, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19218,7 +18214,6 @@ return {
 				["max"] = 30, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19240,7 +18235,6 @@ return {
 				["max"] = 60, 
 				["min"] = 45, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19282,7 +18276,6 @@ return {
 				["max"] = 109, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19292,7 +18285,6 @@ return {
 			}, 
 		}, 
 		["1221_FireDamageWeaponPrefixAndFlat"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19306,7 +18298,6 @@ return {
 				["max"] = 20, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19316,7 +18307,6 @@ return {
 			}, 
 		}, 
 		["1221_LocalFireDamageHybrid"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19326,7 +18316,6 @@ return {
 			}, 
 		}, 
 		["1221_SpellAddedFireDamageHybrid"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19356,7 +18345,6 @@ return {
 				["max"] = 164, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19366,7 +18354,6 @@ return {
 			}, 
 		}, 
 		["1221_TwoHandFireDamageWeaponPrefixAndFlat"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19376,7 +18363,6 @@ return {
 			}, 
 		}, 
 		["1222_SelfFireAndColdDamageTaken"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19386,7 +18372,6 @@ return {
 			}, 
 		}, 
 		["1222_SelfFireAndLightningDamageTaken"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19408,7 +18393,6 @@ return {
 				["max"] = 19, 
 				["min"] = 7.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19430,7 +18414,6 @@ return {
 				["max"] = 19, 
 				["min"] = 7.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19444,7 +18427,6 @@ return {
 				["max"] = 30, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19462,7 +18444,6 @@ return {
 				["max"] = 21.5, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19488,7 +18469,6 @@ return {
 				["max"] = 37.5, 
 				["min"] = 1.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19498,7 +18478,6 @@ return {
 			}, 
 		}, 
 		["1224_FireDamagePhysConvertedToFire"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19508,7 +18487,6 @@ return {
 			}, 
 		}, 
 		["1225_SelfFireDamageTaken"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19562,7 +18540,6 @@ return {
 				["max"] = 165.5, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Fire Damage", 
 			}, 
@@ -19573,7 +18550,6 @@ return {
 			}, 
 		}, 
 		["1226_LocalFireDamageAndPen"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Fire Damage", 
 			}, 
@@ -19584,7 +18560,6 @@ return {
 			}, 
 		}, 
 		["1226_LocalFireDamageHybrid"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Fire Damage", 
 			}, 
@@ -19647,7 +18622,6 @@ return {
 				["max"] = 48, 
 				["min"] = 11.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Fire Damage", 
 			}, 
@@ -19658,7 +18632,6 @@ return {
 			}, 
 		}, 
 		["1226_LocalFireDamageRanged"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Fire Damage", 
 			}, 
@@ -19709,7 +18682,6 @@ return {
 				["max"] = 307.5, 
 				["min"] = 4.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Fire Damage", 
 			}, 
@@ -19720,7 +18692,6 @@ return {
 			}, 
 		}, 
 		["1226_LocalFireDamageTwoHandAndPen"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Fire Damage", 
 			}, 
@@ -19739,7 +18710,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19801,7 +18771,6 @@ return {
 				["max"] = 109, 
 				["min"] = 36, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19819,7 +18788,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19889,7 +18857,6 @@ return {
 				["max"] = 30, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19907,7 +18874,6 @@ return {
 				["max"] = 30, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19929,7 +18895,6 @@ return {
 				["max"] = 60, 
 				["min"] = 45, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19971,7 +18936,6 @@ return {
 				["max"] = 109, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19981,7 +18945,6 @@ return {
 			}, 
 		}, 
 		["1230_ColdDamageWeaponPrefixAndFlat"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -19991,7 +18954,6 @@ return {
 			}, 
 		}, 
 		["1230_LocalColdDamageHybrid"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20001,7 +18963,6 @@ return {
 			}, 
 		}, 
 		["1230_SpellAddedColdDamageHybrid"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20031,7 +18992,6 @@ return {
 				["max"] = 164, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20041,7 +19001,6 @@ return {
 			}, 
 		}, 
 		["1230_TwoHandColdDamageWeaponPrefixAndFlat"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20051,7 +19010,6 @@ return {
 			}, 
 		}, 
 		["1231_SelfColdAndLightningDamageTaken"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20061,7 +19019,6 @@ return {
 			}, 
 		}, 
 		["1231_SelfFireAndColdDamageTaken"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20083,7 +19040,6 @@ return {
 				["max"] = 19, 
 				["min"] = 7.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20105,7 +19061,6 @@ return {
 				["max"] = 19, 
 				["min"] = 7.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20119,7 +19074,6 @@ return {
 				["max"] = 30, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20137,7 +19091,6 @@ return {
 				["max"] = 19.5, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20163,7 +19116,6 @@ return {
 				["max"] = 34, 
 				["min"] = 1.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20173,7 +19125,6 @@ return {
 			}, 
 		}, 
 		["1233_ColdDamagePhysConvertedToCold"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20183,7 +19134,6 @@ return {
 			}, 
 		}, 
 		["1234_SelfColdDamageTaken"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20237,7 +19187,6 @@ return {
 				["max"] = 150, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Cold Damage", 
 			}, 
@@ -20248,7 +19197,6 @@ return {
 			}, 
 		}, 
 		["1235_LocalColdDamageAndPen"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Cold Damage", 
 			}, 
@@ -20259,7 +19207,6 @@ return {
 			}, 
 		}, 
 		["1235_LocalColdDamageHybrid"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Cold Damage", 
 			}, 
@@ -20322,7 +19269,6 @@ return {
 				["max"] = 43.5, 
 				["min"] = 10.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Cold Damage", 
 			}, 
@@ -20333,7 +19279,6 @@ return {
 			}, 
 		}, 
 		["1235_LocalColdDamageRanged"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Cold Damage", 
 			}, 
@@ -20384,7 +19329,6 @@ return {
 				["max"] = 276, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Cold Damage", 
 			}, 
@@ -20395,7 +19339,6 @@ return {
 			}, 
 		}, 
 		["1235_LocalColdDamageTwoHandAndPen"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Cold Damage", 
 			}, 
@@ -20406,7 +19349,6 @@ return {
 			}, 
 		}, 
 		["1237_AddedFireDamageSpellsAndAttacks"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20416,7 +19358,6 @@ return {
 			}, 
 		}, 
 		["1238_AddedColdDamageToSpellsAndAttacks"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20434,7 +19375,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20448,7 +19388,6 @@ return {
 				["max"] = 22, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20510,7 +19449,6 @@ return {
 				["max"] = 109, 
 				["min"] = 36, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20528,7 +19466,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20598,7 +19535,6 @@ return {
 				["max"] = 30, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20616,7 +19552,6 @@ return {
 				["max"] = 30, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20642,7 +19577,6 @@ return {
 				["max"] = 60, 
 				["min"] = 45, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20684,7 +19618,6 @@ return {
 				["max"] = 109, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20694,7 +19627,6 @@ return {
 			}, 
 		}, 
 		["1241_LightningDamageWeaponPrefixAndFlat"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20704,7 +19636,6 @@ return {
 			}, 
 		}, 
 		["1241_LocalLightningDamageHybrid"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20714,7 +19645,6 @@ return {
 			}, 
 		}, 
 		["1241_SpellAddedLightningDamageHybrid"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20744,7 +19674,6 @@ return {
 				["max"] = 164, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20754,7 +19683,6 @@ return {
 			}, 
 		}, 
 		["1241_TwoHandLightningDamageWeaponPrefixAndFlat"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20764,7 +19692,6 @@ return {
 			}, 
 		}, 
 		["1242_SelfColdAndLightningDamageTaken"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20774,7 +19701,6 @@ return {
 			}, 
 		}, 
 		["1242_SelfFireAndLightningDamageTaken"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20796,7 +19722,6 @@ return {
 				["max"] = 19, 
 				["min"] = 7.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20818,7 +19743,6 @@ return {
 				["max"] = 19, 
 				["min"] = 7.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20832,7 +19756,6 @@ return {
 				["max"] = 30.5, 
 				["min"] = 24.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20850,7 +19773,6 @@ return {
 				["max"] = 26, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20876,7 +19798,6 @@ return {
 				["max"] = 42, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20886,7 +19807,6 @@ return {
 			}, 
 		}, 
 		["1244_LightningDamagePhysConvertedToLightning"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20896,7 +19816,6 @@ return {
 			}, 
 		}, 
 		["1245_SelfLightningDamageTaken"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -20950,7 +19869,6 @@ return {
 				["max"] = 182.5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Lightning Damage", 
 			}, 
@@ -20961,7 +19879,6 @@ return {
 			}, 
 		}, 
 		["1246_LocalLightningDamageAndPen"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Lightning Damage", 
 			}, 
@@ -20972,7 +19889,6 @@ return {
 			}, 
 		}, 
 		["1246_LocalLightningDamageHybrid"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Lightning Damage", 
 			}, 
@@ -21035,7 +19951,6 @@ return {
 				["max"] = 53.5, 
 				["min"] = 13.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Lightning Damage", 
 			}, 
@@ -21046,7 +19961,6 @@ return {
 			}, 
 		}, 
 		["1246_LocalLightningDamageRanged"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Lightning Damage", 
 			}, 
@@ -21097,7 +20011,6 @@ return {
 				["max"] = 338, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Lightning Damage", 
 			}, 
@@ -21108,7 +20021,6 @@ return {
 			}, 
 		}, 
 		["1246_LocalLightningDamageTwoHandAndPen"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Lightning Damage", 
 			}, 
@@ -21127,7 +20039,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21189,7 +20100,6 @@ return {
 				["max"] = 99, 
 				["min"] = 35, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21207,7 +20117,6 @@ return {
 				["max"] = 13, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21245,7 +20154,6 @@ return {
 				["max"] = 54, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21259,7 +20167,6 @@ return {
 				["max"] = 20, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21341,7 +20248,6 @@ return {
 				["max"] = 16, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21359,7 +20265,6 @@ return {
 				["max"] = 30, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21369,7 +20274,6 @@ return {
 			}, 
 		}, 
 		["1249_LocalChanceToPoisonOnHitChaosDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21379,7 +20283,6 @@ return {
 			}, 
 		}, 
 		["1249_LocalChaosDamageHybrid"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21389,7 +20292,6 @@ return {
 			}, 
 		}, 
 		["1249_PoisonDurationChaosDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21399,7 +20301,6 @@ return {
 			}, 
 		}, 
 		["1249_SpellAddedChaosDamageHybrid"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21429,7 +20330,6 @@ return {
 				["max"] = 81, 
 				["min"] = 37, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21443,7 +20343,6 @@ return {
 				["max"] = 25, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21461,7 +20360,6 @@ return {
 				["max"] = 16, 
 				["min"] = 8.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21487,7 +20385,6 @@ return {
 				["max"] = 21, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21541,7 +20438,6 @@ return {
 				["max"] = 123.5, 
 				["min"] = 58, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Chaos Damage", 
 			}, 
@@ -21552,7 +20448,6 @@ return {
 			}, 
 		}, 
 		["1253_LocalChaosDamageHybrid"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Chaos Damage", 
 			}, 
@@ -21615,7 +20510,6 @@ return {
 				["max"] = 34.5, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Chaos Damage", 
 			}, 
@@ -21666,7 +20560,6 @@ return {
 				["max"] = 214.5, 
 				["min"] = 105, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Chaos Damage", 
 			}, 
@@ -21677,7 +20570,6 @@ return {
 			}, 
 		}, 
 		["1253_LocalIncreasedAttackSpeedAddedChaos"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Chaos Damage", 
 			}, 
@@ -21688,7 +20580,6 @@ return {
 			}, 
 		}, 
 		["1253_PoisonDamageAddedChaosToAttacks"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21726,7 +20617,6 @@ return {
 				["max"] = 60, 
 				["min"] = 34, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21736,7 +20626,6 @@ return {
 			}, 
 		}, 
 		["1266_SpellAddedPhysicalDamageHybrid"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21754,7 +20643,6 @@ return {
 				["max"] = 19, 
 				["min"] = 4.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21764,7 +20652,6 @@ return {
 			}, 
 		}, 
 		["1267_FireDamageWeaponPrefixAndFlat"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21802,7 +20689,6 @@ return {
 				["max"] = 90.5, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21812,7 +20698,6 @@ return {
 			}, 
 		}, 
 		["1267_SpellAddedFireDamageHybrid"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21846,7 +20731,6 @@ return {
 				["max"] = 38.5, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21880,7 +20764,6 @@ return {
 				["max"] = 121.5, 
 				["min"] = 2.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21894,7 +20777,6 @@ return {
 				["max"] = 61, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21912,7 +20794,6 @@ return {
 				["max"] = 27.5, 
 				["min"] = 7.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21922,7 +20803,6 @@ return {
 			}, 
 		}, 
 		["1267_TwoHandFireDamageWeaponPrefixAndFlat"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21932,7 +20812,6 @@ return {
 			}, 
 		}, 
 		["1268_ColdDamageWeaponPrefixAndFlat"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21970,7 +20849,6 @@ return {
 				["max"] = 73.5, 
 				["min"] = 1.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -21980,7 +20858,6 @@ return {
 			}, 
 		}, 
 		["1268_SpellAddedColdDamageHybrid"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22014,7 +20891,6 @@ return {
 				["max"] = 31.5, 
 				["min"] = 7.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22048,7 +20924,6 @@ return {
 				["max"] = 110.5, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22062,7 +20937,6 @@ return {
 				["max"] = 50, 
 				["min"] = 20.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22080,7 +20954,6 @@ return {
 				["max"] = 27.5, 
 				["min"] = 7.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22090,7 +20963,6 @@ return {
 			}, 
 		}, 
 		["1268_TwoHandColdDamageWeaponPrefixAndFlat"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22100,7 +20972,6 @@ return {
 			}, 
 		}, 
 		["1269_LightningDamageWeaponPrefixAndFlat"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22138,7 +21009,6 @@ return {
 				["max"] = 96.5, 
 				["min"] = 2.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22148,7 +21018,6 @@ return {
 			}, 
 		}, 
 		["1269_SpellAddedLightningDamageHybrid"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22182,7 +21051,6 @@ return {
 				["max"] = 41.5, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22216,7 +21084,6 @@ return {
 				["max"] = 145, 
 				["min"] = 3.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22230,7 +21097,6 @@ return {
 				["max"] = 64.5, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22248,7 +21114,6 @@ return {
 				["max"] = 25.5, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22258,7 +21123,6 @@ return {
 			}, 
 		}, 
 		["1269_TwoHandLightningDamageWeaponPrefixAndFlat"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22268,7 +21132,6 @@ return {
 			}, 
 		}, 
 		["1270_IncreasedCastSpeedAddedChaos"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22278,7 +21141,6 @@ return {
 			}, 
 		}, 
 		["1270_PoisonDamageAddedChaosToSpells"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22316,7 +21178,6 @@ return {
 				["max"] = 60, 
 				["min"] = 34, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22326,7 +21187,6 @@ return {
 			}, 
 		}, 
 		["1270_SpellAddedChaosDamageHybrid"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22344,7 +21204,6 @@ return {
 				["max"] = 19, 
 				["min"] = 4.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22354,7 +21213,6 @@ return {
 			}, 
 		}, 
 		["1272_AddedLightningDamageSpellsAndAttacks"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22384,7 +21242,6 @@ return {
 				["max"] = 16, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22406,7 +21263,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22420,7 +21276,6 @@ return {
 				["max"] = 14, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22454,7 +21309,6 @@ return {
 				["max"] = 21, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22488,7 +21342,6 @@ return {
 				["max"] = 21, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22550,7 +21403,6 @@ return {
 				["max"] = 22, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Attack Speed", 
 			}, 
@@ -22561,7 +21413,6 @@ return {
 			}, 
 		}, 
 		["1276_LocalAttackSpeedAndLocalItemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Attack Speed", 
 			}, 
@@ -22624,7 +21475,6 @@ return {
 				["max"] = 22, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Attack Speed", 
 			}, 
@@ -22687,7 +21537,6 @@ return {
 				["max"] = 27, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Attack Speed", 
 			}, 
@@ -22698,7 +21547,6 @@ return {
 			}, 
 		}, 
 		["1276_LocalIncreasedAttackSpeedAddedChaos"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Attack Speed", 
 			}, 
@@ -22753,7 +21601,6 @@ return {
 				["max"] = 12, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Attack Speed", 
 			}, 
@@ -22804,7 +21651,6 @@ return {
 				["max"] = 21, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Attack Speed", 
 			}, 
@@ -22823,7 +21669,6 @@ return {
 				["max"] = 12, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Attack Speed", 
 			}, 
@@ -22858,7 +21703,6 @@ return {
 				["max"] = 4, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Attack Speed", 
 			}, 
@@ -22877,7 +21721,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22895,7 +21738,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22913,7 +21755,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22931,7 +21772,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22949,7 +21789,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22967,7 +21806,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -22985,7 +21823,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23003,7 +21840,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23021,7 +21857,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23039,7 +21874,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23057,7 +21891,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23075,7 +21908,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23117,7 +21949,6 @@ return {
 				["max"] = 480, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23127,7 +21958,6 @@ return {
 			}, 
 		}, 
 		["1295_IncreasedAccuracyForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23137,7 +21967,6 @@ return {
 			}, 
 		}, 
 		["1295_LightRadiusAndAccuracy"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23155,7 +21984,6 @@ return {
 				["max"] = 10, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23177,7 +22005,6 @@ return {
 				["max"] = 30, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23195,7 +22022,6 @@ return {
 				["max"] = 14, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23209,7 +22035,6 @@ return {
 				["max"] = 20, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23227,7 +22052,6 @@ return {
 				["max"] = 20, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23289,7 +22113,6 @@ return {
 				["max"] = 20, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23448,7 +22271,6 @@ return {
 				["max"] = 22, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23526,7 +22348,6 @@ return {
 				["max"] = 32, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23536,7 +22357,6 @@ return {
 			}, 
 		}, 
 		["1308_IncreasedCastSpeedAddedChaos"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23562,7 +22382,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23576,7 +22395,6 @@ return {
 				["max"] = 28, 
 				["min"] = 24, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23598,7 +22416,6 @@ return {
 				["max"] = 4, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23624,7 +22441,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23638,7 +22454,6 @@ return {
 				["max"] = 14, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23656,7 +22471,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23674,7 +22488,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23692,7 +22505,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23710,7 +22522,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23728,7 +22539,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23754,7 +22564,6 @@ return {
 				["max"] = 82, 
 				["min"] = 60, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23772,7 +22581,6 @@ return {
 				["max"] = 82, 
 				["min"] = 60, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23790,7 +22598,6 @@ return {
 				["max"] = 14, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23856,7 +22663,6 @@ return {
 				["max"] = 119, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23874,7 +22680,6 @@ return {
 				["max"] = 10, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23888,7 +22693,6 @@ return {
 				["max"] = 22, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23910,7 +22714,6 @@ return {
 				["max"] = 12, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23928,7 +22731,6 @@ return {
 				["max"] = 22, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23946,7 +22748,6 @@ return {
 				["max"] = 22, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23960,7 +22761,6 @@ return {
 				["max"] = 20, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -23986,7 +22786,6 @@ return {
 				["max"] = 26, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24040,7 +22839,6 @@ return {
 				["max"] = 29, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24074,7 +22872,6 @@ return {
 				["max"] = 29, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24108,7 +22905,6 @@ return {
 				["max"] = 29, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24134,7 +22930,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24196,7 +22991,6 @@ return {
 				["max"] = 38, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24206,7 +23000,6 @@ return {
 			}, 
 		}, 
 		["1326_LocalCriticalStrikeChanceAndLocalItemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24268,7 +23061,6 @@ return {
 				["max"] = 32, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24290,7 +23082,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24300,7 +23091,6 @@ return {
 			}, 
 		}, 
 		["1327_CritChanceWithBowForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24314,7 +23104,6 @@ return {
 				["max"] = 44, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24324,7 +23113,6 @@ return {
 			}, 
 		}, 
 		["1336_TrapCritChanceForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24342,7 +23130,6 @@ return {
 				["max"] = 18, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24360,7 +23147,6 @@ return {
 				["max"] = 18, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24378,7 +23164,6 @@ return {
 				["max"] = 18, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24396,7 +23181,6 @@ return {
 				["max"] = 14, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24414,7 +23198,6 @@ return {
 				["max"] = 18, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24432,7 +23215,6 @@ return {
 				["max"] = 18, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24450,7 +23232,6 @@ return {
 				["max"] = 18, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24468,7 +23249,6 @@ return {
 				["max"] = 18, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24486,7 +23266,6 @@ return {
 				["max"] = 14, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24508,7 +23287,6 @@ return {
 				["max"] = 12, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24526,7 +23304,6 @@ return {
 				["max"] = 29, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24544,7 +23321,6 @@ return {
 				["max"] = 25, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24622,7 +23398,6 @@ return {
 				["max"] = 38, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24676,7 +23451,6 @@ return {
 				["max"] = 29, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24698,7 +23472,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24716,7 +23489,6 @@ return {
 				["max"] = 15, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24726,7 +23498,6 @@ return {
 			}, 
 		}, 
 		["1357_CritMultiplierWithBowForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24740,7 +23511,6 @@ return {
 				["max"] = 38, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24758,7 +23528,6 @@ return {
 				["max"] = 18, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24776,7 +23545,6 @@ return {
 				["max"] = 15, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24794,7 +23562,6 @@ return {
 				["max"] = 18, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24812,7 +23579,6 @@ return {
 				["max"] = 18, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24830,7 +23596,6 @@ return {
 				["max"] = 18, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24848,7 +23613,6 @@ return {
 				["max"] = 15, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24858,7 +23622,6 @@ return {
 			}, 
 		}, 
 		["1373_ReducedCriticalStrikeDamageTaken"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24872,7 +23635,6 @@ return {
 				["max"] = 60, 
 				["min"] = 21, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24886,7 +23648,6 @@ return {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24916,7 +23677,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24942,7 +23702,6 @@ return {
 				["max"] = 30, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -24992,7 +23751,6 @@ return {
 				["max"] = 15, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25011,7 +23769,6 @@ return {
 			}, 
 		}, 
 		["1389_LocalBaseWardAndLife"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25021,7 +23778,6 @@ return {
 			}, 
 		}, 
 		["1389_LocalWard"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25099,7 +23855,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25117,7 +23872,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25127,7 +23881,6 @@ return {
 			}, 
 		}, 
 		["1391_LocalWardAndStunRecoveryPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25137,7 +23890,6 @@ return {
 			}, 
 		}, 
 		["1391_LocalWardPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25147,7 +23899,6 @@ return {
 			}, 
 		}, 
 		["1392_WardDelayRecovery"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25225,7 +23976,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25243,7 +23993,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25257,7 +24006,6 @@ return {
 				["max"] = 400, 
 				["min"] = 105, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25283,7 +24031,6 @@ return {
 				["max"] = 300, 
 				["min"] = 80, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25309,7 +24056,6 @@ return {
 				["max"] = 375, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to Armour", 
 			}, 
@@ -25336,7 +24082,6 @@ return {
 				["max"] = 375, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to Armour", 
 			}, 
@@ -25363,7 +24108,6 @@ return {
 				["max"] = 144, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to Armour", 
 			}, 
@@ -25374,7 +24118,6 @@ return {
 			}, 
 		}, 
 		["1401_LocalBaseArmourEnergyShieldAndLife"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to Armour", 
 			}, 
@@ -25385,7 +24128,6 @@ return {
 			}, 
 		}, 
 		["1401_LocalBaseArmourEvasionRatingAndLife"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to Armour", 
 			}, 
@@ -25416,7 +24158,6 @@ return {
 				["max"] = 375, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to Armour", 
 			}, 
@@ -25427,7 +24168,6 @@ return {
 			}, 
 		}, 
 		["1402_ArmourEnergyShieldForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25437,7 +24177,6 @@ return {
 			}, 
 		}, 
 		["1402_ArmourEvasionForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25459,7 +24198,6 @@ return {
 				["max"] = 15, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25477,7 +24215,6 @@ return {
 				["max"] = 18, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25491,7 +24228,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25521,7 +24257,6 @@ return {
 				["max"] = 21, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Armour", 
 			}, 
@@ -25548,7 +24283,6 @@ return {
 				["max"] = 42, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Armour", 
 			}, 
@@ -25579,7 +24313,6 @@ return {
 				["max"] = 110, 
 				["min"] = 26, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Armour", 
 			}, 
@@ -25590,7 +24323,6 @@ return {
 			}, 
 		}, 
 		["1403_LocalPhysicalDamageReductionRatingPercentAndBlockChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Armour", 
 			}, 
@@ -25601,7 +24333,6 @@ return {
 			}, 
 		}, 
 		["1403_LocalPhysicalDamageReductionRatingPercentSuffix"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Armour", 
 			}, 
@@ -25628,7 +24359,6 @@ return {
 				["max"] = 180, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25646,7 +24376,6 @@ return {
 				["max"] = 400, 
 				["min"] = 105, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25672,7 +24401,6 @@ return {
 				["max"] = 375, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to Evasion Rating", 
 			}, 
@@ -25683,7 +24411,6 @@ return {
 			}, 
 		}, 
 		["1409_LocalBaseArmourEvasionRatingAndLife"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to Evasion Rating", 
 			}, 
@@ -25710,7 +24437,6 @@ return {
 				["max"] = 375, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to Evasion Rating", 
 			}, 
@@ -25737,7 +24463,6 @@ return {
 				["max"] = 120, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to Evasion Rating", 
 			}, 
@@ -25748,7 +24473,6 @@ return {
 			}, 
 		}, 
 		["1409_LocalBaseEvasionRatingEnergyShieldAndLife"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to Evasion Rating", 
 			}, 
@@ -25779,7 +24503,6 @@ return {
 				["max"] = 375, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to Evasion Rating", 
 			}, 
@@ -25858,7 +24581,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25876,7 +24598,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25886,7 +24607,6 @@ return {
 			}, 
 		}, 
 		["1410_ArmourEvasionForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25896,7 +24616,6 @@ return {
 			}, 
 		}, 
 		["1410_EvasionEnergyShieldForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25918,7 +24637,6 @@ return {
 				["max"] = 15, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25936,7 +24654,6 @@ return {
 				["max"] = 18, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -25962,7 +24679,6 @@ return {
 				["max"] = 42, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Evasion Rating", 
 			}, 
@@ -25993,7 +24709,6 @@ return {
 				["max"] = 110, 
 				["min"] = 26, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Evasion Rating", 
 			}, 
@@ -26004,7 +24719,6 @@ return {
 			}, 
 		}, 
 		["1411_LocalEvasionRatingIncreasePercentSuffix"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Evasion Rating", 
 			}, 
@@ -26035,7 +24749,6 @@ return {
 				["max"] = 21, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Evasion Rating", 
 			}, 
@@ -26066,7 +24779,6 @@ return {
 				["max"] = 110, 
 				["min"] = 26, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Armour and Energy Shield", 
 			}, 
@@ -26093,7 +24805,6 @@ return {
 				["max"] = 42, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Armour and Energy Shield", 
 			}, 
@@ -26104,7 +24815,6 @@ return {
 			}, 
 		}, 
 		["1413_LocalArmourAndEnergyShieldSuffix"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Armour and Energy Shield", 
 			}, 
@@ -26135,7 +24845,6 @@ return {
 				["max"] = 21, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Armour and Energy Shield", 
 			}, 
@@ -26166,7 +24875,6 @@ return {
 				["max"] = 110, 
 				["min"] = 26, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Armour and Evasion", 
 			}, 
@@ -26193,7 +24901,6 @@ return {
 				["max"] = 42, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Armour and Evasion", 
 			}, 
@@ -26204,7 +24911,6 @@ return {
 			}, 
 		}, 
 		["1414_LocalArmourAndEvasionSuffix"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Armour and Evasion", 
 			}, 
@@ -26235,7 +24941,6 @@ return {
 				["max"] = 21, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Armour and Evasion", 
 			}, 
@@ -26266,7 +24971,6 @@ return {
 				["max"] = 110, 
 				["min"] = 26, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Evasion and Energy Shield", 
 			}, 
@@ -26277,7 +24981,6 @@ return {
 			}, 
 		}, 
 		["1415_LocalEvasionAndEnergyShieldAndStunRecovery"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Evasion and Energy Shield", 
 			}, 
@@ -26288,7 +24991,6 @@ return {
 			}, 
 		}, 
 		["1415_LocalEvasionAndEnergyShieldSuffix"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Evasion and Energy Shield", 
 			}, 
@@ -26319,7 +25021,6 @@ return {
 				["max"] = 21, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Evasion and Energy Shield", 
 			}, 
@@ -26346,7 +25047,6 @@ return {
 				["max"] = 100, 
 				["min"] = 27, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Armour, Evasion and Energy Shield", 
 			}, 
@@ -26373,7 +25073,6 @@ return {
 				["max"] = 42, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Armour, Evasion and Energy Shield", 
 			}, 
@@ -26384,7 +25083,6 @@ return {
 			}, 
 		}, 
 		["1416_LocalArmourAndEvasionAndEnergyShieldSuffix"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Armour, Evasion and Energy Shield", 
 			}, 
@@ -26415,7 +25113,6 @@ return {
 				["max"] = 21, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Armour, Evasion and Energy Shield", 
 			}, 
@@ -26430,7 +25127,6 @@ return {
 				["max"] = 35, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -26460,7 +25156,6 @@ return {
 				["max"] = 47, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -26470,7 +25165,6 @@ return {
 			}, 
 		}, 
 		["1418_EnergyShieldAndDegenGracePeriod"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -26480,7 +25174,6 @@ return {
 			}, 
 		}, 
 		["1418_EnergyShieldAndPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -26490,7 +25183,6 @@ return {
 			}, 
 		}, 
 		["1418_EnergyShieldAndRegen"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -26508,7 +25200,6 @@ return {
 				["max"] = 35, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -26518,7 +25209,6 @@ return {
 			}, 
 		}, 
 		["1418_IncreasedEnergyShieldForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -26544,7 +25234,6 @@ return {
 				["max"] = 80, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to maximum Energy Shield", 
 			}, 
@@ -26555,7 +25244,6 @@ return {
 			}, 
 		}, 
 		["1419_LocalBaseArmourEnergyShieldAndLife"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to maximum Energy Shield", 
 			}, 
@@ -26582,7 +25270,6 @@ return {
 				["max"] = 30, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to maximum Energy Shield", 
 			}, 
@@ -26609,7 +25296,6 @@ return {
 				["max"] = 30, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to maximum Energy Shield", 
 			}, 
@@ -26636,7 +25322,6 @@ return {
 				["max"] = 80, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to maximum Energy Shield", 
 			}, 
@@ -26647,7 +25332,6 @@ return {
 			}, 
 		}, 
 		["1419_LocalBaseEvasionRatingEnergyShieldAndLife"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to maximum Energy Shield", 
 			}, 
@@ -26678,7 +25362,6 @@ return {
 				["max"] = 85, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to maximum Energy Shield", 
 			}, 
@@ -26741,7 +25424,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -26767,7 +25449,6 @@ return {
 				["max"] = 42, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Energy Shield", 
 			}, 
@@ -26798,7 +25479,6 @@ return {
 				["max"] = 110, 
 				["min"] = 26, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Energy Shield", 
 			}, 
@@ -26809,7 +25489,6 @@ return {
 			}, 
 		}, 
 		["1420_LocalEnergyShieldPercentSuffix"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Energy Shield", 
 			}, 
@@ -26840,7 +25519,6 @@ return {
 				["max"] = 21, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Energy Shield", 
 			}, 
@@ -26851,7 +25529,6 @@ return {
 			}, 
 		}, 
 		["1421_ArmourEnergyShieldForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -26861,7 +25538,6 @@ return {
 			}, 
 		}, 
 		["1421_EnergyShieldAndManaForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -26871,7 +25547,6 @@ return {
 			}, 
 		}, 
 		["1421_EnergyShieldAndPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -26889,7 +25564,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -26899,7 +25573,6 @@ return {
 			}, 
 		}, 
 		["1421_EvasionEnergyShieldForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -26921,7 +25594,6 @@ return {
 				["max"] = 15, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -26931,7 +25603,6 @@ return {
 			}, 
 		}, 
 		["1421_LifeAndEnergyShieldForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -26961,7 +25632,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -26979,7 +25649,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -26997,7 +25666,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27023,7 +25691,6 @@ return {
 				["max"] = 38, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27037,7 +25704,6 @@ return {
 				["max"] = 25, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27055,7 +25721,6 @@ return {
 				["max"] = 15, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27069,7 +25734,6 @@ return {
 				["max"] = 15, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27087,7 +25751,6 @@ return {
 				["max"] = 40, 
 				["min"] = 21, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27097,7 +25760,6 @@ return {
 			}, 
 		}, 
 		["1429_BaseLifeAndMana"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27107,7 +25769,6 @@ return {
 			}, 
 		}, 
 		["1429_BaseLifeAndManaDegenGracePeriod"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27145,7 +25806,6 @@ return {
 				["max"] = 60, 
 				["min"] = 28, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27191,7 +25851,6 @@ return {
 				["max"] = 159, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27201,7 +25860,6 @@ return {
 			}, 
 		}, 
 		["1429_IncreasedLifeAndPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27211,7 +25869,6 @@ return {
 			}, 
 		}, 
 		["1429_IncreasedLifeForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27221,7 +25878,6 @@ return {
 			}, 
 		}, 
 		["1429_LifeAndManaForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27231,7 +25887,6 @@ return {
 			}, 
 		}, 
 		["1429_LifeAndPercentLife"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27257,7 +25912,6 @@ return {
 				["max"] = 38, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27267,7 +25921,6 @@ return {
 			}, 
 		}, 
 		["1429_LocalBaseArmourEnergyShieldAndLife"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27277,7 +25930,6 @@ return {
 			}, 
 		}, 
 		["1429_LocalBaseArmourEvasionRatingAndLife"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27303,7 +25955,6 @@ return {
 				["max"] = 38, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27329,7 +25980,6 @@ return {
 				["max"] = 38, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27339,7 +25989,6 @@ return {
 			}, 
 		}, 
 		["1429_LocalBaseEvasionRatingEnergyShieldAndLife"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27349,7 +25998,6 @@ return {
 			}, 
 		}, 
 		["1429_LocalBaseWardAndLife"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27379,7 +26027,6 @@ return {
 				["max"] = 16, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27409,7 +26056,6 @@ return {
 				["max"] = 16, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27439,7 +26085,6 @@ return {
 				["max"] = 16, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27469,7 +26114,6 @@ return {
 				["max"] = 16, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27499,7 +26143,6 @@ return {
 				["max"] = 16, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27529,7 +26172,6 @@ return {
 				["max"] = 16, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27559,7 +26201,6 @@ return {
 				["max"] = 16, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27569,7 +26210,6 @@ return {
 			}, 
 		}, 
 		["1431_IncreasedLifeAndPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27579,7 +26219,6 @@ return {
 			}, 
 		}, 
 		["1431_LifeAndEnergyShieldForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27589,7 +26228,6 @@ return {
 			}, 
 		}, 
 		["1431_LifeAndPercentLife"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27611,7 +26249,6 @@ return {
 				["max"] = 10, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27629,7 +26266,6 @@ return {
 				["max"] = 7, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27643,7 +26279,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27653,7 +26288,6 @@ return {
 			}, 
 		}, 
 		["1431_PercentageLifeAndManaForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27691,7 +26325,6 @@ return {
 				["max"] = 33.3, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27725,7 +26358,6 @@ return {
 				["max"] = 152, 
 				["min"] = 128.1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27739,7 +26371,6 @@ return {
 				["max"] = 20, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27749,7 +26380,6 @@ return {
 			}, 
 		}, 
 		["1434_LifeRegenerationAndPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27759,7 +26389,6 @@ return {
 			}, 
 		}, 
 		["1435_BaseManaAndLifeDegenGracePeriod"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27769,7 +26398,6 @@ return {
 			}, 
 		}, 
 		["1435_LifeDegenerationAndPercentGracePeriod"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27779,7 +26407,6 @@ return {
 			}, 
 		}, 
 		["1435_LifeDegenerationGracePeriod"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27805,7 +26432,6 @@ return {
 				["max"] = 21, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27823,7 +26449,6 @@ return {
 				["max"] = 15, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27837,7 +26462,6 @@ return {
 				["max"] = 15, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27855,7 +26479,6 @@ return {
 				["max"] = 40, 
 				["min"] = 21, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27865,7 +26488,6 @@ return {
 			}, 
 		}, 
 		["1439_BaseLifeAndMana"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27875,7 +26497,6 @@ return {
 			}, 
 		}, 
 		["1439_BaseManaAndLifeDegenGracePeriod"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -27913,7 +26534,6 @@ return {
 				["max"] = 60, 
 				["min"] = 28, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28011,7 +26631,6 @@ return {
 				["max"] = 159, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28021,7 +26640,6 @@ return {
 			}, 
 		}, 
 		["1439_IncreasedManaAndBaseCost"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28031,7 +26649,6 @@ return {
 			}, 
 		}, 
 		["1439_IncreasedManaAndCost"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28041,7 +26658,6 @@ return {
 			}, 
 		}, 
 		["1439_IncreasedManaAndCostNew"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28051,7 +26667,6 @@ return {
 			}, 
 		}, 
 		["1439_IncreasedManaAndDegenGracePeriod"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28061,7 +26676,6 @@ return {
 			}, 
 		}, 
 		["1439_IncreasedManaAndOnHit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28071,7 +26685,6 @@ return {
 			}, 
 		}, 
 		["1439_IncreasedManaAndPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28089,7 +26702,6 @@ return {
 				["max"] = 55, 
 				["min"] = 26, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28099,7 +26711,6 @@ return {
 			}, 
 		}, 
 		["1439_IncreasedManaAndReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28109,7 +26720,6 @@ return {
 			}, 
 		}, 
 		["1439_IncreasedManaForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28119,7 +26729,6 @@ return {
 			}, 
 		}, 
 		["1439_LifeAndManaForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28145,7 +26754,6 @@ return {
 				["max"] = 25, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28163,7 +26771,6 @@ return {
 				["max"] = 55, 
 				["min"] = 26, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28181,7 +26788,6 @@ return {
 				["max"] = 55, 
 				["min"] = 26, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28199,7 +26805,6 @@ return {
 				["max"] = 45, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28217,7 +26822,6 @@ return {
 				["max"] = 64, 
 				["min"] = 26, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28243,7 +26847,6 @@ return {
 				["max"] = 45, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28253,7 +26856,6 @@ return {
 			}, 
 		}, 
 		["1440_EnergyShieldAndManaForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28263,7 +26865,6 @@ return {
 			}, 
 		}, 
 		["1440_IncreasedManaAndPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28285,7 +26886,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28299,7 +26899,6 @@ return {
 				["max"] = 15, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28313,7 +26912,6 @@ return {
 				["max"] = 18, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28331,7 +26929,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28345,7 +26942,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28355,7 +26951,6 @@ return {
 			}, 
 		}, 
 		["1440_PercentageLifeAndManaForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28393,7 +26988,6 @@ return {
 				["max"] = 0.4, 
 				["min"] = 0.3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28415,7 +27009,6 @@ return {
 				["max"] = 8, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28429,7 +27022,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28467,7 +27059,6 @@ return {
 				["max"] = 5.3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28485,7 +27076,6 @@ return {
 				["max"] = 5.3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28499,7 +27089,6 @@ return {
 				["max"] = 3, 
 				["min"] = 1.8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28509,7 +27098,6 @@ return {
 			}, 
 		}, 
 		["1443_BaseLifeAndManaDegenGracePeriod"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28519,7 +27107,6 @@ return {
 			}, 
 		}, 
 		["1443_IncreasedManaAndDegenGracePeriod"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28529,7 +27116,6 @@ return {
 			}, 
 		}, 
 		["1443_ManaDegenerationGracePeriod"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28547,7 +27133,6 @@ return {
 				["max"] = 15, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28625,7 +27210,6 @@ return {
 				["max"] = 69, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28639,7 +27223,6 @@ return {
 				["max"] = 70, 
 				["min"] = 56, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28701,7 +27284,6 @@ return {
 				["max"] = 20, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28723,7 +27305,6 @@ return {
 				["max"] = 15, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28737,7 +27318,6 @@ return {
 				["max"] = 15, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28747,7 +27327,6 @@ return {
 			}, 
 		}, 
 		["1452_ItemFoundQuantityIncrease"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28777,7 +27356,6 @@ return {
 				["max"] = 26, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28807,7 +27385,6 @@ return {
 				["max"] = 28, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28817,7 +27394,6 @@ return {
 			}, 
 		}, 
 		["1456_ItemRarityForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28831,7 +27407,6 @@ return {
 				["max"] = 3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28865,7 +27440,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28903,7 +27477,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28933,7 +27506,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28947,7 +27519,6 @@ return {
 				["max"] = 2, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -28985,7 +27556,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29023,7 +27593,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29061,7 +27630,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29095,7 +27663,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29121,7 +27688,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29135,7 +27701,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29165,7 +27730,6 @@ return {
 				["max"] = 18, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29187,7 +27751,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29205,7 +27768,6 @@ return {
 				["max"] = 22, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29223,7 +27785,6 @@ return {
 				["max"] = 9, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29253,7 +27814,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29267,7 +27827,6 @@ return {
 				["max"] = 2, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29285,7 +27844,6 @@ return {
 				["max"] = 3, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29303,7 +27861,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29321,7 +27878,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29419,7 +27975,6 @@ return {
 				["max"] = 48, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29429,7 +27984,6 @@ return {
 			}, 
 		}, 
 		["1485_FireResistanceAilments"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29439,7 +27993,6 @@ return {
 			}, 
 		}, 
 		["1485_FireResistanceEnemyLeech"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29461,7 +28014,6 @@ return {
 				["max"] = 15, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29471,7 +28023,6 @@ return {
 			}, 
 		}, 
 		["1485_FireResistanceLeech"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29481,7 +28032,6 @@ return {
 			}, 
 		}, 
 		["1485_FireResistancePhysTakenAsFire"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29491,7 +28041,6 @@ return {
 			}, 
 		}, 
 		["1485_FireResistancePrefix"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29509,7 +28058,6 @@ return {
 				["max"] = 3, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29527,7 +28075,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29557,7 +28104,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29571,7 +28117,6 @@ return {
 				["max"] = 2, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29589,7 +28134,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29687,7 +28231,6 @@ return {
 				["max"] = 48, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29697,7 +28240,6 @@ return {
 			}, 
 		}, 
 		["1491_ColdResistanceAilments"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29707,7 +28249,6 @@ return {
 			}, 
 		}, 
 		["1491_ColdResistanceEnemyLeech"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29729,7 +28270,6 @@ return {
 				["max"] = 15, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29739,7 +28279,6 @@ return {
 			}, 
 		}, 
 		["1491_ColdResistanceLeech"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29749,7 +28288,6 @@ return {
 			}, 
 		}, 
 		["1491_ColdResistancePhysTakenAsCold"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29759,7 +28297,6 @@ return {
 			}, 
 		}, 
 		["1491_ColdResistancePrefix"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29777,7 +28314,6 @@ return {
 				["max"] = 3, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29795,7 +28331,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29813,7 +28348,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29911,7 +28445,6 @@ return {
 				["max"] = 48, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29921,7 +28454,6 @@ return {
 			}, 
 		}, 
 		["1496_LightningResistanceAilments"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29931,7 +28463,6 @@ return {
 			}, 
 		}, 
 		["1496_LightningResistanceEnemyLeech"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29953,7 +28484,6 @@ return {
 				["max"] = 15, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29963,7 +28493,6 @@ return {
 			}, 
 		}, 
 		["1496_LightningResistanceLeech"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29973,7 +28502,6 @@ return {
 			}, 
 		}, 
 		["1496_LightningResistancePhysTakenAsLightning"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29983,7 +28511,6 @@ return {
 			}, 
 		}, 
 		["1496_LightningResistancePrefix"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -29997,7 +28524,6 @@ return {
 				["max"] = 3, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30011,7 +28537,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30041,7 +28566,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30055,7 +28579,6 @@ return {
 				["max"] = 2, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30250,7 +28773,6 @@ return {
 				["max"] = 35, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30260,7 +28782,6 @@ return {
 			}, 
 		}, 
 		["1500_ChaosResistanceDamageOverTime"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30282,7 +28803,6 @@ return {
 				["max"] = 13, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30292,7 +28812,6 @@ return {
 			}, 
 		}, 
 		["1500_ChaosResistancePrefix"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30306,7 +28825,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30324,7 +28842,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30346,7 +28863,6 @@ return {
 				["max"] = 60, 
 				["min"] = 41, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30356,7 +28872,6 @@ return {
 			}, 
 		}, 
 		["1506_LifeLeech"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30366,7 +28881,6 @@ return {
 			}, 
 		}, 
 		["1507_EnemyLifeLeechPermyriad"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30392,7 +28906,6 @@ return {
 				["max"] = 0.5, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30410,7 +28923,6 @@ return {
 				["max"] = 0.4, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30472,7 +28984,6 @@ return {
 				["max"] = 1.3, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% of Physical Attack Damage Leeched as Life", 
 			}, 
@@ -30507,7 +29018,6 @@ return {
 				["max"] = 0.6, 
 				["min"] = 0.6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% of Physical Attack Damage Leeched as Life", 
 			}, 
@@ -30530,7 +29040,6 @@ return {
 				["max"] = 0.3, 
 				["min"] = 0.3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30548,7 +29057,6 @@ return {
 				["max"] = 0.2, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30558,7 +29066,6 @@ return {
 			}, 
 		}, 
 		["1526_EnemyPhysicalDamageLifeLeechPermyriad"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30576,7 +29083,6 @@ return {
 				["max"] = 0.2, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30586,7 +29092,6 @@ return {
 			}, 
 		}, 
 		["1529_FireResistanceLeech"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30596,7 +29101,6 @@ return {
 			}, 
 		}, 
 		["1530_EnemyFireDamageLifeLeechPermyriad"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30606,7 +29110,6 @@ return {
 			}, 
 		}, 
 		["1530_FireResistanceEnemyLeech"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30624,7 +29127,6 @@ return {
 				["max"] = 0.2, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30634,7 +29136,6 @@ return {
 			}, 
 		}, 
 		["1534_ColdResistanceLeech"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30644,7 +29145,6 @@ return {
 			}, 
 		}, 
 		["1535_ColdResistanceEnemyLeech"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30654,7 +29154,6 @@ return {
 			}, 
 		}, 
 		["1535_EnemyColdDamageLifeLeechPermyriad"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30672,7 +29171,6 @@ return {
 				["max"] = 0.2, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30682,7 +29180,6 @@ return {
 			}, 
 		}, 
 		["1538_LightningResistanceLeech"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30692,7 +29189,6 @@ return {
 			}, 
 		}, 
 		["1539_EnemyLightningDamageLifeLeechPermyriad"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30702,7 +29198,6 @@ return {
 			}, 
 		}, 
 		["1539_LightningResistanceEnemyLeech"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30712,7 +29207,6 @@ return {
 			}, 
 		}, 
 		["153_LocalIncreaseSocketedSpellGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30730,7 +29224,6 @@ return {
 				["max"] = 0.2, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30740,7 +29233,6 @@ return {
 			}, 
 		}, 
 		["1542_EnemyChaosDamageLifeLeechPermyriad"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30750,7 +29242,6 @@ return {
 			}, 
 		}, 
 		["1556_ManaLeech"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30760,7 +29251,6 @@ return {
 			}, 
 		}, 
 		["1557_EnemyManaLeechPermyriad"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30786,7 +29276,6 @@ return {
 				["max"] = 0.4, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30804,7 +29293,6 @@ return {
 				["max"] = 0.4, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30822,7 +29310,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30884,7 +29371,6 @@ return {
 				["max"] = 0.4, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% of Physical Attack Damage Leeched as Mana", 
 			}, 
@@ -30903,7 +29389,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30921,7 +29406,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -30947,7 +29431,6 @@ return {
 				["max"] = 0.3, 
 				["min"] = 0.3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31013,7 +29496,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31031,7 +29513,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31049,7 +29530,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31059,7 +29539,6 @@ return {
 			}, 
 		}, 
 		["1591_MaximumLifeLeechRateOldFix"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31073,7 +29552,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31091,7 +29569,6 @@ return {
 				["max"] = 30, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31153,7 +29630,6 @@ return {
 				["max"] = 5, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31167,7 +29643,6 @@ return {
 				["max"] = 15, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31189,7 +29664,6 @@ return {
 				["max"] = 20, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31207,7 +29681,6 @@ return {
 				["max"] = 3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31217,7 +29690,6 @@ return {
 			}, 
 		}, 
 		["159_LocalIncreaseSocketedMinionGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31324,7 +29796,6 @@ return {
 			}, 
 		}, 
 		["1602_LifeGainOnHitVsIgnitedEnemies"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31334,7 +29805,6 @@ return {
 			}, 
 		}, 
 		["1603_IncreasedManaAndOnHit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31356,7 +29826,6 @@ return {
 				["max"] = 3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31374,7 +29843,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31392,7 +29860,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31410,7 +29877,6 @@ return {
 				["max"] = 3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31488,7 +29954,6 @@ return {
 				["max"] = 14, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31502,7 +29967,6 @@ return {
 				["max"] = 6, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31516,7 +29980,6 @@ return {
 				["max"] = 6, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31530,7 +29993,6 @@ return {
 				["max"] = 6, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31544,7 +30006,6 @@ return {
 				["max"] = 6, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31558,7 +30019,6 @@ return {
 				["max"] = 2, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31572,7 +30032,6 @@ return {
 				["max"] = 6, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31586,7 +30045,6 @@ return {
 				["max"] = 6, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31596,7 +30054,6 @@ return {
 			}, 
 		}, 
 		["1616_GainLifeOnBlock"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31606,7 +30063,6 @@ return {
 			}, 
 		}, 
 		["1617_GainManaOnBlock"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31684,7 +30140,6 @@ return {
 				["max"] = 6, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31698,7 +30153,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31760,7 +30214,6 @@ return {
 				["max"] = 59, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31794,7 +30247,6 @@ return {
 				["max"] = 40, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31816,7 +30268,6 @@ return {
 				["max"] = 12, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31830,7 +30281,6 @@ return {
 				["max"] = 40, 
 				["min"] = 36, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31844,7 +30294,6 @@ return {
 				["max"] = 25, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31866,7 +30315,6 @@ return {
 				["max"] = 30, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31888,7 +30336,6 @@ return {
 				["max"] = 30, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31906,7 +30353,6 @@ return {
 				["max"] = 12, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31916,7 +30362,6 @@ return {
 			}, 
 		}, 
 		["163_IncreaseSocketedCurseGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -31954,8 +30399,8 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
+				["overrideModLineSingular"] = "Projectiles Pierce an additional Target", 
 			}, 
 			["tradeMod"] = {
 				["id"] = "explicit.stat_2067062068", 
@@ -31980,7 +30425,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLineSingular"] = "Projectiles Pierce an additional Target", 
 			}, 
@@ -31999,7 +30443,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLineSingular"] = "Projectiles Pierce an additional Target", 
 			}, 
@@ -32051,7 +30494,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLineSingular"] = "Bow Attacks fire an additional Arrow", 
 			}, 
@@ -32070,7 +30512,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32096,7 +30537,6 @@ return {
 				["max"] = 25, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32110,7 +30550,6 @@ return {
 				["max"] = 25, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32132,7 +30571,6 @@ return {
 				["max"] = 52, 
 				["min"] = 34, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32146,7 +30584,6 @@ return {
 				["max"] = 30, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32164,7 +30601,6 @@ return {
 				["max"] = 25, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32210,7 +30646,6 @@ return {
 				["max"] = 10, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32224,7 +30659,6 @@ return {
 				["max"] = 30, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32238,7 +30672,6 @@ return {
 				["max"] = 30, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32252,7 +30685,6 @@ return {
 				["max"] = 30, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32262,7 +30694,6 @@ return {
 			}, 
 		}, 
 		["1657_MovementVelocityDodge"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32272,7 +30703,6 @@ return {
 			}, 
 		}, 
 		["1657_MovementVelocitySpeed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32282,7 +30712,6 @@ return {
 			}, 
 		}, 
 		["1657_MovementVelocitySpellDodge"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32292,7 +30721,6 @@ return {
 			}, 
 		}, 
 		["165_LocalIncreaseSocketedTrapGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32306,7 +30734,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32328,7 +30755,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32346,7 +30772,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32356,7 +30781,6 @@ return {
 			}, 
 		}, 
 		["1662_MinimumEnduranceChargesAndOnKillLose"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32390,7 +30814,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32404,7 +30827,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32426,7 +30848,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32444,7 +30865,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32454,7 +30874,6 @@ return {
 			}, 
 		}, 
 		["1667_MinimumFrenzyChargesAndOnKillLose"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32484,7 +30903,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32498,7 +30916,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32508,7 +30925,6 @@ return {
 			}, 
 		}, 
 		["166_IncreasedSocketedTrapOrMineGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32530,7 +30946,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32548,7 +30963,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32558,7 +30972,6 @@ return {
 			}, 
 		}, 
 		["1672_MinimumPowerChargesAndOnKillLose"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32580,7 +30993,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32594,7 +31006,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32620,7 +31031,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32630,7 +31040,6 @@ return {
 			}, 
 		}, 
 		["1683_GainPowerChargeOnKillingFrozenEnemy"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32648,7 +31057,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32666,7 +31074,6 @@ return {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32680,7 +31087,6 @@ return {
 				["max"] = 15, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32694,7 +31100,6 @@ return {
 				["max"] = 15, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32764,7 +31169,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32830,7 +31234,6 @@ return {
 				["max"] = 2, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32844,7 +31247,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32858,7 +31260,6 @@ return {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32872,7 +31273,6 @@ return {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32895,7 +31295,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -32909,7 +31308,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33024,7 +31422,6 @@ return {
 				["max"] = 35, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33038,7 +31435,6 @@ return {
 				["max"] = 35, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33048,7 +31444,6 @@ return {
 			}, 
 		}, 
 		["1703_AvoidChillForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33062,7 +31457,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33076,7 +31470,6 @@ return {
 				["max"] = 100, 
 				["min"] = 100, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33094,7 +31487,6 @@ return {
 				["max"] = 80, 
 				["min"] = 51, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33108,7 +31500,6 @@ return {
 				["max"] = 100, 
 				["min"] = 100, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33118,7 +31509,6 @@ return {
 			}, 
 		}, 
 		["1704_AvoidFreezeForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33148,7 +31538,6 @@ return {
 				["max"] = 60, 
 				["min"] = 39, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33166,7 +31555,6 @@ return {
 				["max"] = 25, 
 				["min"] = 21, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33200,7 +31588,6 @@ return {
 				["max"] = 80, 
 				["min"] = 51, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33210,7 +31597,6 @@ return {
 			}, 
 		}, 
 		["1705_AvoidIgniteForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33228,7 +31614,6 @@ return {
 				["max"] = 25, 
 				["min"] = 21, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33246,7 +31631,6 @@ return {
 				["max"] = 80, 
 				["min"] = 51, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33264,7 +31648,6 @@ return {
 				["max"] = 50, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33282,7 +31665,6 @@ return {
 				["max"] = 25, 
 				["min"] = 21, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33304,7 +31686,6 @@ return {
 				["max"] = 60, 
 				["min"] = 35, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33318,7 +31699,6 @@ return {
 				["max"] = 70, 
 				["min"] = 41, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33352,7 +31732,6 @@ return {
 				["max"] = 50, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33362,7 +31741,6 @@ return {
 			}, 
 		}, 
 		["1708_MovementVelocitySpellDodge"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33396,7 +31774,6 @@ return {
 				["max"] = 50, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33410,7 +31787,6 @@ return {
 				["max"] = 35, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33420,7 +31796,6 @@ return {
 			}, 
 		}, 
 		["1710_AvoidStunForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33434,7 +31809,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33452,7 +31826,6 @@ return {
 				["max"] = 16, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33462,7 +31835,6 @@ return {
 			}, 
 		}, 
 		["1716_ShockDurationForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33476,7 +31848,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33490,7 +31861,6 @@ return {
 				["max"] = 15, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33508,7 +31878,6 @@ return {
 				["max"] = 16, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33518,7 +31887,6 @@ return {
 			}, 
 		}, 
 		["1718_BurnDurationForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33532,7 +31900,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33550,7 +31917,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33564,7 +31930,6 @@ return {
 				["max"] = 20, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33578,7 +31943,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33592,7 +31956,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33606,7 +31969,6 @@ return {
 				["max"] = 15, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33632,7 +31994,6 @@ return {
 				["max"] = 30, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33650,7 +32011,6 @@ return {
 				["max"] = 14, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33720,7 +32080,6 @@ return {
 				["max"] = 35, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33750,7 +32109,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33764,7 +32122,6 @@ return {
 				["max"] = 60, 
 				["min"] = 51, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33778,7 +32135,6 @@ return {
 				["max"] = 60, 
 				["min"] = 51, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33792,7 +32148,6 @@ return {
 				["max"] = 60, 
 				["min"] = 51, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33806,7 +32161,6 @@ return {
 				["max"] = 60, 
 				["min"] = 51, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33828,7 +32182,6 @@ return {
 				["max"] = 60, 
 				["min"] = 41, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33838,7 +32191,6 @@ return {
 			}, 
 		}, 
 		["1736_BurnDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33868,7 +32220,6 @@ return {
 				["max"] = 94, 
 				["min"] = 60, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33886,7 +32237,6 @@ return {
 				["max"] = 20, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33900,7 +32250,6 @@ return {
 				["max"] = 35, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33914,7 +32263,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33928,7 +32276,6 @@ return {
 				["max"] = 16, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33982,7 +32329,6 @@ return {
 				["max"] = 20, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -33996,7 +32342,6 @@ return {
 				["max"] = 15, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34010,7 +32355,6 @@ return {
 				["max"] = 12, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34024,7 +32368,6 @@ return {
 				["max"] = 12, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34054,7 +32397,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34072,7 +32414,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34098,7 +32439,6 @@ return {
 				["max"] = 15, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34148,7 +32488,6 @@ return {
 				["max"] = 15, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34166,7 +32505,6 @@ return {
 				["max"] = 7, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34180,7 +32518,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34190,7 +32527,6 @@ return {
 			}, 
 		}, 
 		["1742_ManaCostReductionForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34200,7 +32536,6 @@ return {
 			}, 
 		}, 
 		["1750_IncreaseManaCostFlat"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34210,7 +32545,6 @@ return {
 			}, 
 		}, 
 		["1750_IncreasedManaAndCost"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34224,7 +32558,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34286,7 +32619,6 @@ return {
 				["max"] = 30, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34312,7 +32644,6 @@ return {
 				["max"] = 60, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34330,7 +32661,6 @@ return {
 				["max"] = 35, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34356,7 +32686,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34382,7 +32711,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34408,7 +32736,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34434,7 +32761,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34444,7 +32770,6 @@ return {
 			}, 
 		}, 
 		["1759_LocalEvasionAndEnergyShieldAndStunRecovery"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34470,7 +32795,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34496,7 +32820,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34506,7 +32829,6 @@ return {
 			}, 
 		}, 
 		["1759_LocalWardAndStunRecoveryPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34524,7 +32846,6 @@ return {
 				["max"] = 34, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34542,7 +32863,6 @@ return {
 				["max"] = 35, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34552,7 +32872,6 @@ return {
 			}, 
 		}, 
 		["1780_TrapCooldownRecoveryAndDuration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34562,7 +32881,6 @@ return {
 			}, 
 		}, 
 		["1781_MineDetonationSpeedAndDuration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34576,7 +32894,6 @@ return {
 				["max"] = 20, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34594,7 +32911,6 @@ return {
 				["max"] = 16, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34612,7 +32928,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34674,7 +32989,6 @@ return {
 				["max"] = 15, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34692,7 +33006,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34710,7 +33023,6 @@ return {
 				["max"] = 16, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34772,7 +33084,6 @@ return {
 				["max"] = 15, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34782,7 +33093,6 @@ return {
 			}, 
 		}, 
 		["1788_SelfPhysAsExtraFireTaken"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34800,7 +33110,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34818,7 +33127,6 @@ return {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34880,7 +33188,6 @@ return {
 				["max"] = 20, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34898,7 +33205,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34964,7 +33270,6 @@ return {
 				["max"] = 20, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -34982,7 +33287,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35032,7 +33336,6 @@ return {
 				["max"] = 20, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35042,7 +33345,6 @@ return {
 			}, 
 		}, 
 		["1792_LocalPhysicalDamagePercentAddedAsChaos"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35108,7 +33410,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35118,7 +33419,6 @@ return {
 			}, 
 		}, 
 		["1795_ChaosDamageAsPortionOfLightningDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35184,7 +33484,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35194,7 +33493,6 @@ return {
 			}, 
 		}, 
 		["1797_ChaosDamageAsPortionOfColdDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35260,7 +33558,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35270,7 +33567,6 @@ return {
 			}, 
 		}, 
 		["1798_ChaosDamageAsPortionOfFireDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35336,7 +33632,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35370,7 +33665,6 @@ return {
 				["max"] = 8, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35477,7 +33771,6 @@ return {
 			}, 
 		}, 
 		["1800_LifeDegenerationAndPercentGracePeriod"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35487,7 +33780,6 @@ return {
 			}, 
 		}, 
 		["1801_LifeRegenerationAndPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35537,7 +33829,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35551,7 +33842,6 @@ return {
 				["max"] = 25, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35561,7 +33851,6 @@ return {
 			}, 
 		}, 
 		["1805_ChaosResistanceDamageOverTime"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35615,7 +33904,6 @@ return {
 				["max"] = 30, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35633,7 +33921,6 @@ return {
 				["max"] = 25, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35643,7 +33930,6 @@ return {
 			}, 
 		}, 
 		["1812_FireDamagePhysConvertedToFire"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35653,7 +33939,6 @@ return {
 			}, 
 		}, 
 		["1814_ColdDamagePhysConvertedToCold"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35707,7 +33992,6 @@ return {
 				["max"] = 25, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35725,7 +34009,6 @@ return {
 				["max"] = 25, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35767,7 +34050,6 @@ return {
 				["max"] = 30, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35785,7 +34067,6 @@ return {
 				["max"] = 25, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35795,7 +34076,6 @@ return {
 			}, 
 		}, 
 		["1816_LightningDamagePhysConvertedToLightning"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35857,7 +34137,6 @@ return {
 				["max"] = 25, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35923,7 +34202,6 @@ return {
 				["max"] = 10, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -35949,7 +34227,6 @@ return {
 				["max"] = 42, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36011,7 +34288,6 @@ return {
 				["max"] = 59, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36029,7 +34305,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36095,7 +34370,6 @@ return {
 				["max"] = 109, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36113,7 +34387,6 @@ return {
 				["max"] = 39, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36123,7 +34396,6 @@ return {
 			}, 
 		}, 
 		["1830_MinionDamageOnWeaponDoubleDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36137,7 +34409,6 @@ return {
 				["max"] = 25, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36155,7 +34426,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36229,7 +34499,6 @@ return {
 				["max"] = 49, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36243,7 +34512,6 @@ return {
 				["max"] = 22, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36261,7 +34529,6 @@ return {
 				["max"] = 60, 
 				["min"] = 45, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36271,7 +34538,6 @@ return {
 			}, 
 		}, 
 		["183_IncreaseSocketedSupportGemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36337,7 +34603,6 @@ return {
 				["max"] = 8, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36351,7 +34616,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36365,7 +34629,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36379,7 +34642,6 @@ return {
 				["max"] = 2, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36393,7 +34655,6 @@ return {
 				["max"] = 2, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36407,7 +34668,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36425,7 +34685,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36439,7 +34698,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36453,7 +34711,6 @@ return {
 				["max"] = 20, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36471,7 +34728,6 @@ return {
 				["max"] = 12, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36485,7 +34741,6 @@ return {
 				["max"] = 25, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36503,7 +34758,6 @@ return {
 				["max"] = 30, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36521,7 +34775,6 @@ return {
 				["max"] = 25, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36583,7 +34836,6 @@ return {
 				["max"] = 780, 
 				["min"] = 80, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to Accuracy Rating", 
 			}, 
@@ -36594,7 +34846,6 @@ return {
 			}, 
 		}, 
 		["1878_LocalAccuracyRatingAndLocalItemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to Accuracy Rating", 
 			}, 
@@ -36657,7 +34908,6 @@ return {
 				["max"] = 350, 
 				["min"] = 161, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to Accuracy Rating", 
 			}, 
@@ -36720,7 +34970,6 @@ return {
 				["max"] = 200, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to Accuracy Rating", 
 			}, 
@@ -36731,7 +34980,6 @@ return {
 			}, 
 		}, 
 		["1878_LocalLightRadiusAndAccuracy"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to Accuracy Rating", 
 			}, 
@@ -36762,7 +35010,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36772,7 +35019,6 @@ return {
 			}, 
 		}, 
 		["1880_ChanceToIgniteForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36834,7 +35080,6 @@ return {
 				["max"] = 40, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36848,7 +35093,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36862,7 +35106,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36880,7 +35123,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36910,7 +35152,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36920,7 +35161,6 @@ return {
 			}, 
 		}, 
 		["1883_ChanceToFreezeForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36982,7 +35222,6 @@ return {
 				["max"] = 40, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -36996,7 +35235,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37014,7 +35252,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37028,7 +35265,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37058,7 +35294,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37068,7 +35303,6 @@ return {
 			}, 
 		}, 
 		["1887_ChanceToShockForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37130,7 +35364,6 @@ return {
 				["max"] = 40, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37148,7 +35381,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37162,7 +35394,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37176,7 +35407,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37190,7 +35420,6 @@ return {
 				["max"] = 20, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37208,7 +35437,6 @@ return {
 				["max"] = 12, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37222,7 +35450,6 @@ return {
 				["max"] = 25, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37248,7 +35475,6 @@ return {
 				["max"] = 37, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37298,7 +35524,6 @@ return {
 				["max"] = 37, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37312,7 +35537,6 @@ return {
 				["max"] = 7, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37461,7 +35685,6 @@ return {
 				["max"] = 7, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37479,7 +35702,6 @@ return {
 				["max"] = 8, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37497,7 +35719,6 @@ return {
 				["max"] = 4, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37511,7 +35732,6 @@ return {
 				["max"] = 14, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37525,7 +35745,6 @@ return {
 				["max"] = 14, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37551,7 +35770,6 @@ return {
 				["max"] = 5, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37573,7 +35791,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37587,7 +35804,6 @@ return {
 				["max"] = 35, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37605,7 +35821,6 @@ return {
 				["max"] = 9, 
 				["min"] = 2.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37623,7 +35838,6 @@ return {
 				["max"] = 9, 
 				["min"] = 2.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37641,7 +35855,6 @@ return {
 				["max"] = 9, 
 				["min"] = 2.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37659,7 +35872,6 @@ return {
 				["max"] = 9, 
 				["min"] = 2.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37677,7 +35889,6 @@ return {
 				["max"] = 9, 
 				["min"] = 2.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37695,7 +35906,6 @@ return {
 				["max"] = 9, 
 				["min"] = 2.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37713,7 +35923,6 @@ return {
 				["max"] = 9, 
 				["min"] = 2.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37727,7 +35936,6 @@ return {
 				["max"] = 7, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37745,7 +35953,6 @@ return {
 				["max"] = 9, 
 				["min"] = 2.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37763,7 +35970,6 @@ return {
 				["max"] = 25, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37781,7 +35987,6 @@ return {
 				["max"] = 25, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37799,7 +36004,6 @@ return {
 				["max"] = 25, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37817,7 +36021,6 @@ return {
 				["max"] = 25, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37835,7 +36038,6 @@ return {
 				["max"] = 25, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37853,7 +36055,6 @@ return {
 				["max"] = 25, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37871,7 +36072,6 @@ return {
 				["max"] = 25, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37889,7 +36089,6 @@ return {
 				["max"] = 25, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37907,7 +36106,6 @@ return {
 				["max"] = 21.5, 
 				["min"] = 6.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37925,7 +36123,6 @@ return {
 				["max"] = 21.5, 
 				["min"] = 6.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37943,7 +36140,6 @@ return {
 				["max"] = 21.5, 
 				["min"] = 6.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37961,7 +36157,6 @@ return {
 				["max"] = 21.5, 
 				["min"] = 6.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37979,7 +36174,6 @@ return {
 				["max"] = 21.5, 
 				["min"] = 6.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -37997,7 +36191,6 @@ return {
 				["max"] = 21.5, 
 				["min"] = 6.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38015,7 +36208,6 @@ return {
 				["max"] = 21.5, 
 				["min"] = 6.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38033,7 +36225,6 @@ return {
 				["max"] = 21.5, 
 				["min"] = 6.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38051,7 +36242,6 @@ return {
 				["max"] = 27.5, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38065,7 +36255,6 @@ return {
 				["max"] = 7, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38083,7 +36272,6 @@ return {
 				["max"] = 27.5, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38101,7 +36289,6 @@ return {
 				["max"] = 27.5, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38119,7 +36306,6 @@ return {
 				["max"] = 27.5, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38137,7 +36323,6 @@ return {
 				["max"] = 27.5, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38155,7 +36340,6 @@ return {
 				["max"] = 27.5, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38173,7 +36357,6 @@ return {
 				["max"] = 27.5, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38191,7 +36374,6 @@ return {
 				["max"] = 27.5, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38209,7 +36391,6 @@ return {
 				["max"] = 18.5, 
 				["min"] = 6.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38227,7 +36408,6 @@ return {
 				["max"] = 18.5, 
 				["min"] = 6.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38245,7 +36425,6 @@ return {
 				["max"] = 18.5, 
 				["min"] = 6.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38263,7 +36442,6 @@ return {
 				["max"] = 20.5, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38281,7 +36459,6 @@ return {
 				["max"] = 20.5, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38299,7 +36476,6 @@ return {
 				["max"] = 20.5, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38317,7 +36493,6 @@ return {
 				["max"] = 29.5, 
 				["min"] = 3.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38335,7 +36510,6 @@ return {
 				["max"] = 29.5, 
 				["min"] = 3.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38353,7 +36527,6 @@ return {
 				["max"] = 29.5, 
 				["min"] = 3.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38371,7 +36544,6 @@ return {
 				["max"] = 29.5, 
 				["min"] = 3.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38389,7 +36561,6 @@ return {
 				["max"] = 29.5, 
 				["min"] = 3.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38407,7 +36578,6 @@ return {
 				["max"] = 29.5, 
 				["min"] = 3.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38425,7 +36595,6 @@ return {
 				["max"] = 28.5, 
 				["min"] = 3.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38443,7 +36612,6 @@ return {
 				["max"] = 28.5, 
 				["min"] = 3.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38461,7 +36629,6 @@ return {
 				["max"] = 28.5, 
 				["min"] = 3.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38479,7 +36646,6 @@ return {
 				["max"] = 20.5, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38497,7 +36663,6 @@ return {
 				["max"] = 20.5, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38515,7 +36680,6 @@ return {
 				["max"] = 20.5, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38541,7 +36705,6 @@ return {
 				["max"] = 25, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38551,7 +36714,6 @@ return {
 			}, 
 		}, 
 		["1979_EnduranceChargeDurationForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38601,7 +36763,6 @@ return {
 				["max"] = 50, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38611,7 +36772,6 @@ return {
 			}, 
 		}, 
 		["1981_FrenzyChargeDurationForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38665,7 +36825,6 @@ return {
 				["max"] = 50, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38683,7 +36842,6 @@ return {
 				["max"] = 18, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38701,7 +36859,6 @@ return {
 				["max"] = 18, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38719,7 +36876,6 @@ return {
 				["max"] = 18, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38729,7 +36885,6 @@ return {
 			}, 
 		}, 
 		["1996_PowerChargeDurationForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38771,7 +36926,6 @@ return {
 				["max"] = 50, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38789,7 +36943,6 @@ return {
 				["max"] = 50, 
 				["min"] = 35, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38799,7 +36952,6 @@ return {
 			}, 
 		}, 
 		["2011_LifeLeechSpeed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38817,7 +36969,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38831,7 +36982,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38841,7 +36991,6 @@ return {
 			}, 
 		}, 
 		["2015_MaximumMinionCount"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38859,7 +37008,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38873,7 +37021,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38887,7 +37034,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLineSingular"] = "You can apply an additional Curse", 
 			}, 
@@ -38902,7 +37048,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLineSingular"] = "You can apply an additional Curse", 
 			}, 
@@ -38917,7 +37062,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLineSingular"] = "You can apply an additional Curse", 
 			}, 
@@ -38936,7 +37080,6 @@ return {
 				["max"] = 30, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38950,7 +37093,6 @@ return {
 				["max"] = 40, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38964,7 +37106,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -38990,7 +37131,6 @@ return {
 				["max"] = 20, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39017,7 +37157,6 @@ return {
 				["max"] = 40, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39031,7 +37170,7 @@ return {
 				["max"] = -20, 
 				["min"] = -33, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39045,7 +37184,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39059,7 +37197,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39077,7 +37214,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39087,7 +37223,6 @@ return {
 			}, 
 		}, 
 		["203_WeaponSpellDamageArcaneSurge"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39109,7 +37244,6 @@ return {
 				["max"] = 33, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39123,7 +37257,6 @@ return {
 				["max"] = 40, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39137,7 +37270,6 @@ return {
 				["max"] = 40, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39167,7 +37299,6 @@ return {
 				["max"] = 200, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39177,7 +37308,6 @@ return {
 			}, 
 		}, 
 		["2067_CurseCastSpeedForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39187,7 +37317,6 @@ return {
 			}, 
 		}, 
 		["2077_AuraRadiusForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39197,7 +37326,6 @@ return {
 			}, 
 		}, 
 		["2078_CurseAreaOfEffect"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39207,7 +37335,6 @@ return {
 			}, 
 		}, 
 		["2078_CurseRadiusForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39217,7 +37344,6 @@ return {
 			}, 
 		}, 
 		["2079_LifeReservationEfficiency"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39247,7 +37373,6 @@ return {
 				["max"] = 14, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39257,7 +37382,6 @@ return {
 			}, 
 		}, 
 		["2085_IncreasedManaAndReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39275,7 +37399,6 @@ return {
 				["max"] = 14, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39286,10 +37409,9 @@ return {
 		}, 
 		["2087_PhysicalAttackDamageTaken"] = {
 			["Belt"] = {
-				["max"] = 36, 
-				["min"] = 35, 
+				["max"] = -35, 
+				["min"] = -36, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39300,10 +37422,9 @@ return {
 		}, 
 		["2088_FlatPhysicalDamageTaken"] = {
 			["Chest"] = {
-				["max"] = 50, 
-				["min"] = 34, 
+				["max"] = -34, 
+				["min"] = -50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39317,7 +37438,7 @@ return {
 				["max"] = -3, 
 				["min"] = -5, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39327,7 +37448,7 @@ return {
 			}, 
 		}, 
 		["2095_FireDamageTaken"] = {
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39337,7 +37458,6 @@ return {
 			}, 
 		}, 
 		["2096_ChaosDamageTakenPercentage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39351,7 +37471,6 @@ return {
 				["max"] = 10, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39361,7 +37480,6 @@ return {
 			}, 
 		}, 
 		["2102_IncreasedShieldBlockPercentage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+#% Chance to Block", 
 			}, 
@@ -39372,7 +37490,6 @@ return {
 			}, 
 		}, 
 		["2102_LocalPhysicalDamageReductionRatingPercentAndBlockChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+#% Chance to Block", 
 			}, 
@@ -39387,7 +37504,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39449,7 +37565,6 @@ return {
 				["max"] = 25, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39483,7 +37598,6 @@ return {
 				["max"] = 5, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39497,7 +37611,6 @@ return {
 				["max"] = 4, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39511,7 +37624,6 @@ return {
 				["max"] = 15, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39561,7 +37673,6 @@ return {
 				["max"] = 20, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39575,7 +37686,6 @@ return {
 				["max"] = 5, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39605,7 +37715,6 @@ return {
 				["max"] = 20, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39623,7 +37732,6 @@ return {
 				["max"] = 20, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39637,7 +37745,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39687,7 +37794,6 @@ return {
 				["max"] = 20, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39697,7 +37803,6 @@ return {
 			}, 
 		}, 
 		["2298_FireResistancePhysTakenAsFire"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39707,7 +37812,6 @@ return {
 			}, 
 		}, 
 		["2298_PhysicalDamageTakenAsFireAndLightningPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39717,7 +37821,6 @@ return {
 			}, 
 		}, 
 		["2298_PhysicalDamageTakenAsFirePercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39735,7 +37838,6 @@ return {
 				["max"] = 13, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39749,7 +37851,6 @@ return {
 				["max"] = 18, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39759,7 +37860,6 @@ return {
 			}, 
 		}, 
 		["2299_ColdResistancePhysTakenAsCold"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39769,7 +37869,6 @@ return {
 			}, 
 		}, 
 		["2299_PhysicalDamageTakenAsCold"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39787,7 +37886,6 @@ return {
 				["max"] = 15, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39801,7 +37899,6 @@ return {
 				["max"] = 18, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39811,7 +37908,6 @@ return {
 			}, 
 		}, 
 		["2300_LightningResistancePhysTakenAsLightning"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39821,7 +37917,6 @@ return {
 			}, 
 		}, 
 		["2300_PhysicalDamageTakenAsFireAndLightningPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39839,7 +37934,6 @@ return {
 				["max"] = 13, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39853,7 +37947,6 @@ return {
 				["max"] = 18, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39867,7 +37960,6 @@ return {
 				["max"] = 15, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39881,7 +37973,6 @@ return {
 				["max"] = 18, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39899,7 +37990,6 @@ return {
 				["max"] = 8, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39921,7 +38011,6 @@ return {
 				["max"] = 3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39931,7 +38020,6 @@ return {
 			}, 
 		}, 
 		["2315_BlockVsProjectiles"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39945,7 +38033,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39971,7 +38058,6 @@ return {
 				["max"] = 20, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39981,7 +38067,6 @@ return {
 			}, 
 		}, 
 		["2332_CausesBleeding25PercentChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -39991,7 +38076,6 @@ return {
 			}, 
 		}, 
 		["2334_CausesBleedingChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40041,7 +38125,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40103,7 +38186,6 @@ return {
 				["max"] = 40, 
 				["min"] = 35, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40113,7 +38195,6 @@ return {
 			}, 
 		}, 
 		["2334_LocalChanceToBleed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40175,7 +38256,6 @@ return {
 				["max"] = 25, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40193,7 +38273,6 @@ return {
 				["max"] = 20, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40211,7 +38290,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40225,7 +38303,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40235,7 +38312,6 @@ return {
 			}, 
 		}, 
 		["2340_BleedingDamageChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40245,7 +38321,6 @@ return {
 			}, 
 		}, 
 		["2340_BleedingDamageChanceWeaponSuffix"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40255,7 +38330,6 @@ return {
 			}, 
 		}, 
 		["2340_ChanceToBleed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40273,7 +38347,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40287,7 +38360,6 @@ return {
 				["max"] = 14.5, 
 				["min"] = 9.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40297,7 +38369,6 @@ return {
 			}, 
 		}, 
 		["2351_LightRadiusAndAccuracy"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40315,7 +38386,6 @@ return {
 				["max"] = 15, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40325,7 +38395,6 @@ return {
 			}, 
 		}, 
 		["2351_LocalLightRadiusAndAccuracy"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40387,7 +38456,6 @@ return {
 				["max"] = 15, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40401,7 +38469,6 @@ return {
 				["max"] = 70, 
 				["min"] = 70, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40411,7 +38478,6 @@ return {
 			}, 
 		}, 
 		["235_SupportedByEmpower"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40434,7 +38500,6 @@ return {
 			}, 
 		}, 
 		["2375_CurseLevel10VulnerabilityOnHit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40552,7 +38617,6 @@ return {
 			}, 
 		}, 
 		["237_SupportedByEnhance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40612,7 +38676,6 @@ return {
 				["max"] = 0.4, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40630,7 +38693,6 @@ return {
 				["max"] = 0.2, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40644,7 +38706,6 @@ return {
 				["max"] = 0.4, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40654,7 +38715,6 @@ return {
 			}, 
 		}, 
 		["238_SupportedByEnlighten"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40668,7 +38728,7 @@ return {
 				["max"] = -5, 
 				["min"] = -15, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40715,7 +38775,6 @@ return {
 				["max"] = 15, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40729,7 +38788,6 @@ return {
 				["max"] = 15, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40743,7 +38801,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40765,7 +38822,6 @@ return {
 				["max"] = 45, 
 				["min"] = 21, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40779,7 +38835,6 @@ return {
 				["max"] = 20, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40793,7 +38848,6 @@ return {
 				["max"] = 20, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40815,7 +38869,6 @@ return {
 				["max"] = 20, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40829,7 +38882,6 @@ return {
 				["max"] = 12, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40843,7 +38895,6 @@ return {
 				["max"] = 25, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40902,7 +38953,6 @@ return {
 				["max"] = 10, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40952,7 +39002,6 @@ return {
 				["max"] = 10, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40970,7 +39019,6 @@ return {
 				["max"] = 4, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -40980,7 +39028,6 @@ return {
 			}, 
 		}, 
 		["2479_MinimumEnduranceChargesAndOnKillLose"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41034,7 +39081,6 @@ return {
 				["max"] = 10, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41088,7 +39134,6 @@ return {
 				["max"] = 10, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41106,7 +39151,6 @@ return {
 				["max"] = 4, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41116,7 +39160,6 @@ return {
 			}, 
 		}, 
 		["2481_MinimumFrenzyChargesAndOnKillLose"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41134,7 +39177,6 @@ return {
 				["max"] = 4, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41176,7 +39218,6 @@ return {
 				["max"] = 10, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41218,7 +39259,6 @@ return {
 				["max"] = 15, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41228,7 +39268,6 @@ return {
 			}, 
 		}, 
 		["2483_MinimumPowerChargesAndOnKillLose"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41242,7 +39281,6 @@ return {
 				["max"] = 100, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41252,7 +39290,6 @@ return {
 			}, 
 		}, 
 		["2495_EnergyShieldAndRegen"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41278,7 +39315,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41292,7 +39328,6 @@ return {
 				["max"] = 1.5, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41302,7 +39337,6 @@ return {
 			}, 
 		}, 
 		["2496_EnergyShieldAndDegenGracePeriod"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41316,7 +39350,6 @@ return {
 				["max"] = 15, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41342,7 +39375,6 @@ return {
 				["max"] = 5, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41356,7 +39388,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41374,7 +39405,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41405,7 +39435,6 @@ return {
 				["max"] = 12, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41419,7 +39448,6 @@ return {
 				["max"] = 18, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41429,7 +39457,6 @@ return {
 			}, 
 		}, 
 		["2592_MagicUtilityFlaskEffect"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41439,7 +39466,6 @@ return {
 			}, 
 		}, 
 		["2594_LocalMeleeWeaponRange"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41469,7 +39495,6 @@ return {
 				["max"] = 0.3, 
 				["min"] = 0.1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41483,7 +39508,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41493,7 +39517,6 @@ return {
 			}, 
 		}, 
 		["2605_RarityDuringFlaskEffect"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41519,7 +39542,6 @@ return {
 				["max"] = 20, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41573,7 +39595,6 @@ return {
 				["max"] = 20, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41587,7 +39608,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41605,7 +39625,6 @@ return {
 				["max"] = 10, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41703,7 +39722,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41725,7 +39743,6 @@ return {
 				["max"] = 12, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41823,7 +39840,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41845,7 +39861,6 @@ return {
 				["max"] = 12, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41943,7 +39958,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41965,7 +39979,6 @@ return {
 				["max"] = 12, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41975,7 +39988,6 @@ return {
 			}, 
 		}, 
 		["264_LocalIncreasedPhysicalDamagePercentIronGrip"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -41993,7 +40005,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42011,7 +40022,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42029,7 +40039,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42043,7 +40052,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42057,7 +40065,6 @@ return {
 				["max"] = 6, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42079,7 +40086,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42089,7 +40095,6 @@ return {
 			}, 
 		}, 
 		["2681_IncreasedDefensesForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42103,7 +40108,6 @@ return {
 				["max"] = 40, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42117,7 +40121,6 @@ return {
 				["max"] = 30, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42157,7 +40160,6 @@ return {
 				["max"] = 50, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42171,7 +40173,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42185,7 +40186,6 @@ return {
 				["max"] = 40, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42211,7 +40211,6 @@ return {
 				["max"] = 20, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42270,7 +40269,6 @@ return {
 				["max"] = 20, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42280,7 +40278,6 @@ return {
 			}, 
 		}, 
 		["271_SupportedByMaim"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42308,7 +40305,6 @@ return {
 			}, 
 		}, 
 		["2751_MinionBlockForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42330,7 +40326,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42392,7 +40387,6 @@ return {
 				["max"] = 38, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42414,7 +40408,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42476,7 +40469,6 @@ return {
 				["max"] = 38, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42494,7 +40486,6 @@ return {
 				["max"] = 0.5, 
 				["min"] = 0.3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42508,7 +40499,6 @@ return {
 				["max"] = 1.5, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42526,7 +40516,6 @@ return {
 				["max"] = 0.8, 
 				["min"] = 0.4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42544,7 +40533,6 @@ return {
 				["max"] = 12, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42562,7 +40550,6 @@ return {
 				["max"] = 30, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42584,7 +40571,6 @@ return {
 				["max"] = 15, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42602,7 +40588,6 @@ return {
 				["max"] = 11, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42628,7 +40613,6 @@ return {
 				["max"] = 15, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42646,7 +40630,6 @@ return {
 				["max"] = 16, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42685,7 +40668,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42715,7 +40697,6 @@ return {
 				["max"] = 15, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42733,7 +40714,6 @@ return {
 				["max"] = 15, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42751,7 +40731,6 @@ return {
 				["max"] = 20, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42761,7 +40740,6 @@ return {
 			}, 
 		}, 
 		["281_LocalPhysicalDamagePercentOnslaught"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42787,7 +40765,6 @@ return {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42891,7 +40868,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -42969,7 +40945,6 @@ return {
 				["max"] = 8, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43003,7 +40978,6 @@ return {
 				["max"] = 4, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43081,7 +41055,6 @@ return {
 				["max"] = 8, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43115,7 +41088,6 @@ return {
 				["max"] = 4, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43193,7 +41165,6 @@ return {
 				["max"] = 8, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43227,7 +41198,6 @@ return {
 				["max"] = 4, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43301,7 +41271,6 @@ return {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43319,7 +41288,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43333,7 +41301,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43347,7 +41314,6 @@ return {
 				["max"] = 16, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43365,7 +41331,6 @@ return {
 				["max"] = 20, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43375,7 +41340,6 @@ return {
 			}, 
 		}, 
 		["2859_IncreasedDamagePerCurse"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43385,7 +41349,6 @@ return {
 			}, 
 		}, 
 		["285_LocalIncreasedPhysicalDamagePercentProjectileAttackDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43395,7 +41358,6 @@ return {
 			}, 
 		}, 
 		["2868_MinionAreaOfEffect"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43413,7 +41375,6 @@ return {
 				["max"] = 20, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43427,7 +41388,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43461,7 +41421,6 @@ return {
 				["max"] = 60, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43471,7 +41430,6 @@ return {
 			}, 
 		}, 
 		["290_LocalIncreasedPhysicalDamagePercentPowerChargeOnCrit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43489,7 +41447,6 @@ return {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43499,7 +41456,6 @@ return {
 			}, 
 		}, 
 		["290_WeaponSpellDamagePowerChargeOnCrit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43517,7 +41473,6 @@ return {
 				["max"] = 5, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43539,7 +41494,6 @@ return {
 				["max"] = 40, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43577,7 +41531,6 @@ return {
 				["max"] = 8, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43591,7 +41544,6 @@ return {
 				["max"] = 25, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43609,7 +41561,6 @@ return {
 				["max"] = 120, 
 				["min"] = 80, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43623,7 +41574,6 @@ return {
 				["max"] = 25, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43637,7 +41587,6 @@ return {
 				["max"] = 25, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43647,7 +41596,6 @@ return {
 			}, 
 		}, 
 		["2979_ChillEnemiesWhenHit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43661,7 +41609,6 @@ return {
 				["max"] = 25, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43675,7 +41622,6 @@ return {
 				["max"] = 22, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43693,7 +41639,6 @@ return {
 				["max"] = 20, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43707,7 +41652,6 @@ return {
 				["max"] = 30, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43717,7 +41661,6 @@ return {
 			}, 
 		}, 
 		["3008_BleedingDamageChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43727,7 +41670,6 @@ return {
 			}, 
 		}, 
 		["3008_BleedingDamageChanceWeaponSuffix"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43741,7 +41683,6 @@ return {
 				["max"] = 35, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43755,7 +41696,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43773,7 +41713,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43787,7 +41726,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43797,7 +41735,6 @@ return {
 			}, 
 		}, 
 		["3009_PoisonDuration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43807,7 +41744,6 @@ return {
 			}, 
 		}, 
 		["3009_PoisonDurationChaosDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43821,7 +41757,6 @@ return {
 				["max"] = 20, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43839,7 +41774,6 @@ return {
 				["max"] = 14, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43857,7 +41791,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43867,7 +41800,6 @@ return {
 			}, 
 		}, 
 		["3012_PoisonOnHit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43881,7 +41813,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43899,7 +41830,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43909,7 +41839,6 @@ return {
 			}, 
 		}, 
 		["3013_MinionsPoisonEnemiesOnHit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43919,7 +41848,6 @@ return {
 			}, 
 		}, 
 		["3020_PoisonDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43929,7 +41857,6 @@ return {
 			}, 
 		}, 
 		["3020_PoisonDamageAddedChaosToAttacks"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43939,7 +41866,6 @@ return {
 			}, 
 		}, 
 		["3020_PoisonDamageAddedChaosToSpells"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43953,7 +41879,6 @@ return {
 				["max"] = 22, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43963,7 +41888,6 @@ return {
 			}, 
 		}, 
 		["3020_PoisonDamageAndLocalChanceOnHit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43981,7 +41905,6 @@ return {
 				["max"] = 20, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -43995,7 +41918,6 @@ return {
 				["max"] = 35, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44013,7 +41935,6 @@ return {
 				["max"] = 26, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44027,7 +41948,6 @@ return {
 				["max"] = 30, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44041,7 +41961,6 @@ return {
 				["max"] = 10, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44091,7 +42010,6 @@ return {
 				["max"] = 20, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44192,7 +42110,6 @@ return {
 				["max"] = 6, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44218,7 +42135,6 @@ return {
 				["max"] = 25, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44244,7 +42160,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44258,7 +42173,6 @@ return {
 				["max"] = 12, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44268,7 +42182,6 @@ return {
 			}, 
 		}, 
 		["3084_MovementVelocitySpeed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44282,7 +42195,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44308,7 +42220,6 @@ return {
 				["max"] = 20, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44322,7 +42233,6 @@ return {
 				["max"] = 60, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44340,7 +42250,6 @@ return {
 				["max"] = 35, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44406,7 +42315,6 @@ return {
 				["max"] = 6, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44416,7 +42324,6 @@ return {
 			}, 
 		}, 
 		["3129_ArcaneSurgeEffect"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44426,7 +42333,6 @@ return {
 			}, 
 		}, 
 		["3131_OnslaughtEffect"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44444,7 +42350,6 @@ return {
 				["max"] = 100, 
 				["min"] = 80, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44458,7 +42363,7 @@ return {
 				["max"] = -3, 
 				["min"] = -5, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44508,7 +42413,6 @@ return {
 				["max"] = 20, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44522,7 +42426,6 @@ return {
 				["max"] = 14, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44536,7 +42439,6 @@ return {
 				["max"] = 50, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44550,7 +42452,6 @@ return {
 				["max"] = 30, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44564,7 +42465,6 @@ return {
 				["max"] = 35, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44602,7 +42502,6 @@ return {
 				["max"] = 45, 
 				["min"] = 35, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44620,7 +42519,6 @@ return {
 				["max"] = 14, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44638,7 +42536,6 @@ return {
 				["max"] = 14, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44672,7 +42569,6 @@ return {
 				["max"] = 40, 
 				["min"] = 28, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44686,7 +42582,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44700,7 +42595,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44734,7 +42628,6 @@ return {
 				["max"] = 40, 
 				["min"] = 28, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44748,7 +42641,6 @@ return {
 				["max"] = 35, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44782,7 +42674,6 @@ return {
 				["max"] = 40, 
 				["min"] = 28, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44813,7 +42704,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44839,7 +42729,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44857,7 +42746,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44883,7 +42771,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44901,7 +42788,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44927,7 +42813,6 @@ return {
 				["max"] = 10, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44945,7 +42830,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -44975,7 +42859,6 @@ return {
 				["max"] = 25, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45029,7 +42912,6 @@ return {
 				["max"] = 25, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45039,7 +42921,6 @@ return {
 			}, 
 		}, 
 		["3228_LightningDamageTaken"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45049,7 +42930,6 @@ return {
 			}, 
 		}, 
 		["3229_ColdDamageTakenPercentage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45067,7 +42947,6 @@ return {
 				["max"] = 20, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45124,7 +43003,6 @@ return {
 				["max"] = 100, 
 				["min"] = 80, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45142,7 +43020,6 @@ return {
 				["max"] = 8, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45160,7 +43037,6 @@ return {
 				["max"] = 60, 
 				["min"] = 41, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45231,7 +43107,6 @@ return {
 				["max"] = 2, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45241,7 +43116,6 @@ return {
 			}, 
 		}, 
 		["3298_TrapCooldownRecoveryAndDuration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45279,7 +43153,6 @@ return {
 				["max"] = 25, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45289,7 +43162,6 @@ return {
 			}, 
 		}, 
 		["3311_ChanceToLoseManaOnSkillUse"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45303,7 +43175,6 @@ return {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45313,7 +43184,6 @@ return {
 			}, 
 		}, 
 		["3316_TrapAreaOfEffect"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45340,7 +43210,6 @@ return {
 				["max"] = 3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45366,7 +43235,6 @@ return {
 				["max"] = 25, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45384,7 +43252,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45394,7 +43261,6 @@ return {
 			}, 
 		}, 
 		["3403_AuraEffectOnEnemies"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45460,7 +43326,6 @@ return {
 				["max"] = 16, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45522,7 +43387,6 @@ return {
 				["max"] = 16, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45584,7 +43448,6 @@ return {
 				["max"] = 12, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45594,7 +43457,6 @@ return {
 			}, 
 		}, 
 		["3595_LocalFireDamageAndPen"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45656,7 +43518,6 @@ return {
 				["max"] = 7, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45666,7 +43527,6 @@ return {
 			}, 
 		}, 
 		["3595_LocalFireDamageTwoHandAndPen"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45728,7 +43588,6 @@ return {
 				["max"] = 15, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45738,7 +43597,6 @@ return {
 			}, 
 		}, 
 		["3596_LocalColdDamageAndPen"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45800,7 +43658,6 @@ return {
 				["max"] = 7, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45810,7 +43667,6 @@ return {
 			}, 
 		}, 
 		["3596_LocalColdDamageTwoHandAndPen"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45872,7 +43728,6 @@ return {
 				["max"] = 15, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45882,7 +43737,6 @@ return {
 			}, 
 		}, 
 		["3597_LocalLightningDamageAndPen"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45944,7 +43798,6 @@ return {
 				["max"] = 7, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -45954,7 +43807,6 @@ return {
 			}, 
 		}, 
 		["3597_LocalLightningDamageTwoHandAndPen"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46016,7 +43868,6 @@ return {
 				["max"] = 15, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46034,7 +43885,6 @@ return {
 				["max"] = 32.5, 
 				["min"] = 3.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46052,7 +43902,6 @@ return {
 				["max"] = 43, 
 				["min"] = 5.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46070,7 +43919,6 @@ return {
 				["max"] = 43, 
 				["min"] = 5.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46088,7 +43936,6 @@ return {
 				["max"] = 41.5, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46106,7 +43953,6 @@ return {
 				["max"] = 32.5, 
 				["min"] = 3.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46120,7 +43966,6 @@ return {
 				["max"] = 25, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46134,7 +43979,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46148,7 +43992,6 @@ return {
 				["max"] = 25, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46162,7 +44005,6 @@ return {
 				["max"] = 25, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46176,7 +44018,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46190,7 +44031,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46244,7 +44084,6 @@ return {
 				["max"] = 20, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46258,7 +44097,6 @@ return {
 				["max"] = 25, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46272,7 +44110,6 @@ return {
 				["max"] = 25, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46290,7 +44127,6 @@ return {
 				["max"] = 20, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46340,7 +44176,6 @@ return {
 				["max"] = 20, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46354,7 +44189,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46408,7 +44242,6 @@ return {
 				["max"] = 20, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46422,7 +44255,6 @@ return {
 				["max"] = 35, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46436,7 +44268,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46486,7 +44317,6 @@ return {
 				["max"] = 20, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46500,7 +44330,6 @@ return {
 				["max"] = 40, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46526,7 +44355,6 @@ return {
 				["max"] = 20, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46540,7 +44368,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46590,7 +44417,6 @@ return {
 				["max"] = 20, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46600,7 +44426,6 @@ return {
 			}, 
 		}, 
 		["401_LocalIncreasedPhysicalDamagePercentFasterProjectiles"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46614,7 +44439,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46628,7 +44452,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46642,7 +44465,6 @@ return {
 				["max"] = 70, 
 				["min"] = 41, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46676,7 +44498,6 @@ return {
 				["max"] = 50, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46686,7 +44507,6 @@ return {
 			}, 
 		}, 
 		["4046_MovementVelocityDodge"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46712,7 +44532,6 @@ return {
 				["max"] = 35, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46766,7 +44585,6 @@ return {
 				["max"] = 20, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46776,7 +44594,6 @@ return {
 			}, 
 		}, 
 		["4060_FlaskChanceToNotConsumeCharges"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46790,7 +44607,6 @@ return {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46844,7 +44660,6 @@ return {
 				["max"] = 20, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46862,7 +44677,6 @@ return {
 				["max"] = 4, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46880,7 +44694,6 @@ return {
 				["max"] = 18, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46898,7 +44711,6 @@ return {
 				["max"] = 400, 
 				["min"] = 105, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46912,7 +44724,6 @@ return {
 				["max"] = 5, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46922,7 +44733,6 @@ return {
 			}, 
 		}, 
 		["4098_AdditionalPhysicalDamageReductionDuringFlaskEffect"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46936,7 +44746,6 @@ return {
 				["max"] = 25, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46954,7 +44763,6 @@ return {
 				["max"] = 25, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46977,7 +44785,6 @@ return {
 			}, 
 		}, 
 		["4102_SelfColdDamageTakenPerFrenzy"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -46995,7 +44802,6 @@ return {
 				["max"] = 5.5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47009,7 +44815,6 @@ return {
 				["max"] = 80, 
 				["min"] = 80, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47023,7 +44828,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47037,7 +44841,6 @@ return {
 				["max"] = 20, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47055,7 +44858,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47073,7 +44875,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47083,7 +44884,6 @@ return {
 			}, 
 		}, 
 		["413_WeaponSpellDamageReducedMana"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47097,7 +44897,6 @@ return {
 				["max"] = 5, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47107,7 +44906,6 @@ return {
 			}, 
 		}, 
 		["4143_PhysicalDamageReductionWhileNotMoving"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47121,7 +44919,6 @@ return {
 				["max"] = 20, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47135,7 +44932,6 @@ return {
 				["max"] = 25, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47145,7 +44941,6 @@ return {
 			}, 
 		}, 
 		["415_LocalPhysicalDamagePercentFortify"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47175,7 +44970,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47189,7 +44983,6 @@ return {
 				["max"] = 25, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47203,7 +44996,6 @@ return {
 				["max"] = 25, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47229,7 +45021,6 @@ return {
 				["max"] = 20, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47243,7 +45034,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47257,7 +45047,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47275,7 +45064,6 @@ return {
 				["max"] = 20, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47289,7 +45077,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47303,7 +45090,6 @@ return {
 				["max"] = 800, 
 				["min"] = 500, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47313,7 +45099,6 @@ return {
 			}, 
 		}, 
 		["4286_AccuracyPer2Dexterity"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47327,7 +45112,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47337,7 +45121,6 @@ return {
 			}, 
 		}, 
 		["4290_AccuracyIfNoEnemySlainRecently"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47351,7 +45134,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47377,7 +45159,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47399,7 +45180,6 @@ return {
 				["max"] = 20, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47413,7 +45193,6 @@ return {
 				["max"] = 5, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47427,7 +45206,6 @@ return {
 				["max"] = 15, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47441,7 +45219,6 @@ return {
 				["max"] = 20, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47459,7 +45236,6 @@ return {
 				["max"] = 15, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47477,7 +45253,6 @@ return {
 				["max"] = 2, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47495,7 +45270,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47509,7 +45283,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47536,7 +45309,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47550,7 +45322,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47596,7 +45367,6 @@ return {
 				["max"] = 20, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47610,7 +45380,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47628,7 +45397,6 @@ return {
 				["max"] = 20, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47642,7 +45410,6 @@ return {
 				["max"] = 25, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47652,7 +45419,6 @@ return {
 			}, 
 		}, 
 		["4420_AngerReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47666,7 +45432,6 @@ return {
 				["max"] = 50, 
 				["min"] = 40, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47692,7 +45457,6 @@ return {
 				["max"] = 20, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47702,7 +45466,6 @@ return {
 			}, 
 		}, 
 		["443_LocalPhysicalDamagePercentEnduranceChargeOnStun"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47732,7 +45495,6 @@ return {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47742,7 +45504,6 @@ return {
 			}, 
 		}, 
 		["4445_ArcticArmourReservationCost"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47752,7 +45513,6 @@ return {
 			}, 
 		}, 
 		["4446_ArcticArmourReservationEfficiency"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47790,7 +45550,6 @@ return {
 				["max"] = 25, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47816,7 +45575,6 @@ return {
 				["max"] = 45, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47830,7 +45588,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47856,7 +45613,6 @@ return {
 				["max"] = 3, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47874,7 +45630,6 @@ return {
 				["max"] = 5, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47888,7 +45643,6 @@ return {
 				["max"] = 3, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47911,7 +45665,6 @@ return {
 				["max"] = 500, 
 				["min"] = 500, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47929,7 +45682,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47943,7 +45695,6 @@ return {
 				["max"] = 2, 
 				["min"] = 0.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47953,7 +45704,6 @@ return {
 			}, 
 		}, 
 		["451_DisplaySupportedSkillsHaveAChanceToIgnite"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47967,7 +45717,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47981,7 +45730,6 @@ return {
 				["max"] = 12, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -47995,7 +45743,6 @@ return {
 				["max"] = 50, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48013,7 +45760,6 @@ return {
 				["max"] = 10, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48031,7 +45777,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48045,7 +45790,6 @@ return {
 				["max"] = 3.5, 
 				["min"] = 3.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48091,7 +45835,6 @@ return {
 				["max"] = 4, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48129,7 +45872,6 @@ return {
 				["max"] = 3.5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48155,7 +45897,6 @@ return {
 				["max"] = 30, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48189,7 +45930,6 @@ return {
 				["max"] = 20, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48203,7 +45943,6 @@ return {
 				["max"] = 12, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48221,7 +45960,6 @@ return {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48283,7 +46021,6 @@ return {
 				["max"] = 15, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48293,7 +46030,6 @@ return {
 			}, 
 		}, 
 		["4622_IncreasedAttackSpeedPerDexterity"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48311,7 +46047,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48373,7 +46108,6 @@ return {
 				["max"] = 40, 
 				["min"] = 40, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48431,7 +46165,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48465,7 +46198,6 @@ return {
 				["max"] = 8, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48479,7 +46211,6 @@ return {
 				["max"] = 20, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48493,7 +46224,6 @@ return {
 				["max"] = 25, 
 				["min"] = 21, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48511,7 +46241,6 @@ return {
 				["max"] = 7, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48525,7 +46254,6 @@ return {
 				["max"] = 4, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48535,7 +46263,6 @@ return {
 			}, 
 		}, 
 		["4640_IntimidateOnHit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48581,7 +46308,6 @@ return {
 				["max"] = 3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48595,7 +46321,6 @@ return {
 				["max"] = 90, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48613,7 +46338,6 @@ return {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48631,7 +46355,6 @@ return {
 				["max"] = 12, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48642,22 +46365,21 @@ return {
 		}, 
 		["465_SocketedAttacksManaCost"] = {
 			["Boots"] = {
-				["max"] = 15, 
-				["min"] = 15, 
+				["max"] = -15, 
+				["min"] = -15, 
 			}, 
 			["Chest"] = {
-				["max"] = 15, 
-				["min"] = 15, 
+				["max"] = -15, 
+				["min"] = -15, 
 			}, 
 			["Helmet"] = {
-				["max"] = 15, 
-				["min"] = 15, 
+				["max"] = -15, 
+				["min"] = -15, 
 			}, 
 			["Shield"] = {
-				["max"] = 15, 
-				["min"] = 15, 
+				["max"] = -15, 
+				["min"] = -15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48668,10 +46390,9 @@ return {
 		}, 
 		["465_SocketedAttacksManaCostMaven"] = {
 			["Chest"] = {
-				["max"] = 20, 
-				["min"] = 20, 
+				["max"] = -20, 
+				["min"] = -20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48685,7 +46406,6 @@ return {
 				["max"] = 15, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48699,7 +46419,6 @@ return {
 				["max"] = 16, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48713,7 +46432,6 @@ return {
 				["max"] = 30, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48751,7 +46469,6 @@ return {
 				["max"] = 40, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48765,7 +46482,6 @@ return {
 				["max"] = 30, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48779,7 +46495,6 @@ return {
 				["max"] = 12, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48793,7 +46508,6 @@ return {
 				["max"] = 12, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48811,7 +46525,6 @@ return {
 				["max"] = 16, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48825,7 +46538,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48835,7 +46547,6 @@ return {
 			}, 
 		}, 
 		["4706_BleedDuration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48849,7 +46560,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48875,7 +46585,6 @@ return {
 				["max"] = 20, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48889,7 +46598,6 @@ return {
 				["max"] = 0.4, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48903,7 +46611,6 @@ return {
 				["max"] = 0.4, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48917,7 +46624,6 @@ return {
 				["max"] = 0.4, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48931,7 +46637,7 @@ return {
 				["max"] = -11, 
 				["min"] = -20, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48945,7 +46651,6 @@ return {
 				["max"] = 200, 
 				["min"] = 200, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -48979,7 +46684,6 @@ return {
 				["max"] = 20, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49013,7 +46717,6 @@ return {
 				["max"] = 20, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49047,7 +46750,6 @@ return {
 				["max"] = 20, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49057,7 +46759,6 @@ return {
 			}, 
 		}, 
 		["4739_MinionDuration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49071,7 +46772,6 @@ return {
 				["max"] = 50, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49093,7 +46793,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49145,7 +46844,6 @@ return {
 				["max"] = 18, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49159,7 +46857,6 @@ return {
 				["max"] = 18, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49238,7 +46935,6 @@ return {
 				["max"] = 40, 
 				["min"] = 40, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49252,7 +46948,6 @@ return {
 				["max"] = 4, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49266,7 +46961,6 @@ return {
 				["max"] = 90, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49288,7 +46982,6 @@ return {
 				["max"] = 20, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49311,7 +47004,6 @@ return {
 				["max"] = 8, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49402,7 +47094,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLineSingular"] = "Has 1 Abyssal Socket", 
 			}, 
@@ -49439,7 +47130,6 @@ return {
 				["max"] = 30, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49453,7 +47143,6 @@ return {
 				["max"] = 14, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49487,7 +47176,6 @@ return {
 				["max"] = 20, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49505,7 +47193,6 @@ return {
 				["max"] = 20, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49523,7 +47210,6 @@ return {
 				["max"] = 7, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49541,7 +47227,6 @@ return {
 				["max"] = 10, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49567,7 +47252,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49581,7 +47265,6 @@ return {
 				["max"] = 25, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49615,7 +47298,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49681,7 +47363,6 @@ return {
 				["max"] = 7, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49695,7 +47376,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49761,7 +47441,6 @@ return {
 				["max"] = 20, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49799,7 +47478,6 @@ return {
 				["max"] = 20, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49825,7 +47503,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49839,7 +47516,6 @@ return {
 				["max"] = 4, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49853,7 +47529,6 @@ return {
 				["max"] = 12, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49879,7 +47554,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49905,7 +47579,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49923,7 +47596,6 @@ return {
 				["max"] = 30, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49949,7 +47621,6 @@ return {
 				["max"] = 25, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49975,7 +47646,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -49989,7 +47659,6 @@ return {
 				["max"] = 10, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50027,7 +47696,6 @@ return {
 				["max"] = 15, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50037,7 +47705,6 @@ return {
 			}, 
 		}, 
 		["5314_SpellUnnerveOnHit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50072,7 +47739,6 @@ return {
 				["max"] = 40, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50086,7 +47752,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50108,7 +47773,6 @@ return {
 				["max"] = 50, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50118,7 +47782,6 @@ return {
 			}, 
 		}, 
 		["5382_ColdAilmentDuration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50136,7 +47799,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50150,7 +47812,6 @@ return {
 				["max"] = 20, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50248,7 +47909,6 @@ return {
 				["max"] = 15, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50262,7 +47922,6 @@ return {
 				["max"] = 10, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50285,7 +47944,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50325,7 +47983,6 @@ return {
 				["max"] = 45, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50335,7 +47992,6 @@ return {
 			}, 
 		}, 
 		["5491_LightningResistanceAilments"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50378,7 +48034,6 @@ return {
 				["max"] = 50, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50412,7 +48067,6 @@ return {
 				["max"] = 50, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50426,7 +48080,6 @@ return {
 				["max"] = 75, 
 				["min"] = 45, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50444,7 +48097,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50462,7 +48114,6 @@ return {
 				["max"] = 100, 
 				["min"] = 80, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50476,7 +48127,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50506,7 +48156,6 @@ return {
 				["max"] = 35, 
 				["min"] = 26, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50520,7 +48169,6 @@ return {
 				["max"] = 30, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50554,7 +48202,6 @@ return {
 				["max"] = 50, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50616,7 +48263,6 @@ return {
 				["max"] = 40, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50634,7 +48280,6 @@ return {
 				["max"] = 45, 
 				["min"] = 35, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50648,7 +48293,6 @@ return {
 				["max"] = 20, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50662,7 +48306,6 @@ return {
 				["max"] = 20, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50680,7 +48323,7 @@ return {
 				["max"] = -10, 
 				["min"] = -15, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50690,7 +48333,6 @@ return {
 			}, 
 		}, 
 		["5576_CurseDuration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50704,7 +48346,6 @@ return {
 				["max"] = 50, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50722,7 +48363,6 @@ return {
 				["max"] = 2, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50740,7 +48380,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50754,7 +48393,6 @@ return {
 				["max"] = 50, 
 				["min"] = 36, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50768,7 +48406,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50782,7 +48419,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50796,7 +48432,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50810,7 +48445,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50876,7 +48510,6 @@ return {
 				["max"] = 10, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50890,7 +48523,6 @@ return {
 				["max"] = 3, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50908,7 +48540,6 @@ return {
 				["max"] = 40, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50918,7 +48549,6 @@ return {
 			}, 
 		}, 
 		["5643_ColdResistanceAilments"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50932,7 +48562,6 @@ return {
 				["max"] = 40, 
 				["min"] = 26, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -50994,7 +48623,6 @@ return {
 				["max"] = 120, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51012,7 +48640,6 @@ return {
 				["max"] = 80, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51026,7 +48653,6 @@ return {
 				["max"] = 22, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51040,7 +48666,6 @@ return {
 				["max"] = 15, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51058,7 +48683,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51072,7 +48696,7 @@ return {
 				["max"] = -4, 
 				["min"] = -7, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51090,7 +48714,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51124,7 +48747,6 @@ return {
 				["max"] = 40, 
 				["min"] = 28, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51134,7 +48756,6 @@ return {
 			}, 
 		}, 
 		["5736_DeterminationReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51148,7 +48769,6 @@ return {
 				["max"] = 50, 
 				["min"] = 40, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51158,7 +48778,6 @@ return {
 			}, 
 		}, 
 		["5741_GlobalDexterityGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51168,7 +48787,6 @@ return {
 			}, 
 		}, 
 		["5748_DisciplineReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51182,7 +48800,6 @@ return {
 				["max"] = 60, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51200,7 +48817,6 @@ return {
 				["max"] = 30, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51282,7 +48898,6 @@ return {
 				["max"] = 59, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51336,7 +48951,6 @@ return {
 				["max"] = 37, 
 				["min"] = 28, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51354,7 +48968,6 @@ return {
 				["max"] = 55, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51368,7 +48981,6 @@ return {
 				["max"] = 100, 
 				["min"] = 100, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51382,7 +48994,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51396,7 +49007,6 @@ return {
 				["max"] = 35, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51406,7 +49016,6 @@ return {
 			}, 
 		}, 
 		["5922_EnemiesExplodeOnDeathPhysical"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51420,7 +49029,6 @@ return {
 				["max"] = 5, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51438,7 +49046,7 @@ return {
 				["max"] = -15, 
 				["min"] = -20, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51456,7 +49064,7 @@ return {
 				["max"] = -15, 
 				["min"] = -20, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51474,7 +49082,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51492,7 +49099,6 @@ return {
 				["max"] = 5, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51503,14 +49109,13 @@ return {
 		}, 
 		["5963_EnchantmentWither"] = {
 			["AbyssJewel"] = {
-				["max"] = 2, 
-				["min"] = 2, 
+				["max"] = -2, 
+				["min"] = -2, 
 			}, 
 			["AnyJewel"] = {
-				["max"] = 2, 
-				["min"] = 2, 
+				["max"] = -2, 
+				["min"] = -2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51528,7 +49133,6 @@ return {
 				["max"] = 20, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51542,7 +49146,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51560,7 +49163,6 @@ return {
 				["max"] = 200, 
 				["min"] = 90, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51610,7 +49212,6 @@ return {
 				["max"] = 0.5, 
 				["min"] = 0.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51628,7 +49229,6 @@ return {
 				["max"] = 20, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51646,7 +49246,6 @@ return {
 				["max"] = 32, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51669,7 +49268,6 @@ return {
 				["max"] = 1.5, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51727,7 +49325,6 @@ return {
 				["max"] = 500, 
 				["min"] = 500, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51753,7 +49350,6 @@ return {
 				["max"] = 50, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51771,7 +49367,6 @@ return {
 				["max"] = 35, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51847,7 +49442,6 @@ return {
 				["max"] = 25, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51861,7 +49455,6 @@ return {
 				["max"] = 15, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51903,7 +49496,6 @@ return {
 				["max"] = 15, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -51917,7 +49509,6 @@ return {
 				["max"] = 15, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52015,7 +49606,6 @@ return {
 				["max"] = 15, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52029,7 +49619,6 @@ return {
 				["max"] = 10, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52052,7 +49641,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52066,7 +49654,6 @@ return {
 				["max"] = 35, 
 				["min"] = 21, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52080,7 +49667,6 @@ return {
 				["max"] = 8, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52094,7 +49680,6 @@ return {
 				["max"] = 8, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52108,7 +49693,6 @@ return {
 				["max"] = 8, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52122,7 +49706,6 @@ return {
 				["max"] = 8, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52132,7 +49715,7 @@ return {
 			}, 
 		}, 
 		["6183_ShockYourselfOnFocusCDR"] = {
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52142,7 +49725,6 @@ return {
 			}, 
 		}, 
 		["6183_SkillsCostNoManaWhileFocusedCDR"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52156,7 +49738,6 @@ return {
 				["max"] = 8, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52174,7 +49755,6 @@ return {
 				["max"] = 40, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52218,7 +49798,6 @@ return {
 				["max"] = 30, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52280,7 +49859,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52294,7 +49872,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52308,7 +49885,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52322,7 +49898,6 @@ return {
 				["max"] = 7, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52336,7 +49911,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52350,7 +49924,6 @@ return {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52425,7 +49998,6 @@ return {
 				["max"] = 37, 
 				["min"] = 26, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52439,7 +50011,6 @@ return {
 				["max"] = 42, 
 				["min"] = 28.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52453,7 +50024,6 @@ return {
 				["max"] = 47, 
 				["min"] = 35.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52463,7 +50033,6 @@ return {
 			}, 
 		}, 
 		["6401_GraceReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52477,7 +50046,6 @@ return {
 				["max"] = 50, 
 				["min"] = 40, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52487,7 +50055,6 @@ return {
 			}, 
 		}, 
 		["6432_HatredReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52501,7 +50068,6 @@ return {
 				["max"] = 50, 
 				["min"] = 40, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52511,7 +50077,6 @@ return {
 			}, 
 		}, 
 		["647_CurseOnHitCriticalWeakness"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52521,7 +50086,6 @@ return {
 			}, 
 		}, 
 		["648_CurseOnHitPoachersMark"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52531,7 +50095,6 @@ return {
 			}, 
 		}, 
 		["650_CurseOnHitWarlordsMark"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52545,7 +50108,6 @@ return {
 				["max"] = 50, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52559,7 +50121,6 @@ return {
 				["max"] = 50, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52569,7 +50130,6 @@ return {
 			}, 
 		}, 
 		["6623_ArcaneSurgeOnSpendingMana"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52579,7 +50139,6 @@ return {
 			}, 
 		}, 
 		["6633_HitAndAilmentDamageCursedEnemies"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52617,7 +50176,6 @@ return {
 				["max"] = 35, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52770,7 +50328,6 @@ return {
 				["max"] = 38, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52780,7 +50337,6 @@ return {
 			}, 
 		}, 
 		["6757_GlobalIntelligenceGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52855,7 +50411,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52869,7 +50424,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52883,7 +50437,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52893,7 +50446,6 @@ return {
 			}, 
 		}, 
 		["6819_EnemyLifeLeechPermyriadWhileFocusedAndVaalPact"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52903,7 +50455,6 @@ return {
 			}, 
 		}, 
 		["682_TriggerOnRareAssassinsMark"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52917,7 +50468,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52935,7 +50485,6 @@ return {
 				["max"] = 1, 
 				["min"] = 0.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52945,7 +50494,6 @@ return {
 			}, 
 		}, 
 		["687_TriggerOnRarePoachersMark"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52955,7 +50503,6 @@ return {
 			}, 
 		}, 
 		["6880_LifeRegenerationRatePerMinuteWhileUsingFlask"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52973,7 +50520,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52983,7 +50529,6 @@ return {
 			}, 
 		}, 
 		["6887_LightningAilmentEffect"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -52997,7 +50542,6 @@ return {
 				["max"] = 15, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53011,7 +50555,6 @@ return {
 				["max"] = 20, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53109,7 +50652,6 @@ return {
 				["max"] = 15, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53119,7 +50661,6 @@ return {
 			}, 
 		}, 
 		["689_TriggerOnRareWarlordsMark"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53133,7 +50674,6 @@ return {
 				["max"] = 10, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53156,7 +50696,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53165,12 +50704,24 @@ return {
 				["type"] = "explicit", 
 			}, 
 		}, 
+		["70_LocalIncreasedBlockPercentage"] = {
+			["Shield"] = {
+				["max"] = 81, 
+				["min"] = 31, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "explicit.stat_2481353198", 
+				["text"] = "#% increased Chance to Block", 
+				["type"] = "explicit", 
+			}, 
+		}, 
 		["718_FlaskExtraMaxCharges"] = {
 			["Flask"] = {
 				["max"] = 35, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53193,7 +50744,6 @@ return {
 				["max"] = 3, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53203,7 +50753,6 @@ return {
 			}, 
 		}, 
 		["722_FlaskFullRechargeOnCrit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53217,7 +50766,6 @@ return {
 				["max"] = 35, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53231,7 +50779,6 @@ return {
 				["max"] = 50, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53245,7 +50792,6 @@ return {
 				["max"] = 66, 
 				["min"] = 37, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53259,7 +50805,7 @@ return {
 				["max"] = -14, 
 				["min"] = -28, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53273,7 +50819,6 @@ return {
 				["max"] = 25, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53335,7 +50880,6 @@ return {
 				["max"] = 25, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53349,7 +50893,6 @@ return {
 				["max"] = 60, 
 				["min"] = 35, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53411,7 +50954,6 @@ return {
 				["max"] = 59, 
 				["min"] = 37, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53473,7 +51015,6 @@ return {
 				["max"] = 60, 
 				["min"] = 60, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53535,7 +51076,6 @@ return {
 				["max"] = 60, 
 				["min"] = 60, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53549,7 +51089,6 @@ return {
 				["max"] = 200, 
 				["min"] = 100, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53611,7 +51150,6 @@ return {
 				["max"] = 15, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53673,7 +51211,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53735,7 +51272,6 @@ return {
 				["max"] = 16, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53791,7 +51327,6 @@ return {
 				["max"] = 70, 
 				["min"] = 41, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53802,10 +51337,9 @@ return {
 		}, 
 		["7356_NearbyEnemyChaosDamageResistance"] = {
 			["Helmet"] = {
-				["max"] = 12, 
-				["min"] = 9, 
+				["max"] = -9, 
+				["min"] = -12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53816,10 +51350,9 @@ return {
 		}, 
 		["7357_NearbyEnemyColdDamageResistance"] = {
 			["Helmet"] = {
-				["max"] = 12, 
-				["min"] = 9, 
+				["max"] = -9, 
+				["min"] = -12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53833,7 +51366,6 @@ return {
 				["max"] = 9, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53844,10 +51376,9 @@ return {
 		}, 
 		["7359_NearbyEnemyFireDamageResistance"] = {
 			["Helmet"] = {
-				["max"] = 12, 
-				["min"] = 9, 
+				["max"] = -9, 
+				["min"] = -12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53861,7 +51392,7 @@ return {
 				["max"] = -66, 
 				["min"] = -66, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53875,7 +51406,7 @@ return {
 				["max"] = -66, 
 				["min"] = -66, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53889,7 +51420,6 @@ return {
 				["max"] = 50, 
 				["min"] = 21, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53903,7 +51433,6 @@ return {
 				["max"] = 70, 
 				["min"] = 41, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53917,7 +51446,7 @@ return {
 				["max"] = -11, 
 				["min"] = -30, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53931,7 +51460,6 @@ return {
 				["max"] = 66, 
 				["min"] = 66, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53945,7 +51473,7 @@ return {
 				["max"] = -36, 
 				["min"] = -55, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53956,10 +51484,9 @@ return {
 		}, 
 		["7361_NearbyEnemyLightningDamageResistance"] = {
 			["Helmet"] = {
-				["max"] = 12, 
-				["min"] = 9, 
+				["max"] = -9, 
+				["min"] = -12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53973,7 +51500,6 @@ return {
 				["max"] = 12, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -53987,7 +51513,7 @@ return {
 				["max"] = -33, 
 				["min"] = -33, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54001,7 +51527,6 @@ return {
 				["max"] = 70, 
 				["min"] = 41, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54015,7 +51540,6 @@ return {
 				["max"] = 135, 
 				["min"] = 135, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54077,7 +51601,6 @@ return {
 				["max"] = 80, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54087,7 +51610,6 @@ return {
 			}, 
 		}, 
 		["7387_DexterityAndLocalItemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54097,7 +51619,6 @@ return {
 			}, 
 		}, 
 		["7387_IntelligenceAndLocalItemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54107,7 +51628,6 @@ return {
 			}, 
 		}, 
 		["7387_LocalAccuracyRatingAndLocalItemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54117,7 +51637,6 @@ return {
 			}, 
 		}, 
 		["7387_LocalAttackSpeedAndLocalItemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54127,7 +51646,6 @@ return {
 			}, 
 		}, 
 		["7387_LocalCriticalStrikeChanceAndLocalItemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54145,7 +51663,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54155,7 +51672,6 @@ return {
 			}, 
 		}, 
 		["7387_StrengthAndLocalItemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54169,7 +51685,7 @@ return {
 				["max"] = -23, 
 				["min"] = -38, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54183,7 +51699,6 @@ return {
 				["max"] = 40, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54197,7 +51712,7 @@ return {
 				["max"] = -35, 
 				["min"] = -49, 
 			}, 
-			["inverseKey"] = "less", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54211,7 +51726,7 @@ return {
 				["max"] = -35, 
 				["min"] = -49, 
 			}, 
-			["inverseKey"] = "less", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54225,7 +51740,7 @@ return {
 				["max"] = -35, 
 				["min"] = -49, 
 			}, 
-			["inverseKey"] = "less", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54239,7 +51754,7 @@ return {
 				["max"] = -35, 
 				["min"] = -49, 
 			}, 
-			["inverseKey"] = "less", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54253,7 +51768,7 @@ return {
 				["max"] = -35, 
 				["min"] = -49, 
 			}, 
-			["inverseKey"] = "less", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54267,7 +51782,6 @@ return {
 				["max"] = 130, 
 				["min"] = 101, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54285,7 +51799,6 @@ return {
 				["max"] = 50, 
 				["min"] = 35, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54348,7 +51861,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54394,7 +51906,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54408,7 +51919,6 @@ return {
 				["max"] = 50, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54454,7 +51964,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54464,7 +51973,6 @@ return {
 			}, 
 		}, 
 		["7433_LocalChanceToPoisonOnHit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% chance to Poison on Hit", 
 			}, 
@@ -54475,7 +51983,6 @@ return {
 			}, 
 		}, 
 		["7433_LocalChanceToPoisonOnHitChaosDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% chance to Poison on Hit", 
 			}, 
@@ -54538,7 +52045,6 @@ return {
 				["max"] = 25, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% chance to Poison on Hit", 
 			}, 
@@ -54549,7 +52055,6 @@ return {
 			}, 
 		}, 
 		["7433_PoisonDamageAndLocalChanceOnHit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% chance to Poison on Hit", 
 			}, 
@@ -54590,7 +52095,6 @@ return {
 				["max"] = 15, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54604,7 +52108,6 @@ return {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54618,7 +52121,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54628,7 +52130,6 @@ return {
 			}, 
 		}, 
 		["7572_MalevolenceReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54642,7 +52143,6 @@ return {
 				["max"] = 50, 
 				["min"] = 40, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54656,7 +52156,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54670,7 +52169,6 @@ return {
 				["max"] = 3, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54680,7 +52178,6 @@ return {
 			}, 
 		}, 
 		["7594_ManaGainedOnBlock"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54694,7 +52191,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54708,7 +52204,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54774,7 +52269,6 @@ return {
 				["max"] = 0.4, 
 				["min"] = 0.4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54796,7 +52290,6 @@ return {
 				["max"] = 70, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54823,7 +52316,6 @@ return {
 				["max"] = 40, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54837,7 +52329,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54851,7 +52342,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54861,7 +52351,6 @@ return {
 			}, 
 		}, 
 		["786_FlaskDispellsPoison"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54875,7 +52364,6 @@ return {
 				["max"] = 17, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54911,7 +52399,6 @@ return {
 				["max"] = 40, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54925,7 +52412,6 @@ return {
 				["max"] = 40, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54939,7 +52425,6 @@ return {
 				["max"] = 25, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54953,7 +52438,7 @@ return {
 				["max"] = -25, 
 				["min"] = -25, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54976,7 +52461,6 @@ return {
 				["max"] = 60, 
 				["min"] = 41, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -54990,7 +52474,6 @@ return {
 				["max"] = 60, 
 				["min"] = 41, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55004,7 +52487,6 @@ return {
 				["max"] = 30, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55014,7 +52496,6 @@ return {
 			}, 
 		}, 
 		["821_FlaskBuffAccuracyWhileHealing"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55024,7 +52505,6 @@ return {
 			}, 
 		}, 
 		["822_FlaskBuffAttackSpeedWhileHealing"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55034,7 +52514,6 @@ return {
 			}, 
 		}, 
 		["823_FlaskBuffCastSpeedWhileHealing"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55048,7 +52527,6 @@ return {
 				["max"] = 14, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55062,7 +52540,6 @@ return {
 				["max"] = 80, 
 				["min"] = 51, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55076,7 +52553,6 @@ return {
 				["max"] = 20, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55086,7 +52562,6 @@ return {
 			}, 
 		}, 
 		["827_FlaskBuffLifeLeechWhileHealing"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55100,7 +52575,6 @@ return {
 				["max"] = 0.8, 
 				["min"] = 0.4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55114,7 +52588,6 @@ return {
 				["max"] = 0.8, 
 				["min"] = 0.4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55124,7 +52597,6 @@ return {
 			}, 
 		}, 
 		["830_FlaskBuffLifeLeechPermyriadWhileHealing"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55134,7 +52606,6 @@ return {
 			}, 
 		}, 
 		["832_FlaskBuffManaLeechPermyriadWhileHealing"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55157,7 +52628,6 @@ return {
 				["max"] = 55, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55171,7 +52641,6 @@ return {
 				["max"] = 55, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55185,7 +52654,6 @@ return {
 				["max"] = 55, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55199,7 +52667,6 @@ return {
 				["max"] = 55, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55225,7 +52692,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55239,7 +52705,6 @@ return {
 				["max"] = 5, 
 				["min"] = 4.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55253,7 +52718,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55275,7 +52739,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55289,7 +52752,6 @@ return {
 				["max"] = 55, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55299,7 +52761,6 @@ return {
 			}, 
 		}, 
 		["849_LocalFlaskAvoidStunChanceAndMovementSpeedDuringFlaskEffect"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55313,7 +52774,6 @@ return {
 				["max"] = 50, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55323,7 +52783,6 @@ return {
 			}, 
 		}, 
 		["8501_LifeAddedAsEnergyShield"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55333,7 +52792,6 @@ return {
 			}, 
 		}, 
 		["8502_MaximumLifeConvertedToEnergyShield"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55343,7 +52801,6 @@ return {
 			}, 
 		}, 
 		["8510_ManaPer2Intelligence"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55357,7 +52814,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55371,7 +52827,6 @@ return {
 				["max"] = 34, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55385,7 +52840,6 @@ return {
 				["max"] = 35, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55412,7 +52866,6 @@ return {
 				["max"] = 50, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55426,7 +52879,6 @@ return {
 				["max"] = 55, 
 				["min"] = 26, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55440,7 +52892,6 @@ return {
 				["max"] = 60, 
 				["min"] = 40, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55450,7 +52901,6 @@ return {
 			}, 
 		}, 
 		["8550_MineAreaOfEffect"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55460,7 +52910,6 @@ return {
 			}, 
 		}, 
 		["8553_MineDetonationSpeedAndDuration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55478,7 +52927,6 @@ return {
 				["max"] = 28.5, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55492,7 +52940,6 @@ return {
 				["max"] = 37.5, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55502,7 +52949,6 @@ return {
 			}, 
 		}, 
 		["8564_ColdDamageToAttacksPerDexterity"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55516,7 +52962,6 @@ return {
 				["max"] = 37.5, 
 				["min"] = 19, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55530,7 +52975,6 @@ return {
 				["max"] = 5.5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55540,7 +52984,6 @@ return {
 			}, 
 		}, 
 		["8571_FireDamageToAttacksPerStrength"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55554,7 +52997,6 @@ return {
 				["max"] = 45.5, 
 				["min"] = 21, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55568,7 +53010,6 @@ return {
 				["max"] = 6.5, 
 				["min"] = 3.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55578,7 +53019,6 @@ return {
 			}, 
 		}, 
 		["8575_AddedLightningDamagePerShockedEnemyKilled"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55588,7 +53028,6 @@ return {
 			}, 
 		}, 
 		["8576_LightningDamageToAttacksPerIntelligence"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55602,7 +53041,6 @@ return {
 				["max"] = 14, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55629,7 +53067,6 @@ return {
 				["max"] = 3.5, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55643,7 +53080,6 @@ return {
 				["max"] = 14.5, 
 				["min"] = 9.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55661,7 +53097,6 @@ return {
 				["max"] = 250, 
 				["min"] = 95, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55679,7 +53114,6 @@ return {
 				["max"] = 624, 
 				["min"] = 80, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55693,7 +53127,6 @@ return {
 				["max"] = 30, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55711,7 +53144,6 @@ return {
 				["max"] = 26, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55746,7 +53178,6 @@ return {
 				["max"] = 25, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55756,7 +53187,6 @@ return {
 			}, 
 		}, 
 		["8601_MinionAttackAndCastSpeedIfEnemySlainRecently"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55774,7 +53204,6 @@ return {
 				["max"] = 6, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55784,7 +53213,6 @@ return {
 			}, 
 		}, 
 		["8608_MinionDamageOnWeaponDoubleDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55815,7 +53243,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55837,7 +53264,6 @@ return {
 				["max"] = 109, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55855,7 +53281,6 @@ return {
 				["max"] = 38, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55886,7 +53311,6 @@ return {
 				["max"] = 40, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55904,7 +53328,6 @@ return {
 				["max"] = 60, 
 				["min"] = 22, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55918,7 +53341,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55932,7 +53354,6 @@ return {
 				["max"] = 8, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55950,7 +53371,6 @@ return {
 				["max"] = 8, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55964,7 +53384,6 @@ return {
 				["max"] = 15, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55978,7 +53397,6 @@ return {
 				["max"] = 3, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -55992,7 +53410,6 @@ return {
 				["max"] = 100, 
 				["min"] = 100, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56006,7 +53423,6 @@ return {
 				["max"] = 100, 
 				["min"] = 100, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56020,7 +53436,6 @@ return {
 				["max"] = 80, 
 				["min"] = 45, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56030,7 +53445,7 @@ return {
 			}, 
 		}, 
 		["871_LocalFlaskSkillManaCostDuringFlaskEffect"] = {
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56060,7 +53475,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56078,7 +53492,6 @@ return {
 				["max"] = 4, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56088,7 +53501,6 @@ return {
 			}, 
 		}, 
 		["8736_MovementSpeedOnBurningChilledShockedGround"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56102,7 +53514,6 @@ return {
 				["max"] = 65, 
 				["min"] = 36, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56116,7 +53527,6 @@ return {
 				["max"] = 65, 
 				["min"] = 36, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56178,7 +53588,6 @@ return {
 				["max"] = 20, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56192,7 +53601,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56254,7 +53662,6 @@ return {
 				["max"] = 5, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56264,7 +53671,6 @@ return {
 			}, 
 		}, 
 		["8785_WeaponSpellDamageAddedAsChaos"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56278,7 +53684,7 @@ return {
 				["max"] = -36, 
 				["min"] = -65, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56292,7 +53698,6 @@ return {
 				["max"] = 15, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56322,7 +53727,6 @@ return {
 				["max"] = 25, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56349,7 +53753,7 @@ return {
 				["max"] = -36, 
 				["min"] = -65, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56402,7 +53806,6 @@ return {
 			}, 
 		}, 
 		["8897_SpiritAndPhantasmRefreshOnUnique"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56420,7 +53823,6 @@ return {
 				["max"] = 4, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56438,7 +53840,6 @@ return {
 				["max"] = 4000, 
 				["min"] = 1000, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56496,7 +53897,6 @@ return {
 				["max"] = 1000, 
 				["min"] = 1000, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56514,7 +53914,6 @@ return {
 				["max"] = 55, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56528,7 +53927,6 @@ return {
 				["max"] = 100, 
 				["min"] = 100, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56542,7 +53940,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56552,7 +53949,6 @@ return {
 			}, 
 		}, 
 		["8992_PrideReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56566,7 +53962,6 @@ return {
 				["max"] = 50, 
 				["min"] = 40, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56580,7 +53975,6 @@ return {
 				["max"] = 35, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56598,7 +53992,6 @@ return {
 				["max"] = 30, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56608,7 +54001,6 @@ return {
 			}, 
 		}, 
 		["9036_PurityOfFireReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56622,7 +54014,6 @@ return {
 				["max"] = 60, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56632,7 +54023,6 @@ return {
 			}, 
 		}, 
 		["9039_PurityOfIceReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56646,7 +54036,6 @@ return {
 				["max"] = 60, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56656,7 +54045,6 @@ return {
 			}, 
 		}, 
 		["9042_PurityOfLightningReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56670,7 +54058,6 @@ return {
 				["max"] = 60, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56680,7 +54067,6 @@ return {
 			}, 
 		}, 
 		["9050_Quiver1AdditionalPierceOld"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLineSingular"] = "Projectiles Pierce an additional Target", 
 			}, 
@@ -56691,7 +54077,6 @@ return {
 			}, 
 		}, 
 		["9051_Quiver2AdditionalPierceOld"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56701,7 +54086,6 @@ return {
 			}, 
 		}, 
 		["9070_SpiritAndPhantasmRefreshOnUnique"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56715,7 +54099,6 @@ return {
 				["max"] = 60, 
 				["min"] = 36, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56729,7 +54112,6 @@ return {
 				["max"] = 40, 
 				["min"] = 40, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56804,7 +54186,6 @@ return {
 			}, 
 		}, 
 		["9181_AllResistancesWithChaos"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56818,7 +54199,6 @@ return {
 				["max"] = 40, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56836,7 +54216,7 @@ return {
 				["max"] = -30, 
 				["min"] = -35, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56854,7 +54234,7 @@ return {
 				["max"] = -30, 
 				["min"] = -35, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56876,7 +54256,6 @@ return {
 				["max"] = 50, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56886,7 +54265,6 @@ return {
 			}, 
 		}, 
 		["9262_ShockYourselfOnFocusCDR"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56900,7 +54278,6 @@ return {
 				["max"] = 4, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56914,7 +54291,6 @@ return {
 				["max"] = 4, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56924,7 +54300,7 @@ return {
 			}, 
 		}, 
 		["9268_ChillAndShockEffectOnYouJewel"] = {
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56942,7 +54318,7 @@ return {
 				["max"] = -24, 
 				["min"] = -40, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56968,7 +54344,6 @@ return {
 				["max"] = 60, 
 				["min"] = 41, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -56982,7 +54357,6 @@ return {
 				["max"] = 60, 
 				["min"] = 51, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57000,7 +54374,6 @@ return {
 				["max"] = 28, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57011,14 +54384,13 @@ return {
 		}, 
 		["9308_ManaCostTotalChannelled"] = {
 			["Amulet"] = {
-				["max"] = 4, 
-				["min"] = 1, 
+				["max"] = -1, 
+				["min"] = -4, 
 			}, 
 			["Ring"] = {
-				["max"] = 4, 
-				["min"] = 1, 
+				["max"] = -1, 
+				["min"] = -4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57028,7 +54400,6 @@ return {
 			}, 
 		}, 
 		["9309_ManaCostBaseChannelled"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57038,7 +54409,6 @@ return {
 			}, 
 		}, 
 		["9310_IncreasedManaAndCostNew"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57049,14 +54419,13 @@ return {
 		}, 
 		["9310_ManaCostTotalNonChannelled"] = {
 			["Amulet"] = {
-				["max"] = 9, 
-				["min"] = 4, 
+				["max"] = -4, 
+				["min"] = -9, 
 			}, 
 			["Ring"] = {
-				["max"] = 9, 
-				["min"] = 4, 
+				["max"] = -4, 
+				["min"] = -9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57066,7 +54435,6 @@ return {
 			}, 
 		}, 
 		["9311_IncreasedManaAndBaseCost"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57076,7 +54444,6 @@ return {
 			}, 
 		}, 
 		["9311_ManaCostBaseNonChannelled"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57099,7 +54466,6 @@ return {
 				["max"] = 2, 
 				["min"] = 0.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57113,7 +54479,6 @@ return {
 				["max"] = 12, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57147,7 +54512,6 @@ return {
 				["max"] = 7, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57161,7 +54525,6 @@ return {
 				["max"] = 75, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57175,7 +54538,6 @@ return {
 				["max"] = 35, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57193,7 +54555,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57211,7 +54572,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57237,7 +54597,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57255,7 +54614,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57273,7 +54631,6 @@ return {
 				["max"] = 8, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57287,7 +54644,6 @@ return {
 				["max"] = 40, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57369,7 +54725,7 @@ return {
 				["max"] = -18, 
 				["min"] = -32, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57379,7 +54735,6 @@ return {
 			}, 
 		}, 
 		["9488_GlobalStrengthGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57402,7 +54757,6 @@ return {
 				["max"] = 47, 
 				["min"] = 31.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57412,7 +54766,6 @@ return {
 			}, 
 		}, 
 		["9548_FireResistanceAilments"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57426,7 +54779,6 @@ return {
 				["max"] = 25, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57462,7 +54814,6 @@ return {
 			}, 
 		}, 
 		["9582_WarcryTauntedEnemiesTakeIncreasedDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57476,7 +54827,6 @@ return {
 				["max"] = 21, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57602,7 +54952,6 @@ return {
 				["max"] = 25, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57616,7 +54965,6 @@ return {
 				["max"] = 15, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57630,7 +54978,6 @@ return {
 				["max"] = 25, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57660,7 +55007,6 @@ return {
 				["max"] = 25, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57674,7 +55020,6 @@ return {
 				["max"] = 30, 
 				["min"] = 21, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57688,7 +55033,6 @@ return {
 				["max"] = 30, 
 				["min"] = 26, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57698,7 +55042,6 @@ return {
 			}, 
 		}, 
 		["9826_WrathReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57712,7 +55055,6 @@ return {
 				["max"] = 50, 
 				["min"] = 40, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57739,7 +55081,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57753,7 +55094,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57787,7 +55127,6 @@ return {
 				["max"] = 40, 
 				["min"] = 28, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57797,7 +55136,6 @@ return {
 			}, 
 		}, 
 		["9900_ZealotryReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -57811,7 +55149,6 @@ return {
 				["max"] = 50, 
 				["min"] = 40, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -58082,7 +55419,6 @@ return {
 			}, 
 		}, 
 		["9973_MapMonsterPacksVaalMapWorlds"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -58111,28 +55447,29 @@ return {
 		}, 
 	}, 
 	["Implicit"] = {
+		["implicit.stat_1001829678"] = {
+			["2HWeapon"] = {
+				["max"] = 25, 
+				["min"] = 20, 
+			}, 
+			["Staff"] = {
+				["max"] = 25, 
+				["min"] = 20, 
+			}, 
+			["specialCaseData"] = {
+				["overrideModLine"] = "+#% Chance to Block Attack Damage while wielding a Staff", 
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_1001829678", 
+				["text"] = "+#% Chance to Block Attack Damage while wielding a Staff (Staves)", 
+				["type"] = "implicit", 
+			}, 
+		}, 
 		["implicit.stat_1002362373"] = {
-			["Boots"] = {
-				["max"] = 20, 
-				["min"] = 16, 
-				["subType"] = "Armour", 
-			}, 
-			["Chest"] = {
-				["max"] = 20, 
-				["min"] = 16, 
-				["subType"] = "Armour", 
-			}, 
 			["Gloves"] = {
 				["max"] = 20, 
 				["min"] = 16, 
-				["subType"] = "Armour", 
 			}, 
-			["Helmet"] = {
-				["max"] = 20, 
-				["min"] = 16, 
-				["subType"] = "Armour", 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -58141,27 +55478,11 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_1017730114"] = {
-			["Amulet"] = {
-				["max"] = 50, 
-				["min"] = 50, 
-				["subType"] = "Talisman", 
-			}, 
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_1017730114", 
-				["text"] = "#% of Lightning Damage from Hits taken as Cold Damage", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_1033086302"] = {
 			["Ring"] = {
 				["max"] = 50, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -58174,13 +55495,11 @@ return {
 			["Chest"] = {
 				["max"] = 25, 
 				["min"] = 20, 
-				["subType"] = "Evasion/Energy Shield", 
 			}, 
 			["Ring"] = {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -58189,27 +55508,11 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_1054322244"] = {
-			["Amulet"] = {
-				["max"] = 10, 
-				["min"] = 10, 
-				["subType"] = "Talisman", 
-			}, 
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_1054322244", 
-				["text"] = "#% chance to gain an Endurance Charge on Kill", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_1069618951"] = {
 			["Ring"] = {
 				["max"] = 15, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -58222,24 +55525,7 @@ return {
 			["Boots"] = {
 				["max"] = 50, 
 				["min"] = 45, 
-				["subType"] = "Energy Shield", 
 			}, 
-			["Chest"] = {
-				["max"] = 50, 
-				["min"] = 45, 
-				["subType"] = "Energy Shield", 
-			}, 
-			["Gloves"] = {
-				["max"] = 50, 
-				["min"] = 45, 
-				["subType"] = "Energy Shield", 
-			}, 
-			["Helmet"] = {
-				["max"] = 50, 
-				["min"] = 45, 
-				["subType"] = "Energy Shield", 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -58253,7 +55539,6 @@ return {
 				["max"] = 30, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -58262,42 +55547,8 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_1168985596"] = {
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_1168985596", 
-				["text"] = "#% chance to Poison with Melee Weapons", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_1172810729"] = {
-			["1HAxe"] = {
-				["max"] = 5, 
-				["min"] = 5, 
-			}, 
-			["1HMace"] = {
-				["max"] = 5, 
-				["min"] = 5, 
-			}, 
-			["1HSword"] = {
-				["max"] = 5, 
-				["min"] = 5, 
-			}, 
-			["1HWeapon"] = {
-				["max"] = 5, 
-				["min"] = 5, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 5, 
-				["min"] = 5, 
-			}, 
 			["2HMace"] = {
-				["max"] = 5, 
-				["min"] = 5, 
-			}, 
-			["2HSword"] = {
 				["max"] = 5, 
 				["min"] = 5, 
 			}, 
@@ -58305,27 +55556,6 @@ return {
 				["max"] = 5, 
 				["min"] = 5, 
 			}, 
-			["Bow"] = {
-				["max"] = 5, 
-				["min"] = 5, 
-			}, 
-			["Claw"] = {
-				["max"] = 5, 
-				["min"] = 5, 
-			}, 
-			["Dagger"] = {
-				["max"] = 5, 
-				["min"] = 5, 
-			}, 
-			["Staff"] = {
-				["max"] = 5, 
-				["min"] = 5, 
-			}, 
-			["Wand"] = {
-				["max"] = 5, 
-				["min"] = 5, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -58334,71 +55564,12 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_1189760108"] = {
-			["Amulet"] = {
-				["max"] = 50, 
-				["min"] = 50, 
-				["subType"] = "Talisman", 
-			}, 
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_1189760108", 
-				["text"] = "#% of Cold Damage from Hits taken as Fire Damage", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_1263158408"] = {
-			["1HAxe"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
 			["1HMace"] = {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["1HSword"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
 			["1HWeapon"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HMace"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HSword"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Bow"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Claw"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Dagger"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Staff"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Wand"] = {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
@@ -58410,43 +55581,11 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_1296614065"] = {
-			["Amulet"] = {
-				["max"] = 40, 
-				["min"] = 30, 
-				["subType"] = "Talisman", 
-			}, 
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_1296614065", 
-				["text"] = "#% increased Fish Bite Sensitivity", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_1301765461"] = {
-			["Boots"] = {
-				["max"] = 4, 
-				["min"] = 2, 
-				["subType"] = "Armour/Evasion", 
-			}, 
-			["Chest"] = {
-				["max"] = 4, 
-				["min"] = 2, 
-				["subType"] = "Armour/Evasion", 
-			}, 
-			["Gloves"] = {
-				["max"] = 4, 
-				["min"] = 2, 
-				["subType"] = "Armour/Evasion", 
-			}, 
 			["Helmet"] = {
 				["max"] = 4, 
 				["min"] = 2, 
-				["subType"] = "Armour/Evasion", 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -58460,84 +55599,19 @@ return {
 				["max"] = 12, 
 				["min"] = 8, 
 			}, 
-			["1HMace"] = {
-				["max"] = 12, 
-				["min"] = 8, 
-			}, 
-			["1HSword"] = {
-				["max"] = 12, 
-				["min"] = 8, 
-			}, 
 			["1HWeapon"] = {
 				["max"] = 12, 
 				["min"] = 8, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 12, 
-				["min"] = 8, 
-			}, 
-			["2HMace"] = {
-				["max"] = 12, 
-				["min"] = 8, 
-			}, 
-			["2HSword"] = {
-				["max"] = 12, 
-				["min"] = 8, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 12, 
-				["min"] = 8, 
-			}, 
-			["Amulet"] = {
-				["max"] = 30, 
-				["min"] = 20, 
-				["subType"] = "Talisman", 
 			}, 
 			["Belt"] = {
 				["max"] = 24, 
 				["min"] = 12, 
 			}, 
-			["Bow"] = {
-				["max"] = 12, 
-				["min"] = 8, 
-			}, 
-			["Claw"] = {
-				["max"] = 12, 
-				["min"] = 8, 
-			}, 
-			["Dagger"] = {
-				["max"] = 12, 
-				["min"] = 8, 
-			}, 
-			["Staff"] = {
-				["max"] = 12, 
-				["min"] = 8, 
-			}, 
-			["Wand"] = {
-				["max"] = 12, 
-				["min"] = 8, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
 				["id"] = "implicit.stat_1310194496", 
 				["text"] = "#% increased Global Physical Damage", 
-				["type"] = "implicit", 
-			}, 
-		}, 
-		["implicit.stat_1313503107"] = {
-			["Amulet"] = {
-				["max"] = 50, 
-				["min"] = 50, 
-				["subType"] = "Talisman", 
-			}, 
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_1313503107", 
-				["text"] = "#% of Cold Damage from Hits taken as Lightning Damage", 
 				["type"] = "implicit", 
 			}, 
 		}, 
@@ -58554,7 +55628,6 @@ return {
 				["max"] = 12, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -58564,16 +55637,10 @@ return {
 			}, 
 		}, 
 		["implicit.stat_1389153006"] = {
-			["Amulet"] = {
-				["max"] = 25, 
-				["min"] = 15, 
-				["subType"] = "Talisman", 
-			}, 
 			["Ring"] = {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -58587,7 +55654,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -58597,31 +55663,7 @@ return {
 			}, 
 		}, 
 		["implicit.stat_1423749435"] = {
-			["1HAxe"] = {
-				["max"] = 20, 
-				["min"] = 20, 
-			}, 
-			["1HMace"] = {
-				["max"] = 20, 
-				["min"] = 20, 
-			}, 
-			["1HSword"] = {
-				["max"] = 20, 
-				["min"] = 20, 
-			}, 
-			["1HWeapon"] = {
-				["max"] = 20, 
-				["min"] = 20, 
-			}, 
 			["2HAxe"] = {
-				["max"] = 20, 
-				["min"] = 20, 
-			}, 
-			["2HMace"] = {
-				["max"] = 20, 
-				["min"] = 20, 
-			}, 
-			["2HSword"] = {
 				["max"] = 20, 
 				["min"] = 20, 
 			}, 
@@ -58629,27 +55671,6 @@ return {
 				["max"] = 20, 
 				["min"] = 20, 
 			}, 
-			["Bow"] = {
-				["max"] = 20, 
-				["min"] = 20, 
-			}, 
-			["Claw"] = {
-				["max"] = 20, 
-				["min"] = 20, 
-			}, 
-			["Dagger"] = {
-				["max"] = 20, 
-				["min"] = 20, 
-			}, 
-			["Staff"] = {
-				["max"] = 20, 
-				["min"] = 20, 
-			}, 
-			["Wand"] = {
-				["max"] = 20, 
-				["min"] = 20, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -58659,14 +55680,6 @@ return {
 			}, 
 		}, 
 		["implicit.stat_1431238626"] = {
-			["1HAxe"] = {
-				["max"] = 100, 
-				["min"] = 100, 
-			}, 
-			["1HMace"] = {
-				["max"] = 100, 
-				["min"] = 100, 
-			}, 
 			["1HSword"] = {
 				["max"] = 100, 
 				["min"] = 100, 
@@ -58675,43 +55688,6 @@ return {
 				["max"] = 100, 
 				["min"] = 100, 
 			}, 
-			["2HAxe"] = {
-				["max"] = 100, 
-				["min"] = 100, 
-			}, 
-			["2HMace"] = {
-				["max"] = 100, 
-				["min"] = 100, 
-			}, 
-			["2HSword"] = {
-				["max"] = 100, 
-				["min"] = 100, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 100, 
-				["min"] = 100, 
-			}, 
-			["Bow"] = {
-				["max"] = 100, 
-				["min"] = 100, 
-			}, 
-			["Claw"] = {
-				["max"] = 100, 
-				["min"] = 100, 
-			}, 
-			["Dagger"] = {
-				["max"] = 100, 
-				["min"] = 100, 
-			}, 
-			["Staff"] = {
-				["max"] = 100, 
-				["min"] = 100, 
-			}, 
-			["Wand"] = {
-				["max"] = 100, 
-				["min"] = 100, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -58721,31 +55697,7 @@ return {
 			}, 
 		}, 
 		["implicit.stat_1434716233"] = {
-			["1HAxe"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["1HMace"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["1HSword"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["1HWeapon"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
 			["2HMace"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HSword"] = {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
@@ -58753,27 +55705,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["Bow"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Claw"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Dagger"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Staff"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Wand"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -58783,59 +55714,22 @@ return {
 			}, 
 		}, 
 		["implicit.stat_1443060084"] = {
-			["1HAxe"] = {
-				["max"] = 20, 
-				["min"] = 10, 
-			}, 
 			["1HMace"] = {
-				["max"] = 20, 
-				["min"] = 10, 
-			}, 
-			["1HSword"] = {
-				["max"] = 20, 
+				["max"] = 15, 
 				["min"] = 10, 
 			}, 
 			["1HWeapon"] = {
-				["max"] = 20, 
-				["min"] = 10, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 20, 
+				["max"] = 15, 
 				["min"] = 10, 
 			}, 
 			["2HMace"] = {
 				["max"] = 20, 
-				["min"] = 10, 
-			}, 
-			["2HSword"] = {
-				["max"] = 20, 
-				["min"] = 10, 
+				["min"] = 20, 
 			}, 
 			["2HWeapon"] = {
 				["max"] = 20, 
-				["min"] = 10, 
+				["min"] = 20, 
 			}, 
-			["Bow"] = {
-				["max"] = 20, 
-				["min"] = 10, 
-			}, 
-			["Claw"] = {
-				["max"] = 20, 
-				["min"] = 10, 
-			}, 
-			["Dagger"] = {
-				["max"] = 20, 
-				["min"] = 10, 
-			}, 
-			["Staff"] = {
-				["max"] = 20, 
-				["min"] = 10, 
-			}, 
-			["Wand"] = {
-				["max"] = 20, 
-				["min"] = 10, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -58844,88 +55738,15 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_1504091975"] = {
-			["Amulet"] = {
-				["max"] = 50, 
-				["min"] = 50, 
-				["subType"] = "Talisman", 
-			}, 
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_1504091975", 
-				["text"] = "#% of Fire Damage from Hits taken as Lightning Damage", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_1519615863"] = {
-			["1HAxe"] = {
-				["max"] = 20, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
-			}, 
-			["1HMace"] = {
-				["max"] = 20, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
-			}, 
 			["1HSword"] = {
 				["max"] = 20, 
 				["min"] = 15, 
-				["subType"] = "Thrusting", 
 			}, 
 			["1HWeapon"] = {
 				["max"] = 20, 
 				["min"] = 15, 
-				["subType"] = "Thrusting", 
 			}, 
-			["2HAxe"] = {
-				["max"] = 20, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
-			}, 
-			["2HMace"] = {
-				["max"] = 20, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
-			}, 
-			["2HSword"] = {
-				["max"] = 20, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 20, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
-			}, 
-			["Bow"] = {
-				["max"] = 20, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
-			}, 
-			["Claw"] = {
-				["max"] = 20, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
-			}, 
-			["Dagger"] = {
-				["max"] = 20, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
-			}, 
-			["Staff"] = {
-				["max"] = 20, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
-			}, 
-			["Wand"] = {
-				["max"] = 20, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -58935,15 +55756,7 @@ return {
 			}, 
 		}, 
 		["implicit.stat_1523888729"] = {
-			["1HAxe"] = {
-				["max"] = 20, 
-				["min"] = 10, 
-			}, 
 			["1HMace"] = {
-				["max"] = 20, 
-				["min"] = 10, 
-			}, 
-			["1HSword"] = {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
@@ -58951,43 +55764,6 @@ return {
 				["max"] = 20, 
 				["min"] = 10, 
 			}, 
-			["2HAxe"] = {
-				["max"] = 20, 
-				["min"] = 10, 
-			}, 
-			["2HMace"] = {
-				["max"] = 20, 
-				["min"] = 10, 
-			}, 
-			["2HSword"] = {
-				["max"] = 20, 
-				["min"] = 10, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 20, 
-				["min"] = 10, 
-			}, 
-			["Bow"] = {
-				["max"] = 20, 
-				["min"] = 10, 
-			}, 
-			["Claw"] = {
-				["max"] = 20, 
-				["min"] = 10, 
-			}, 
-			["Dagger"] = {
-				["max"] = 20, 
-				["min"] = 10, 
-			}, 
-			["Staff"] = {
-				["max"] = 20, 
-				["min"] = 10, 
-			}, 
-			["Wand"] = {
-				["max"] = 20, 
-				["min"] = 10, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -59001,7 +55777,6 @@ return {
 				["max"] = 24, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -59015,7 +55790,6 @@ return {
 				["max"] = 21, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -59029,7 +55803,6 @@ return {
 				["max"] = 100, 
 				["min"] = 100, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -59039,84 +55812,22 @@ return {
 			}, 
 		}, 
 		["implicit.stat_1589917703"] = {
-			["1HAxe"] = {
-				["max"] = 30, 
-				["min"] = 12, 
-			}, 
-			["1HMace"] = {
-				["max"] = 30, 
-				["min"] = 12, 
-			}, 
-			["1HSword"] = {
-				["max"] = 30, 
-				["min"] = 12, 
-			}, 
 			["1HWeapon"] = {
 				["max"] = 30, 
 				["min"] = 12, 
 			}, 
-			["2HAxe"] = {
-				["max"] = 30, 
-				["min"] = 12, 
-			}, 
-			["2HMace"] = {
-				["max"] = 30, 
-				["min"] = 12, 
-			}, 
-			["2HSword"] = {
-				["max"] = 30, 
-				["min"] = 12, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 30, 
-				["min"] = 12, 
-			}, 
-			["Boots"] = {
-				["max"] = 20, 
-				["min"] = 5, 
-				["subType"] = "Energy Shield", 
-			}, 
-			["Bow"] = {
-				["max"] = 30, 
-				["min"] = 12, 
-			}, 
-			["Chest"] = {
-				["max"] = 20, 
-				["min"] = 5, 
-				["subType"] = "Energy Shield", 
-			}, 
-			["Claw"] = {
-				["max"] = 30, 
-				["min"] = 12, 
-			}, 
-			["Dagger"] = {
-				["max"] = 30, 
-				["min"] = 12, 
-			}, 
-			["Gloves"] = {
-				["max"] = 20, 
-				["min"] = 5, 
-				["subType"] = "Energy Shield", 
-			}, 
 			["Helmet"] = {
 				["max"] = 20, 
-				["min"] = 5, 
-				["subType"] = "Energy Shield", 
+				["min"] = 15, 
 			}, 
 			["Shield"] = {
 				["max"] = 10, 
 				["min"] = 5, 
-				["subType"] = "Energy Shield", 
-			}, 
-			["Staff"] = {
-				["max"] = 30, 
-				["min"] = 12, 
 			}, 
 			["Wand"] = {
 				["max"] = 30, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -59125,83 +55836,15 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_1630041051"] = {
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_1630041051", 
-				["text"] = "#% chance to cause Bleeding with Melee Weapons", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_1633778432"] = {
-			["1HAxe"] = {
-				["max"] = 30, 
-				["min"] = 10, 
-				["subType"] = "Rune", 
-			}, 
-			["1HMace"] = {
-				["max"] = 30, 
-				["min"] = 10, 
-				["subType"] = "Rune", 
-			}, 
-			["1HSword"] = {
-				["max"] = 30, 
-				["min"] = 10, 
-				["subType"] = "Rune", 
-			}, 
 			["1HWeapon"] = {
 				["max"] = 30, 
 				["min"] = 10, 
-				["subType"] = "Rune", 
-			}, 
-			["2HAxe"] = {
-				["max"] = 30, 
-				["min"] = 10, 
-				["subType"] = "Rune", 
-			}, 
-			["2HMace"] = {
-				["max"] = 30, 
-				["min"] = 10, 
-				["subType"] = "Rune", 
-			}, 
-			["2HSword"] = {
-				["max"] = 30, 
-				["min"] = 10, 
-				["subType"] = "Rune", 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 30, 
-				["min"] = 10, 
-				["subType"] = "Rune", 
-			}, 
-			["Bow"] = {
-				["max"] = 30, 
-				["min"] = 10, 
-				["subType"] = "Rune", 
-			}, 
-			["Claw"] = {
-				["max"] = 30, 
-				["min"] = 10, 
-				["subType"] = "Rune", 
 			}, 
 			["Dagger"] = {
 				["max"] = 30, 
 				["min"] = 10, 
-				["subType"] = "Rune", 
 			}, 
-			["Staff"] = {
-				["max"] = 30, 
-				["min"] = 10, 
-				["subType"] = "Rune", 
-			}, 
-			["Wand"] = {
-				["max"] = 30, 
-				["min"] = 10, 
-				["subType"] = "Rune", 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -59211,51 +55854,7 @@ return {
 			}, 
 		}, 
 		["implicit.stat_1662717006"] = {
-			["1HAxe"] = {
-				["max"] = 38, 
-				["min"] = 3, 
-			}, 
-			["1HMace"] = {
-				["max"] = 38, 
-				["min"] = 3, 
-			}, 
-			["1HSword"] = {
-				["max"] = 38, 
-				["min"] = 3, 
-			}, 
 			["1HWeapon"] = {
-				["max"] = 38, 
-				["min"] = 3, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 38, 
-				["min"] = 3, 
-			}, 
-			["2HMace"] = {
-				["max"] = 38, 
-				["min"] = 3, 
-			}, 
-			["2HSword"] = {
-				["max"] = 38, 
-				["min"] = 3, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 38, 
-				["min"] = 3, 
-			}, 
-			["Bow"] = {
-				["max"] = 38, 
-				["min"] = 3, 
-			}, 
-			["Claw"] = {
-				["max"] = 38, 
-				["min"] = 3, 
-			}, 
-			["Dagger"] = {
-				["max"] = 38, 
-				["min"] = 3, 
-			}, 
-			["Staff"] = {
 				["max"] = 38, 
 				["min"] = 3, 
 			}, 
@@ -59263,7 +55862,6 @@ return {
 				["max"] = 38, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -59277,7 +55875,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -59286,12 +55883,39 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
+		["implicit.stat_170394517"] = {
+			["Boots"] = {
+				["max"] = -25, 
+				["min"] = -25, 
+			}, 
+			["invertOnNegative"] = true, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_170394517", 
+				["text"] = "#% more Accuracy Rating", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_1745952865"] = {
+			["Ring"] = {
+				["max"] = -50, 
+				["min"] = -50, 
+			}, 
+			["invertOnNegative"] = true, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_1745952865", 
+				["text"] = "#% reduced Elemental Ailment Duration on you", 
+				["type"] = "implicit", 
+			}, 
+		}, 
 		["implicit.stat_1754445556"] = {
 			["Quiver"] = {
 				["max"] = 3, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -59305,7 +55929,6 @@ return {
 				["max"] = 20, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -59319,7 +55942,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -59333,7 +55955,6 @@ return {
 				["max"] = 50, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -59355,67 +55976,8 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_1808507379"] = {
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_1808507379", 
-				["text"] = "#% increased Effect of Blind from Melee Weapons", 
-				["type"] = "implicit", 
-			}, 
-		}, 
-		["implicit.stat_1826802197"] = {
-			["Amulet"] = {
-				["max"] = 10, 
-				["min"] = 10, 
-				["subType"] = "Talisman", 
-			}, 
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_1826802197", 
-				["text"] = "#% chance to gain a Frenzy Charge on Kill", 
-				["type"] = "implicit", 
-			}, 
-		}, 
-		["implicit.stat_1858426568"] = {
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_1858426568", 
-				["text"] = "#% chance to Freeze with Melee Weapons", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_1907260000"] = {
-			["1HAxe"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-			}, 
-			["1HMace"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-			}, 
-			["1HSword"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-			}, 
-			["1HWeapon"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-			}, 
 			["2HAxe"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-			}, 
-			["2HMace"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-			}, 
-			["2HSword"] = {
 				["max"] = 50, 
 				["min"] = 30, 
 			}, 
@@ -59423,27 +55985,6 @@ return {
 				["max"] = 50, 
 				["min"] = 30, 
 			}, 
-			["Bow"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-			}, 
-			["Claw"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-			}, 
-			["Dagger"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-			}, 
-			["Staff"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-			}, 
-			["Wand"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -59453,27 +55994,10 @@ return {
 			}, 
 		}, 
 		["implicit.stat_1915414884"] = {
-			["Boots"] = {
-				["max"] = 30, 
-				["min"] = 25, 
-				["subType"] = "Energy Shield", 
-			}, 
-			["Chest"] = {
-				["max"] = 30, 
-				["min"] = 25, 
-				["subType"] = "Energy Shield", 
-			}, 
 			["Gloves"] = {
 				["max"] = 30, 
 				["min"] = 25, 
-				["subType"] = "Energy Shield", 
 			}, 
-			["Helmet"] = {
-				["max"] = 30, 
-				["min"] = 25, 
-				["subType"] = "Energy Shield", 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -59482,27 +56006,30 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
+		["implicit.stat_1916904011"] = {
+			["Ring"] = {
+				["max"] = -15, 
+				["min"] = -15, 
+			}, 
+			["invertOnNegative"] = true, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_1916904011", 
+				["text"] = "Left ring slot: Minions take #% increased Damage", 
+				["type"] = "implicit", 
+			}, 
+		}, 
 		["implicit.stat_2005503156"] = {
 			["Flask"] = {
 				["max"] = 1, 
 				["min"] = 1, 
-				["subType"] = "Utility", 
 			}, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
 				["id"] = "implicit.stat_2005503156", 
 				["text"] = "Taunts nearby Enemies on use", 
-				["type"] = "implicit", 
-			}, 
-		}, 
-		["implicit.stat_2012294704"] = {
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_2012294704", 
-				["text"] = "Gain # Rage on Melee Weapon Hit", 
 				["type"] = "implicit", 
 			}, 
 		}, 
@@ -59519,27 +56046,11 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_2067062068"] = {
-			["Amulet"] = {
-				["max"] = 2, 
-				["min"] = 2, 
-				["subType"] = "Talisman", 
-			}, 
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_2067062068", 
-				["text"] = "Projectiles Pierce # additional Targets", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_2091591880"] = {
 			["Quiver"] = {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -59549,15 +56060,7 @@ return {
 			}, 
 		}, 
 		["implicit.stat_2101383955"] = {
-			["1HAxe"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
 			["1HMace"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["1HSword"] = {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
@@ -59565,43 +56068,6 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["2HAxe"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["2HMace"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["2HSword"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["Bow"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["Claw"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["Dagger"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["Staff"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["Wand"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -59611,47 +56077,7 @@ return {
 			}, 
 		}, 
 		["implicit.stat_2120297997"] = {
-			["1HAxe"] = {
-				["max"] = 25, 
-				["min"] = 20, 
-			}, 
-			["1HMace"] = {
-				["max"] = 25, 
-				["min"] = 20, 
-			}, 
-			["1HSword"] = {
-				["max"] = 25, 
-				["min"] = 20, 
-			}, 
-			["1HWeapon"] = {
-				["max"] = 25, 
-				["min"] = 20, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 25, 
-				["min"] = 20, 
-			}, 
-			["2HMace"] = {
-				["max"] = 25, 
-				["min"] = 20, 
-			}, 
-			["2HSword"] = {
-				["max"] = 25, 
-				["min"] = 20, 
-			}, 
 			["2HWeapon"] = {
-				["max"] = 25, 
-				["min"] = 20, 
-			}, 
-			["Bow"] = {
-				["max"] = 25, 
-				["min"] = 20, 
-			}, 
-			["Claw"] = {
-				["max"] = 25, 
-				["min"] = 20, 
-			}, 
-			["Dagger"] = {
 				["max"] = 25, 
 				["min"] = 20, 
 			}, 
@@ -59659,11 +56085,6 @@ return {
 				["max"] = 25, 
 				["min"] = 20, 
 			}, 
-			["Wand"] = {
-				["max"] = 25, 
-				["min"] = 20, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -59676,7 +56097,6 @@ return {
 			["Flask"] = {
 				["max"] = 1, 
 				["min"] = 1, 
-				["subType"] = "Utility", 
 			}, 
 			["specialCaseData"] = {
 			}, 
@@ -59686,43 +56106,11 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_2154246560"] = {
-			["Amulet"] = {
-				["max"] = 35, 
-				["min"] = 25, 
-				["subType"] = "Talisman", 
-			}, 
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_2154246560", 
-				["text"] = "#% increased Damage", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_2162876159"] = {
-			["Boots"] = {
-				["max"] = 18, 
-				["min"] = 14, 
-				["subType"] = "Evasion", 
-			}, 
-			["Chest"] = {
-				["max"] = 18, 
-				["min"] = 14, 
-				["subType"] = "Evasion", 
-			}, 
 			["Gloves"] = {
 				["max"] = 18, 
 				["min"] = 14, 
-				["subType"] = "Evasion", 
 			}, 
-			["Helmet"] = {
-				["max"] = 18, 
-				["min"] = 14, 
-				["subType"] = "Evasion", 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -59732,55 +56120,11 @@ return {
 			}, 
 		}, 
 		["implicit.stat_2170876738"] = {
-			["1HAxe"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["1HMace"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["1HSword"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["1HWeapon"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HMace"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
 			["2HSword"] = {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
 			["2HWeapon"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Bow"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Claw"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Dagger"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Staff"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Wand"] = {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
@@ -59792,18 +56136,17 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_2231156303"] = {
-			["Amulet"] = {
-				["max"] = 30, 
-				["min"] = 20, 
-				["subType"] = "Talisman", 
+		["implicit.stat_221309863"] = {
+			["Ring"] = {
+				["max"] = -30, 
+				["min"] = -30, 
 			}, 
-			["sign"] = "", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
-				["id"] = "implicit.stat_2231156303", 
-				["text"] = "#% increased Lightning Damage", 
+				["id"] = "implicit.stat_221309863", 
+				["text"] = "Left ring slot: #% increased Duration of Ailments on You", 
 				["type"] = "implicit", 
 			}, 
 		}, 
@@ -59812,7 +56155,6 @@ return {
 				["max"] = 15, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -59821,95 +56163,23 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_2245266924"] = {
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_2245266924", 
-				["text"] = "#% increased Effect of Shock from Melee Weapons", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_2250533757"] = {
-			["1HAxe"] = {
-				["max"] = 10, 
-				["min"] = 6, 
-			}, 
-			["1HMace"] = {
-				["max"] = 10, 
-				["min"] = 6, 
-			}, 
-			["1HSword"] = {
-				["max"] = 10, 
-				["min"] = 6, 
-			}, 
-			["1HWeapon"] = {
-				["max"] = 10, 
-				["min"] = 6, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 10, 
-				["min"] = 6, 
-			}, 
-			["2HMace"] = {
-				["max"] = 10, 
-				["min"] = 6, 
-			}, 
-			["2HSword"] = {
-				["max"] = 10, 
-				["min"] = 6, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 10, 
-				["min"] = 6, 
-			}, 
 			["Boots"] = {
-				["max"] = 9, 
-				["min"] = 3, 
-				["subType"] = "Evasion", 
+				["max"] = -10, 
+				["min"] = -10, 
 			}, 
 			["Bow"] = {
 				["max"] = 10, 
 				["min"] = 6, 
 			}, 
 			["Chest"] = {
-				["max"] = 9, 
+				["max"] = 3, 
 				["min"] = 3, 
-				["subType"] = "Evasion", 
-			}, 
-			["Claw"] = {
-				["max"] = 10, 
-				["min"] = 6, 
-			}, 
-			["Dagger"] = {
-				["max"] = 10, 
-				["min"] = 6, 
-			}, 
-			["Gloves"] = {
-				["max"] = 9, 
-				["min"] = 3, 
-				["subType"] = "Evasion", 
-			}, 
-			["Helmet"] = {
-				["max"] = 9, 
-				["min"] = 3, 
-				["subType"] = "Evasion", 
 			}, 
 			["Shield"] = {
 				["max"] = 9, 
 				["min"] = 3, 
-				["subType"] = "Evasion", 
 			}, 
-			["Staff"] = {
-				["max"] = 10, 
-				["min"] = 6, 
-			}, 
-			["Wand"] = {
-				["max"] = 10, 
-				["min"] = 6, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -59923,7 +56193,6 @@ return {
 				["max"] = 24, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -59933,72 +56202,14 @@ return {
 			}, 
 		}, 
 		["implicit.stat_2308278768"] = {
-			["1HAxe"] = {
-				["max"] = 40, 
-				["min"] = 20, 
-				["subType"] = "Rune", 
-			}, 
-			["1HMace"] = {
-				["max"] = 40, 
-				["min"] = 20, 
-				["subType"] = "Rune", 
-			}, 
-			["1HSword"] = {
-				["max"] = 40, 
-				["min"] = 20, 
-				["subType"] = "Rune", 
-			}, 
 			["1HWeapon"] = {
 				["max"] = 40, 
 				["min"] = 20, 
-				["subType"] = "Rune", 
-			}, 
-			["2HAxe"] = {
-				["max"] = 40, 
-				["min"] = 20, 
-				["subType"] = "Rune", 
-			}, 
-			["2HMace"] = {
-				["max"] = 40, 
-				["min"] = 20, 
-				["subType"] = "Rune", 
-			}, 
-			["2HSword"] = {
-				["max"] = 40, 
-				["min"] = 20, 
-				["subType"] = "Rune", 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 40, 
-				["min"] = 20, 
-				["subType"] = "Rune", 
-			}, 
-			["Bow"] = {
-				["max"] = 40, 
-				["min"] = 20, 
-				["subType"] = "Rune", 
-			}, 
-			["Claw"] = {
-				["max"] = 40, 
-				["min"] = 20, 
-				["subType"] = "Rune", 
 			}, 
 			["Dagger"] = {
 				["max"] = 40, 
 				["min"] = 20, 
-				["subType"] = "Rune", 
 			}, 
-			["Staff"] = {
-				["max"] = 40, 
-				["min"] = 20, 
-				["subType"] = "Rune", 
-			}, 
-			["Wand"] = {
-				["max"] = 40, 
-				["min"] = 20, 
-				["subType"] = "Rune", 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -60007,22 +56218,11 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_2313961828"] = {
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_2313961828", 
-				["text"] = "#% chance to Shock with Melee Weapons", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_2316658489"] = {
 			["Belt"] = {
 				["max"] = 320, 
 				["min"] = 260, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -60032,59 +56232,18 @@ return {
 			}, 
 		}, 
 		["implicit.stat_2375316951"] = {
-			["1HAxe"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-			}, 
-			["1HMace"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-			}, 
-			["1HSword"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-			}, 
-			["1HWeapon"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-			}, 
 			["2HAxe"] = {
 				["max"] = 50, 
-				["min"] = 30, 
-			}, 
-			["2HMace"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-			}, 
-			["2HSword"] = {
-				["max"] = 50, 
-				["min"] = 30, 
+				["min"] = 50, 
 			}, 
 			["2HWeapon"] = {
 				["max"] = 50, 
-				["min"] = 30, 
+				["min"] = 50, 
 			}, 
 			["Bow"] = {
 				["max"] = 50, 
 				["min"] = 30, 
 			}, 
-			["Claw"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-			}, 
-			["Dagger"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-			}, 
-			["Staff"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-			}, 
-			["Wand"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -60097,9 +56256,7 @@ return {
 			["Helmet"] = {
 				["max"] = 106.5, 
 				["min"] = 4, 
-				["subType"] = "Evasion/Energy Shield", 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -60112,7 +56269,6 @@ return {
 			["Flask"] = {
 				["max"] = 1, 
 				["min"] = 1, 
-				["subType"] = "Utility", 
 			}, 
 			["specialCaseData"] = {
 			}, 
@@ -60127,27 +56283,11 @@ return {
 				["max"] = 30, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
 				["id"] = "implicit.stat_2457848738", 
 				["text"] = "Right ring slot: #% increased Duration of Ailments on You", 
-				["type"] = "implicit", 
-			}, 
-		}, 
-		["implicit.stat_2483795307"] = {
-			["Amulet"] = {
-				["max"] = 10, 
-				["min"] = 10, 
-				["subType"] = "Talisman", 
-			}, 
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_2483795307", 
-				["text"] = "#% chance to gain a Power Charge on Kill", 
 				["type"] = "implicit", 
 			}, 
 		}, 
@@ -60159,24 +56299,7 @@ return {
 			["Boots"] = {
 				["max"] = 50, 
 				["min"] = 30, 
-				["subType"] = "Armour", 
 			}, 
-			["Chest"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-				["subType"] = "Armour", 
-			}, 
-			["Gloves"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-				["subType"] = "Armour", 
-			}, 
-			["Helmet"] = {
-				["max"] = 50, 
-				["min"] = 30, 
-				["subType"] = "Armour", 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -60186,31 +56309,7 @@ return {
 			}, 
 		}, 
 		["implicit.stat_2517001139"] = {
-			["1HAxe"] = {
-				["max"] = 45, 
-				["min"] = 30, 
-			}, 
-			["1HMace"] = {
-				["max"] = 45, 
-				["min"] = 30, 
-			}, 
-			["1HSword"] = {
-				["max"] = 45, 
-				["min"] = 30, 
-			}, 
-			["1HWeapon"] = {
-				["max"] = 45, 
-				["min"] = 30, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 45, 
-				["min"] = 30, 
-			}, 
 			["2HMace"] = {
-				["max"] = 45, 
-				["min"] = 30, 
-			}, 
-			["2HSword"] = {
 				["max"] = 45, 
 				["min"] = 30, 
 			}, 
@@ -60222,27 +56321,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["Bow"] = {
-				["max"] = 45, 
-				["min"] = 30, 
-			}, 
-			["Claw"] = {
-				["max"] = 45, 
-				["min"] = 30, 
-			}, 
-			["Dagger"] = {
-				["max"] = 45, 
-				["min"] = 30, 
-			}, 
-			["Staff"] = {
-				["max"] = 45, 
-				["min"] = 30, 
-			}, 
-			["Wand"] = {
-				["max"] = 45, 
-				["min"] = 30, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -60251,69 +56329,8 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_2522672898"] = {
-			["Amulet"] = {
-				["max"] = 50, 
-				["min"] = 50, 
-				["subType"] = "Talisman", 
-			}, 
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_2522672898", 
-				["text"] = "#% of Fire Damage from Hits taken as Cold Damage", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_2530372417"] = {
-			["1HAxe"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["1HMace"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["1HSword"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
 			["1HWeapon"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["2HMace"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["2HSword"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["Boots"] = {
-				["max"] = 6, 
-				["min"] = 3, 
-				["subType"] = "Armour", 
-			}, 
-			["Bow"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["Chest"] = {
-				["max"] = 6, 
-				["min"] = 3, 
-				["subType"] = "Armour", 
-			}, 
-			["Claw"] = {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
@@ -60324,22 +56341,7 @@ return {
 			["Gloves"] = {
 				["max"] = 6, 
 				["min"] = 3, 
-				["subType"] = "Armour", 
 			}, 
-			["Helmet"] = {
-				["max"] = 6, 
-				["min"] = 3, 
-				["subType"] = "Armour", 
-			}, 
-			["Staff"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["Wand"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -60349,27 +56351,10 @@ return {
 			}, 
 		}, 
 		["implicit.stat_2546859843"] = {
-			["Boots"] = {
-				["max"] = 25, 
-				["min"] = 10, 
-				["subType"] = "Evasion", 
-			}, 
-			["Chest"] = {
-				["max"] = 25, 
-				["min"] = 10, 
-				["subType"] = "Evasion", 
-			}, 
 			["Gloves"] = {
 				["max"] = 25, 
 				["min"] = 10, 
-				["subType"] = "Evasion", 
 			}, 
-			["Helmet"] = {
-				["max"] = 25, 
-				["min"] = 10, 
-				["subType"] = "Evasion", 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -60379,55 +56364,11 @@ return {
 			}, 
 		}, 
 		["implicit.stat_261342933"] = {
-			["1HAxe"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
 			["1HMace"] = {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["1HSword"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
 			["1HWeapon"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HMace"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HSword"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Bow"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Claw"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Dagger"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Staff"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Wand"] = {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
@@ -60440,31 +56381,7 @@ return {
 			}, 
 		}, 
 		["implicit.stat_2622251413"] = {
-			["1HAxe"] = {
-				["max"] = 25, 
-				["min"] = 25, 
-			}, 
-			["1HMace"] = {
-				["max"] = 25, 
-				["min"] = 25, 
-			}, 
-			["1HSword"] = {
-				["max"] = 25, 
-				["min"] = 25, 
-			}, 
-			["1HWeapon"] = {
-				["max"] = 25, 
-				["min"] = 25, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 25, 
-				["min"] = 25, 
-			}, 
 			["2HMace"] = {
-				["max"] = 25, 
-				["min"] = 25, 
-			}, 
-			["2HSword"] = {
 				["max"] = 25, 
 				["min"] = 25, 
 			}, 
@@ -60472,27 +56389,6 @@ return {
 				["max"] = 25, 
 				["min"] = 25, 
 			}, 
-			["Bow"] = {
-				["max"] = 25, 
-				["min"] = 25, 
-			}, 
-			["Claw"] = {
-				["max"] = 25, 
-				["min"] = 25, 
-			}, 
-			["Dagger"] = {
-				["max"] = 25, 
-				["min"] = 25, 
-			}, 
-			["Staff"] = {
-				["max"] = 25, 
-				["min"] = 25, 
-			}, 
-			["Wand"] = {
-				["max"] = 25, 
-				["min"] = 25, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -60502,55 +56398,11 @@ return {
 			}, 
 		}, 
 		["implicit.stat_264042990"] = {
-			["1HAxe"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["1HMace"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["1HSword"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
 			["1HWeapon"] = {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["2HAxe"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HMace"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HSword"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Bow"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Claw"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
 			["Dagger"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Staff"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Wand"] = {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
@@ -60562,31 +56414,8 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_2672805335"] = {
-			["Amulet"] = {
-				["max"] = 10, 
-				["min"] = 6, 
-				["subType"] = "Talisman", 
-			}, 
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_2672805335", 
-				["text"] = "#% increased Attack and Cast Speed", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_2709367754"] = {
 			["1HAxe"] = {
-				["max"] = 5, 
-				["min"] = 3, 
-			}, 
-			["1HMace"] = {
-				["max"] = 5, 
-				["min"] = 3, 
-			}, 
-			["1HSword"] = {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
@@ -60594,43 +56423,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["2HAxe"] = {
-				["max"] = 5, 
-				["min"] = 3, 
-			}, 
-			["2HMace"] = {
-				["max"] = 5, 
-				["min"] = 3, 
-			}, 
-			["2HSword"] = {
-				["max"] = 5, 
-				["min"] = 3, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 5, 
-				["min"] = 3, 
-			}, 
-			["Bow"] = {
-				["max"] = 5, 
-				["min"] = 3, 
-			}, 
-			["Claw"] = {
-				["max"] = 5, 
-				["min"] = 3, 
-			}, 
-			["Dagger"] = {
-				["max"] = 5, 
-				["min"] = 3, 
-			}, 
-			["Staff"] = {
-				["max"] = 5, 
-				["min"] = 3, 
-			}, 
-			["Wand"] = {
-				["max"] = 5, 
-				["min"] = 3, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -60640,16 +56432,15 @@ return {
 			}, 
 		}, 
 		["implicit.stat_2748665614"] = {
-			["Amulet"] = {
-				["max"] = 30, 
-				["min"] = 20, 
-				["subType"] = "Talisman", 
+			["Gloves"] = {
+				["max"] = -30, 
+				["min"] = -30, 
 			}, 
 			["Ring"] = {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -60659,59 +56450,22 @@ return {
 			}, 
 		}, 
 		["implicit.stat_2763429652"] = {
-			["1HAxe"] = {
-				["max"] = 25, 
-				["min"] = 15, 
-			}, 
-			["1HMace"] = {
-				["max"] = 25, 
-				["min"] = 15, 
-			}, 
 			["1HSword"] = {
-				["max"] = 25, 
+				["max"] = 20, 
 				["min"] = 15, 
 			}, 
 			["1HWeapon"] = {
-				["max"] = 25, 
+				["max"] = 20, 
 				["min"] = 15, 
 			}, 
 			["2HAxe"] = {
 				["max"] = 25, 
-				["min"] = 15, 
-			}, 
-			["2HMace"] = {
-				["max"] = 25, 
-				["min"] = 15, 
-			}, 
-			["2HSword"] = {
-				["max"] = 25, 
-				["min"] = 15, 
+				["min"] = 25, 
 			}, 
 			["2HWeapon"] = {
 				["max"] = 25, 
-				["min"] = 15, 
+				["min"] = 25, 
 			}, 
-			["Bow"] = {
-				["max"] = 25, 
-				["min"] = 15, 
-			}, 
-			["Claw"] = {
-				["max"] = 25, 
-				["min"] = 15, 
-			}, 
-			["Dagger"] = {
-				["max"] = 25, 
-				["min"] = 15, 
-			}, 
-			["Staff"] = {
-				["max"] = 25, 
-				["min"] = 15, 
-			}, 
-			["Wand"] = {
-				["max"] = 25, 
-				["min"] = 15, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -60720,32 +56474,11 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_2791825817"] = {
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_2791825817", 
-				["text"] = "#% reduced Enemy Stun Threshold with Melee Weapons", 
-				["type"] = "implicit", 
-			}, 
-		}, 
-		["implicit.stat_2795267150"] = {
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_2795267150", 
-				["text"] = "#% chance to Blind Enemies on Hit with Melee Weapons", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_2797971005"] = {
 			["Quiver"] = {
 				["max"] = 8, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -60755,31 +56488,7 @@ return {
 			}, 
 		}, 
 		["implicit.stat_280731498"] = {
-			["1HAxe"] = {
-				["max"] = 20, 
-				["min"] = 15, 
-			}, 
-			["1HMace"] = {
-				["max"] = 20, 
-				["min"] = 15, 
-			}, 
-			["1HSword"] = {
-				["max"] = 20, 
-				["min"] = 15, 
-			}, 
-			["1HWeapon"] = {
-				["max"] = 20, 
-				["min"] = 15, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 20, 
-				["min"] = 15, 
-			}, 
 			["2HMace"] = {
-				["max"] = 20, 
-				["min"] = 15, 
-			}, 
-			["2HSword"] = {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
@@ -60787,32 +56496,6 @@ return {
 				["max"] = 20, 
 				["min"] = 15, 
 			}, 
-			["Amulet"] = {
-				["max"] = 8, 
-				["min"] = 5, 
-				["subType"] = "Talisman", 
-			}, 
-			["Bow"] = {
-				["max"] = 20, 
-				["min"] = 15, 
-			}, 
-			["Claw"] = {
-				["max"] = 20, 
-				["min"] = 15, 
-			}, 
-			["Dagger"] = {
-				["max"] = 20, 
-				["min"] = 15, 
-			}, 
-			["Staff"] = {
-				["max"] = 20, 
-				["min"] = 15, 
-			}, 
-			["Wand"] = {
-				["max"] = 20, 
-				["min"] = 15, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -60821,67 +56504,8 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_2843214518"] = {
-			["Amulet"] = {
-				["max"] = 30, 
-				["min"] = 20, 
-				["subType"] = "Talisman", 
-			}, 
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_2843214518", 
-				["text"] = "#% increased Attack Damage", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_2885144362"] = {
-			["1HAxe"] = {
-				["max"] = 43.5, 
-				["min"] = 5, 
-			}, 
-			["1HMace"] = {
-				["max"] = 43.5, 
-				["min"] = 5, 
-			}, 
-			["1HSword"] = {
-				["max"] = 43.5, 
-				["min"] = 5, 
-			}, 
 			["1HWeapon"] = {
-				["max"] = 43.5, 
-				["min"] = 5, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 43.5, 
-				["min"] = 5, 
-			}, 
-			["2HMace"] = {
-				["max"] = 43.5, 
-				["min"] = 5, 
-			}, 
-			["2HSword"] = {
-				["max"] = 43.5, 
-				["min"] = 5, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 43.5, 
-				["min"] = 5, 
-			}, 
-			["Bow"] = {
-				["max"] = 43.5, 
-				["min"] = 5, 
-			}, 
-			["Claw"] = {
-				["max"] = 43.5, 
-				["min"] = 5, 
-			}, 
-			["Dagger"] = {
-				["max"] = 43.5, 
-				["min"] = 5, 
-			}, 
-			["Staff"] = {
 				["max"] = 43.5, 
 				["min"] = 5, 
 			}, 
@@ -60889,7 +56513,6 @@ return {
 				["max"] = 43.5, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -60899,51 +56522,7 @@ return {
 			}, 
 		}, 
 		["implicit.stat_2891184298"] = {
-			["1HAxe"] = {
-				["max"] = 14, 
-				["min"] = 10, 
-			}, 
-			["1HMace"] = {
-				["max"] = 14, 
-				["min"] = 10, 
-			}, 
-			["1HSword"] = {
-				["max"] = 14, 
-				["min"] = 10, 
-			}, 
 			["1HWeapon"] = {
-				["max"] = 14, 
-				["min"] = 10, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 14, 
-				["min"] = 10, 
-			}, 
-			["2HMace"] = {
-				["max"] = 14, 
-				["min"] = 10, 
-			}, 
-			["2HSword"] = {
-				["max"] = 14, 
-				["min"] = 10, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 14, 
-				["min"] = 10, 
-			}, 
-			["Bow"] = {
-				["max"] = 14, 
-				["min"] = 10, 
-			}, 
-			["Claw"] = {
-				["max"] = 14, 
-				["min"] = 10, 
-			}, 
-			["Dagger"] = {
-				["max"] = 14, 
-				["min"] = 10, 
-			}, 
-			["Staff"] = {
 				["max"] = 14, 
 				["min"] = 10, 
 			}, 
@@ -60951,7 +56530,6 @@ return {
 				["max"] = 14, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -60966,24 +56544,12 @@ return {
 				["min"] = 8, 
 			}, 
 			["Boots"] = {
-				["max"] = 25, 
-				["min"] = 4, 
-				["subType"] = "Armour/Energy Shield", 
+				["max"] = 16, 
+				["min"] = 8, 
 			}, 
 			["Chest"] = {
 				["max"] = 25, 
-				["min"] = 4, 
-				["subType"] = "Armour/Energy Shield", 
-			}, 
-			["Gloves"] = {
-				["max"] = 25, 
-				["min"] = 4, 
-				["subType"] = "Armour/Energy Shield", 
-			}, 
-			["Helmet"] = {
-				["max"] = 25, 
-				["min"] = 4, 
-				["subType"] = "Armour/Energy Shield", 
+				["min"] = 8, 
 			}, 
 			["Ring"] = {
 				["max"] = 10, 
@@ -60992,9 +56558,7 @@ return {
 			["Shield"] = {
 				["max"] = 12, 
 				["min"] = 4, 
-				["subType"] = "Armour/Energy Shield", 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -61004,27 +56568,10 @@ return {
 			}, 
 		}, 
 		["implicit.stat_2905515354"] = {
-			["Boots"] = {
-				["max"] = 10, 
-				["min"] = 10, 
-				["subType"] = "Armour", 
-			}, 
-			["Chest"] = {
-				["max"] = 10, 
-				["min"] = 10, 
-				["subType"] = "Armour", 
-			}, 
 			["Gloves"] = {
 				["max"] = 10, 
 				["min"] = 10, 
-				["subType"] = "Armour", 
 			}, 
-			["Helmet"] = {
-				["max"] = 10, 
-				["min"] = 10, 
-				["subType"] = "Armour", 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -61033,42 +56580,15 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_2912587137"] = {
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_2912587137", 
-				["text"] = "#% increased Stun Duration with Melee Weapons", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_2915988346"] = {
 			["Boots"] = {
 				["max"] = 12, 
 				["min"] = 8, 
-				["subType"] = "Armour/Evasion", 
-			}, 
-			["Chest"] = {
-				["max"] = 12, 
-				["min"] = 8, 
-				["subType"] = "Armour/Evasion", 
-			}, 
-			["Gloves"] = {
-				["max"] = 12, 
-				["min"] = 8, 
-				["subType"] = "Armour/Evasion", 
-			}, 
-			["Helmet"] = {
-				["max"] = 12, 
-				["min"] = 8, 
-				["subType"] = "Armour/Evasion", 
 			}, 
 			["Ring"] = {
 				["max"] = 16, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -61081,7 +56601,6 @@ return {
 			["Boots"] = {
 				["max"] = 17, 
 				["min"] = 13, 
-				["subType"] = "Evasion/Energy Shield", 
 			}, 
 			["Ring"] = {
 				["max"] = 23, 
@@ -61091,7 +56610,6 @@ return {
 				["max"] = 19, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -61101,89 +56619,26 @@ return {
 			}, 
 		}, 
 		["implicit.stat_2974417149"] = {
-			["1HAxe"] = {
-				["max"] = 40, 
-				["min"] = 8, 
-			}, 
-			["1HMace"] = {
-				["max"] = 40, 
-				["min"] = 8, 
-			}, 
-			["1HSword"] = {
-				["max"] = 40, 
-				["min"] = 8, 
-			}, 
 			["1HWeapon"] = {
 				["max"] = 40, 
 				["min"] = 8, 
 			}, 
-			["2HAxe"] = {
-				["max"] = 40, 
-				["min"] = 8, 
-			}, 
-			["2HMace"] = {
-				["max"] = 40, 
-				["min"] = 8, 
-			}, 
-			["2HSword"] = {
-				["max"] = 40, 
-				["min"] = 8, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 40, 
-				["min"] = 8, 
-			}, 
-			["Amulet"] = {
-				["max"] = 30, 
-				["min"] = 20, 
-				["subType"] = "Talisman", 
-			}, 
-			["Boots"] = {
-				["max"] = 16, 
-				["min"] = 3, 
-				["subType"] = "Energy Shield", 
-			}, 
-			["Bow"] = {
-				["max"] = 40, 
-				["min"] = 8, 
-			}, 
 			["Chest"] = {
-				["max"] = 16, 
+				["max"] = 10, 
 				["min"] = 3, 
-				["subType"] = "Energy Shield", 
-			}, 
-			["Claw"] = {
-				["max"] = 40, 
-				["min"] = 8, 
-			}, 
-			["Dagger"] = {
-				["max"] = 40, 
-				["min"] = 8, 
 			}, 
 			["Gloves"] = {
 				["max"] = 16, 
-				["min"] = 3, 
-				["subType"] = "Energy Shield", 
-			}, 
-			["Helmet"] = {
-				["max"] = 16, 
-				["min"] = 3, 
-				["subType"] = "Energy Shield", 
+				["min"] = 12, 
 			}, 
 			["Shield"] = {
 				["max"] = 15, 
 				["min"] = 5, 
-				["subType"] = "Energy Shield", 
-			}, 
-			["Staff"] = {
-				["max"] = 40, 
-				["min"] = 8, 
 			}, 
 			["Wand"] = {
 				["max"] = 40, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -61201,7 +56656,6 @@ return {
 				["max"] = 9, 
 				["min"] = 2.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -61211,15 +56665,7 @@ return {
 			}, 
 		}, 
 		["implicit.stat_3141070085"] = {
-			["1HAxe"] = {
-				["max"] = 40, 
-				["min"] = 10, 
-			}, 
 			["1HMace"] = {
-				["max"] = 40, 
-				["min"] = 10, 
-			}, 
-			["1HSword"] = {
 				["max"] = 40, 
 				["min"] = 10, 
 			}, 
@@ -61227,47 +56673,10 @@ return {
 				["max"] = 40, 
 				["min"] = 10, 
 			}, 
-			["2HAxe"] = {
-				["max"] = 40, 
-				["min"] = 10, 
-			}, 
-			["2HMace"] = {
-				["max"] = 40, 
-				["min"] = 10, 
-			}, 
-			["2HSword"] = {
-				["max"] = 40, 
-				["min"] = 10, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 40, 
-				["min"] = 10, 
-			}, 
-			["Bow"] = {
-				["max"] = 40, 
-				["min"] = 10, 
-			}, 
-			["Claw"] = {
-				["max"] = 40, 
-				["min"] = 10, 
-			}, 
-			["Dagger"] = {
-				["max"] = 40, 
-				["min"] = 10, 
-			}, 
 			["Ring"] = {
 				["max"] = 25, 
 				["min"] = 15, 
 			}, 
-			["Staff"] = {
-				["max"] = 40, 
-				["min"] = 10, 
-			}, 
-			["Wand"] = {
-				["max"] = 40, 
-				["min"] = 10, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -61276,32 +56685,17 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_3143208761"] = {
-			["Amulet"] = {
-				["max"] = 16, 
-				["min"] = 12, 
-				["subType"] = "Talisman", 
-			}, 
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_3143208761", 
-				["text"] = "#% increased Attributes", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_3182714256"] = {
 			["Amulet"] = {
-				["max"] = 1, 
-				["min"] = 1, 
+				["max"] = -1, 
+				["min"] = -2, 
 			}, 
 			["Ring"] = {
-				["max"] = 1, 
-				["min"] = 1, 
+				["max"] = 3, 
+				["min"] = -3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
+				["overrideModLinePlural"] = "+# Prefix Modifiers allowed", 
 			}, 
 			["tradeMod"] = {
 				["id"] = "implicit.stat_3182714256", 
@@ -61310,59 +56704,10 @@ return {
 			}, 
 		}, 
 		["implicit.stat_321077055"] = {
-			["1HAxe"] = {
-				["max"] = 165, 
-				["min"] = 57.5, 
-			}, 
-			["1HMace"] = {
-				["max"] = 165, 
-				["min"] = 57.5, 
-			}, 
-			["1HSword"] = {
-				["max"] = 165, 
-				["min"] = 57.5, 
-			}, 
-			["1HWeapon"] = {
-				["max"] = 165, 
-				["min"] = 57.5, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 165, 
-				["min"] = 57.5, 
-			}, 
-			["2HMace"] = {
-				["max"] = 165, 
-				["min"] = 57.5, 
-			}, 
-			["2HSword"] = {
-				["max"] = 165, 
-				["min"] = 57.5, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 165, 
-				["min"] = 57.5, 
-			}, 
 			["Bow"] = {
 				["max"] = 165, 
 				["min"] = 57.5, 
 			}, 
-			["Claw"] = {
-				["max"] = 165, 
-				["min"] = 57.5, 
-			}, 
-			["Dagger"] = {
-				["max"] = 165, 
-				["min"] = 57.5, 
-			}, 
-			["Staff"] = {
-				["max"] = 165, 
-				["min"] = 57.5, 
-			}, 
-			["Wand"] = {
-				["max"] = 165, 
-				["min"] = 57.5, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -61380,7 +56725,6 @@ return {
 				["max"] = 40, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -61394,7 +56738,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -61403,55 +56746,14 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_3291658075"] = {
-			["Amulet"] = {
-				["max"] = 30, 
-				["min"] = 20, 
-				["subType"] = "Talisman", 
-			}, 
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_3291658075", 
-				["text"] = "#% increased Cold Damage", 
-				["type"] = "implicit", 
-			}, 
-		}, 
-		["implicit.stat_3296814491"] = {
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_3296814491", 
-				["text"] = "#% increased Effect of Chill from Melee Weapons", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_3299347043"] = {
 			["Belt"] = {
 				["max"] = 40, 
 				["min"] = 25, 
 			}, 
-			["Boots"] = {
-				["max"] = 40, 
-				["min"] = 10, 
-				["subType"] = "Armour", 
-			}, 
-			["Chest"] = {
-				["max"] = 40, 
-				["min"] = 10, 
-				["subType"] = "Armour", 
-			}, 
 			["Gloves"] = {
-				["max"] = 40, 
-				["min"] = 10, 
-				["subType"] = "Armour", 
-			}, 
-			["Helmet"] = {
-				["max"] = 40, 
-				["min"] = 10, 
-				["subType"] = "Armour", 
+				["max"] = 30, 
+				["min"] = 20, 
 			}, 
 			["Ring"] = {
 				["max"] = 30, 
@@ -61460,9 +56762,7 @@ return {
 			["Shield"] = {
 				["max"] = 40, 
 				["min"] = 10, 
-				["subType"] = "Armour", 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -61475,7 +56775,6 @@ return {
 			["Flask"] = {
 				["max"] = 1, 
 				["min"] = 1, 
-				["subType"] = "Utility", 
 			}, 
 			["specialCaseData"] = {
 			}, 
@@ -61490,7 +56789,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -61499,12 +56797,25 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
+		["implicit.stat_3320868777"] = {
+			["Ring"] = {
+				["max"] = -15, 
+				["min"] = -15, 
+			}, 
+			["invertOnNegative"] = true, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_3320868777", 
+				["text"] = "Left ring slot: #% increased Skill Effect Duration", 
+				["type"] = "implicit", 
+			}, 
+		}, 
 		["implicit.stat_3325883026"] = {
 			["Amulet"] = {
 				["max"] = 4, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -61522,7 +56833,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -61536,7 +56846,6 @@ return {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -61545,32 +56854,30 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_3375859421"] = {
-			["Amulet"] = {
-				["max"] = 50, 
-				["min"] = 50, 
-				["subType"] = "Talisman", 
-			}, 
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_3375859421", 
-				["text"] = "#% of Lightning Damage from Hits taken as Fire Damage", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_3407849389"] = {
 			["Ring"] = {
 				["max"] = 50, 
 				["min"] = 50, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
 				["id"] = "implicit.stat_3407849389", 
 				["text"] = "#% reduced Effect of Curses on you", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_3417757416"] = {
+			["Gloves"] = {
+				["max"] = -30, 
+				["min"] = -30, 
+			}, 
+			["invertOnNegative"] = true, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_3417757416", 
+				["text"] = "#% increased Cooldown Recovery Rate for throwing Traps", 
 				["type"] = "implicit", 
 			}, 
 		}, 
@@ -61591,28 +56898,11 @@ return {
 			["Boots"] = {
 				["max"] = 12, 
 				["min"] = 8, 
-				["subType"] = "Armour/Energy Shield", 
-			}, 
-			["Chest"] = {
-				["max"] = 12, 
-				["min"] = 8, 
-				["subType"] = "Armour/Energy Shield", 
-			}, 
-			["Gloves"] = {
-				["max"] = 12, 
-				["min"] = 8, 
-				["subType"] = "Armour/Energy Shield", 
-			}, 
-			["Helmet"] = {
-				["max"] = 12, 
-				["min"] = 8, 
-				["subType"] = "Armour/Energy Shield", 
 			}, 
 			["Ring"] = {
 				["max"] = 16, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -61622,34 +56912,6 @@ return {
 			}, 
 		}, 
 		["implicit.stat_3489782002"] = {
-			["1HAxe"] = {
-				["max"] = 165, 
-				["min"] = 66, 
-			}, 
-			["1HMace"] = {
-				["max"] = 165, 
-				["min"] = 66, 
-			}, 
-			["1HSword"] = {
-				["max"] = 165, 
-				["min"] = 66, 
-			}, 
-			["1HWeapon"] = {
-				["max"] = 165, 
-				["min"] = 66, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 165, 
-				["min"] = 66, 
-			}, 
-			["2HMace"] = {
-				["max"] = 165, 
-				["min"] = 66, 
-			}, 
-			["2HSword"] = {
-				["max"] = 165, 
-				["min"] = 66, 
-			}, 
 			["2HWeapon"] = {
 				["max"] = 165, 
 				["min"] = 66, 
@@ -61657,18 +56919,6 @@ return {
 			["Belt"] = {
 				["max"] = 80, 
 				["min"] = 9, 
-			}, 
-			["Bow"] = {
-				["max"] = 165, 
-				["min"] = 66, 
-			}, 
-			["Claw"] = {
-				["max"] = 165, 
-				["min"] = 66, 
-			}, 
-			["Dagger"] = {
-				["max"] = 165, 
-				["min"] = 66, 
 			}, 
 			["Ring"] = {
 				["max"] = 25, 
@@ -61678,11 +56928,6 @@ return {
 				["max"] = 165, 
 				["min"] = 66, 
 			}, 
-			["Wand"] = {
-				["max"] = 165, 
-				["min"] = 66, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -61691,40 +56936,22 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
+		["implicit.stat_3527617737"] = {
+			["Belt"] = {
+				["max"] = 1, 
+				["min"] = 1, 
+			}, 
+			["specialCaseData"] = {
+				["overrideModLineSingular"] = "Has 1 Abyssal Socket", 
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_3527617737", 
+				["text"] = "Has # Abyssal Sockets", 
+				["type"] = "implicit", 
+			}, 
+		}, 
 		["implicit.stat_3531280422"] = {
-			["1HAxe"] = {
-				["max"] = 88, 
-				["min"] = 39, 
-			}, 
-			["1HMace"] = {
-				["max"] = 88, 
-				["min"] = 39, 
-			}, 
-			["1HSword"] = {
-				["max"] = 88, 
-				["min"] = 39, 
-			}, 
 			["1HWeapon"] = {
-				["max"] = 88, 
-				["min"] = 39, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 88, 
-				["min"] = 39, 
-			}, 
-			["2HMace"] = {
-				["max"] = 88, 
-				["min"] = 39, 
-			}, 
-			["2HSword"] = {
-				["max"] = 88, 
-				["min"] = 39, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 88, 
-				["min"] = 39, 
-			}, 
-			["Bow"] = {
 				["max"] = 88, 
 				["min"] = 39, 
 			}, 
@@ -61732,19 +56959,6 @@ return {
 				["max"] = 88, 
 				["min"] = 39, 
 			}, 
-			["Dagger"] = {
-				["max"] = 88, 
-				["min"] = 39, 
-			}, 
-			["Staff"] = {
-				["max"] = 88, 
-				["min"] = 39, 
-			}, 
-			["Wand"] = {
-				["max"] = 88, 
-				["min"] = 39, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -61754,77 +56968,26 @@ return {
 			}, 
 		}, 
 		["implicit.stat_3556824919"] = {
-			["1HAxe"] = {
-				["max"] = 50, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
-			}, 
-			["1HMace"] = {
-				["max"] = 50, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
-			}, 
 			["1HSword"] = {
-				["max"] = 50, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
+				["max"] = 35, 
+				["min"] = 25, 
 			}, 
 			["1HWeapon"] = {
-				["max"] = 50, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
-			}, 
-			["2HAxe"] = {
-				["max"] = 50, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
-			}, 
-			["2HMace"] = {
-				["max"] = 50, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
+				["max"] = 35, 
+				["min"] = 25, 
 			}, 
 			["2HSword"] = {
 				["max"] = 50, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
+				["min"] = 25, 
 			}, 
 			["2HWeapon"] = {
 				["max"] = 50, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
-			}, 
-			["Amulet"] = {
-				["max"] = 36, 
-				["min"] = 24, 
-				["subType"] = "Talisman", 
+				["min"] = 25, 
 			}, 
 			["Bow"] = {
-				["max"] = 50, 
+				["max"] = 25, 
 				["min"] = 15, 
-				["subType"] = "Thrusting", 
 			}, 
-			["Claw"] = {
-				["max"] = 50, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
-			}, 
-			["Dagger"] = {
-				["max"] = 50, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
-			}, 
-			["Staff"] = {
-				["max"] = 50, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
-			}, 
-			["Wand"] = {
-				["max"] = 50, 
-				["min"] = 15, 
-				["subType"] = "Thrusting", 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -61834,55 +56997,11 @@ return {
 			}, 
 		}, 
 		["implicit.stat_3574189159"] = {
-			["1HAxe"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
 			["1HMace"] = {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["1HSword"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
 			["1HWeapon"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HMace"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HSword"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Bow"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Claw"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Dagger"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Staff"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Wand"] = {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
@@ -61895,39 +57014,7 @@ return {
 			}, 
 		}, 
 		["implicit.stat_3593843976"] = {
-			["1HAxe"] = {
-				["max"] = 2, 
-				["min"] = 1.6, 
-			}, 
-			["1HMace"] = {
-				["max"] = 2, 
-				["min"] = 1.6, 
-			}, 
-			["1HSword"] = {
-				["max"] = 2, 
-				["min"] = 1.6, 
-			}, 
 			["1HWeapon"] = {
-				["max"] = 2, 
-				["min"] = 1.6, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 2, 
-				["min"] = 1.6, 
-			}, 
-			["2HMace"] = {
-				["max"] = 2, 
-				["min"] = 1.6, 
-			}, 
-			["2HSword"] = {
-				["max"] = 2, 
-				["min"] = 1.6, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 2, 
-				["min"] = 1.6, 
-			}, 
-			["Bow"] = {
 				["max"] = 2, 
 				["min"] = 1.6, 
 			}, 
@@ -61935,19 +57022,6 @@ return {
 				["max"] = 2, 
 				["min"] = 1.6, 
 			}, 
-			["Dagger"] = {
-				["max"] = 2, 
-				["min"] = 1.6, 
-			}, 
-			["Staff"] = {
-				["max"] = 2, 
-				["min"] = 1.6, 
-			}, 
-			["Wand"] = {
-				["max"] = 2, 
-				["min"] = 1.6, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -61956,33 +57030,11 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_3660450649"] = {
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_3660450649", 
-				["text"] = "#% increased Damage with Bleeding from Melee Weapons", 
-				["type"] = "implicit", 
-			}, 
-		}, 
-		["implicit.stat_3678828098"] = {
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_3678828098", 
-				["text"] = "#% increased Critical Strike Chance with Melee Weapons", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_3680664274"] = {
 			["Shield"] = {
 				["max"] = 5, 
 				["min"] = 3, 
-				["subType"] = "Evasion/Energy Shield", 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -61992,32 +57044,10 @@ return {
 			}, 
 		}, 
 		["implicit.stat_369183568"] = {
-			["Boots"] = {
-				["max"] = 180, 
-				["min"] = 60, 
-				["subType"] = "Armour/Evasion", 
-			}, 
-			["Chest"] = {
-				["max"] = 180, 
-				["min"] = 60, 
-				["subType"] = "Armour/Evasion", 
-			}, 
-			["Gloves"] = {
-				["max"] = 180, 
-				["min"] = 60, 
-				["subType"] = "Armour/Evasion", 
-			}, 
-			["Helmet"] = {
-				["max"] = 180, 
-				["min"] = 60, 
-				["subType"] = "Armour/Evasion", 
-			}, 
 			["Shield"] = {
 				["max"] = 180, 
 				["min"] = 60, 
-				["subType"] = "Armour/Evasion", 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -62026,27 +57056,11 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_3753703249"] = {
-			["Amulet"] = {
-				["max"] = 12, 
-				["min"] = 6, 
-				["subType"] = "Talisman", 
-			}, 
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_3753703249", 
-				["text"] = "Gain #% of Physical Damage as Extra Damage of a random Element", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_3759663284"] = {
 			["Quiver"] = {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -62056,32 +57070,10 @@ return {
 			}, 
 		}, 
 		["implicit.stat_3771516363"] = {
-			["Amulet"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-				["subType"] = "Talisman", 
-			}, 
-			["Boots"] = {
-				["max"] = 15, 
-				["min"] = 15, 
-				["subType"] = "Armour/Evasion", 
-			}, 
-			["Chest"] = {
-				["max"] = 15, 
-				["min"] = 15, 
-				["subType"] = "Armour/Evasion", 
-			}, 
-			["Gloves"] = {
-				["max"] = 15, 
-				["min"] = 15, 
-				["subType"] = "Armour/Evasion", 
-			}, 
 			["Helmet"] = {
-				["max"] = 15, 
-				["min"] = 15, 
-				["subType"] = "Armour/Evasion", 
+				["max"] = -15, 
+				["min"] = -15, 
 			}, 
-			["sign"] = "-", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -62091,63 +57083,22 @@ return {
 			}, 
 		}, 
 		["implicit.stat_387439868"] = {
-			["1HAxe"] = {
-				["max"] = 30, 
-				["min"] = 20, 
-			}, 
-			["1HMace"] = {
-				["max"] = 30, 
-				["min"] = 20, 
-			}, 
-			["1HSword"] = {
-				["max"] = 30, 
-				["min"] = 20, 
-			}, 
-			["1HWeapon"] = {
-				["max"] = 30, 
-				["min"] = 20, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 30, 
-				["min"] = 20, 
-			}, 
-			["2HMace"] = {
-				["max"] = 30, 
-				["min"] = 20, 
-			}, 
 			["2HSword"] = {
 				["max"] = 30, 
-				["min"] = 20, 
+				["min"] = 30, 
 			}, 
 			["2HWeapon"] = {
 				["max"] = 30, 
-				["min"] = 20, 
+				["min"] = 30, 
 			}, 
 			["Bow"] = {
-				["max"] = 30, 
-				["min"] = 20, 
-			}, 
-			["Claw"] = {
-				["max"] = 30, 
-				["min"] = 20, 
-			}, 
-			["Dagger"] = {
-				["max"] = 30, 
+				["max"] = 24, 
 				["min"] = 20, 
 			}, 
 			["Quiver"] = {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["Staff"] = {
-				["max"] = 30, 
-				["min"] = 20, 
-			}, 
-			["Wand"] = {
-				["max"] = 30, 
-				["min"] = 20, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -62169,7 +57120,6 @@ return {
 				["max"] = 15, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -62178,77 +57128,8 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_3935936274"] = {
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_3935936274", 
-				["text"] = "#% increased Damage with Ignite from Melee Weapons", 
-				["type"] = "implicit", 
-			}, 
-		}, 
-		["implicit.stat_3962278098"] = {
-			["Amulet"] = {
-				["max"] = 30, 
-				["min"] = 20, 
-				["subType"] = "Talisman", 
-			}, 
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_3962278098", 
-				["text"] = "#% increased Fire Damage", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_3964634628"] = {
-			["1HAxe"] = {
-				["max"] = 47.5, 
-				["min"] = 2, 
-			}, 
-			["1HMace"] = {
-				["max"] = 47.5, 
-				["min"] = 2, 
-			}, 
-			["1HSword"] = {
-				["max"] = 47.5, 
-				["min"] = 2, 
-			}, 
 			["1HWeapon"] = {
-				["max"] = 47.5, 
-				["min"] = 2, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 47.5, 
-				["min"] = 2, 
-			}, 
-			["2HMace"] = {
-				["max"] = 47.5, 
-				["min"] = 2, 
-			}, 
-			["2HSword"] = {
-				["max"] = 47.5, 
-				["min"] = 2, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 47.5, 
-				["min"] = 2, 
-			}, 
-			["Bow"] = {
-				["max"] = 47.5, 
-				["min"] = 2, 
-			}, 
-			["Claw"] = {
-				["max"] = 47.5, 
-				["min"] = 2, 
-			}, 
-			["Dagger"] = {
-				["max"] = 47.5, 
-				["min"] = 2, 
-			}, 
-			["Staff"] = {
 				["max"] = 47.5, 
 				["min"] = 2, 
 			}, 
@@ -62256,7 +57137,6 @@ return {
 				["max"] = 47.5, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -62265,27 +57145,11 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_3988349707"] = {
-			["Amulet"] = {
-				["max"] = 18, 
-				["min"] = 12, 
-				["subType"] = "Talisman", 
-			}, 
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_3988349707", 
-				["text"] = "+#% to Damage over Time Multiplier", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_4067062424"] = {
 			["Quiver"] = {
 				["max"] = 2.5, 
 				["min"] = 2.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -62298,7 +57162,6 @@ return {
 			["Amulet"] = {
 				["max"] = 1, 
 				["min"] = 1, 
-				["subType"] = "Talisman", 
 			}, 
 			["Belt"] = {
 				["max"] = 1, 
@@ -62329,7 +57192,6 @@ return {
 				["max"] = 35, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -62339,72 +57201,14 @@ return {
 			}, 
 		}, 
 		["implicit.stat_4138979329"] = {
-			["1HAxe"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-				["subType"] = "Warstaff", 
-			}, 
-			["1HMace"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-				["subType"] = "Warstaff", 
-			}, 
-			["1HSword"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-				["subType"] = "Warstaff", 
-			}, 
-			["1HWeapon"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-				["subType"] = "Warstaff", 
-			}, 
-			["2HAxe"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-				["subType"] = "Warstaff", 
-			}, 
-			["2HMace"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-				["subType"] = "Warstaff", 
-			}, 
-			["2HSword"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-				["subType"] = "Warstaff", 
-			}, 
 			["2HWeapon"] = {
 				["max"] = 1, 
 				["min"] = 1, 
-				["subType"] = "Warstaff", 
-			}, 
-			["Bow"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-				["subType"] = "Warstaff", 
-			}, 
-			["Claw"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-				["subType"] = "Warstaff", 
-			}, 
-			["Dagger"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-				["subType"] = "Warstaff", 
 			}, 
 			["Staff"] = {
 				["max"] = 1, 
 				["min"] = 1, 
-				["subType"] = "Warstaff", 
 			}, 
-			["Wand"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-				["subType"] = "Warstaff", 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -62417,24 +57221,7 @@ return {
 			["Boots"] = {
 				["max"] = 3.5, 
 				["min"] = 3, 
-				["subType"] = "Evasion", 
 			}, 
-			["Chest"] = {
-				["max"] = 3.5, 
-				["min"] = 3, 
-				["subType"] = "Evasion", 
-			}, 
-			["Gloves"] = {
-				["max"] = 3.5, 
-				["min"] = 3, 
-				["subType"] = "Evasion", 
-			}, 
-			["Helmet"] = {
-				["max"] = 3.5, 
-				["min"] = 3, 
-				["subType"] = "Evasion", 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -62444,27 +57231,10 @@ return {
 			}, 
 		}, 
 		["implicit.stat_4154259475"] = {
-			["Boots"] = {
-				["max"] = 2, 
-				["min"] = 1, 
-				["subType"] = "Armour/Energy Shield", 
-			}, 
-			["Chest"] = {
-				["max"] = 2, 
-				["min"] = 1, 
-				["subType"] = "Armour/Energy Shield", 
-			}, 
-			["Gloves"] = {
-				["max"] = 2, 
-				["min"] = 1, 
-				["subType"] = "Armour/Energy Shield", 
-			}, 
 			["Helmet"] = {
-				["max"] = 2, 
-				["min"] = 1, 
-				["subType"] = "Armour/Energy Shield", 
+				["max"] = -1, 
+				["min"] = -2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -62474,27 +57244,10 @@ return {
 			}, 
 		}, 
 		["implicit.stat_4180346416"] = {
-			["Boots"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-				["subType"] = "Armour/Evasion/Energy Shield", 
-			}, 
 			["Chest"] = {
 				["max"] = 1, 
 				["min"] = 1, 
-				["subType"] = "Armour/Evasion/Energy Shield", 
 			}, 
-			["Gloves"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-				["subType"] = "Armour/Evasion/Energy Shield", 
-			}, 
-			["Helmet"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-				["subType"] = "Armour/Evasion/Energy Shield", 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -62503,22 +57256,11 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_4206255461"] = {
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_4206255461", 
-				["text"] = "#% chance to Ignite with Melee Weapons", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_4220027924"] = {
 			["Ring"] = {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -62528,31 +57270,7 @@ return {
 			}, 
 		}, 
 		["implicit.stat_4251717817"] = {
-			["1HAxe"] = {
-				["max"] = 30, 
-				["min"] = 30, 
-			}, 
-			["1HMace"] = {
-				["max"] = 30, 
-				["min"] = 30, 
-			}, 
-			["1HSword"] = {
-				["max"] = 30, 
-				["min"] = 30, 
-			}, 
-			["1HWeapon"] = {
-				["max"] = 30, 
-				["min"] = 30, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 30, 
-				["min"] = 30, 
-			}, 
 			["2HMace"] = {
-				["max"] = 30, 
-				["min"] = 30, 
-			}, 
-			["2HSword"] = {
 				["max"] = 30, 
 				["min"] = 30, 
 			}, 
@@ -62560,27 +57278,6 @@ return {
 				["max"] = 30, 
 				["min"] = 30, 
 			}, 
-			["Bow"] = {
-				["max"] = 30, 
-				["min"] = 30, 
-			}, 
-			["Claw"] = {
-				["max"] = 30, 
-				["min"] = 30, 
-			}, 
-			["Dagger"] = {
-				["max"] = 30, 
-				["min"] = 30, 
-			}, 
-			["Staff"] = {
-				["max"] = 30, 
-				["min"] = 30, 
-			}, 
-			["Wand"] = {
-				["max"] = 30, 
-				["min"] = 30, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -62593,13 +57290,11 @@ return {
 			["Boots"] = {
 				["max"] = 12, 
 				["min"] = 8, 
-				["subType"] = "Evasion/Energy Shield", 
 			}, 
 			["Ring"] = {
 				["max"] = 16, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -62613,7 +57308,6 @@ return {
 				["max"] = 30, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -62623,51 +57317,7 @@ return {
 			}, 
 		}, 
 		["implicit.stat_4282426229"] = {
-			["1HAxe"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["1HMace"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["1HSword"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
 			["1HWeapon"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HMace"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HSword"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Bow"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Claw"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Dagger"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Staff"] = {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
@@ -62688,7 +57338,6 @@ return {
 				["max"] = 25, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -62697,38 +57346,25 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_503138266"] = {
-			["sign"] = "", 
+		["implicit.stat_496053892"] = {
+			["Ring"] = {
+				["max"] = -30, 
+				["min"] = -30, 
+			}, 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
-				["id"] = "implicit.stat_503138266", 
-				["text"] = "#% increased Elemental Damage with Melee Weapons", 
+				["id"] = "implicit.stat_496053892", 
+				["text"] = "Left ring slot: #% increased Effect of Curses on you", 
 				["type"] = "implicit", 
 			}, 
 		}, 
 		["implicit.stat_524797741"] = {
-			["Boots"] = {
-				["max"] = 2, 
-				["min"] = 1, 
-				["subType"] = "Armour/Energy Shield", 
-			}, 
-			["Chest"] = {
-				["max"] = 2, 
-				["min"] = 1, 
-				["subType"] = "Armour/Energy Shield", 
-			}, 
-			["Gloves"] = {
-				["max"] = 2, 
-				["min"] = 1, 
-				["subType"] = "Armour/Energy Shield", 
-			}, 
 			["Helmet"] = {
 				["max"] = 2, 
 				["min"] = 1, 
-				["subType"] = "Armour/Energy Shield", 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -62758,7 +57394,6 @@ return {
 			["Flask"] = {
 				["max"] = 1, 
 				["min"] = 1, 
-				["subType"] = "Utility", 
 			}, 
 			["specialCaseData"] = {
 			}, 
@@ -62769,30 +57404,6 @@ return {
 			}, 
 		}, 
 		["implicit.stat_538848803"] = {
-			["1HAxe"] = {
-				["max"] = 50, 
-				["min"] = 50, 
-			}, 
-			["1HMace"] = {
-				["max"] = 50, 
-				["min"] = 50, 
-			}, 
-			["1HSword"] = {
-				["max"] = 50, 
-				["min"] = 50, 
-			}, 
-			["1HWeapon"] = {
-				["max"] = 50, 
-				["min"] = 50, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 50, 
-				["min"] = 50, 
-			}, 
-			["2HMace"] = {
-				["max"] = 50, 
-				["min"] = 50, 
-			}, 
 			["2HSword"] = {
 				["max"] = 50, 
 				["min"] = 50, 
@@ -62805,27 +57416,6 @@ return {
 				["max"] = 24, 
 				["min"] = 16, 
 			}, 
-			["Bow"] = {
-				["max"] = 50, 
-				["min"] = 50, 
-			}, 
-			["Claw"] = {
-				["max"] = 50, 
-				["min"] = 50, 
-			}, 
-			["Dagger"] = {
-				["max"] = 50, 
-				["min"] = 50, 
-			}, 
-			["Staff"] = {
-				["max"] = 50, 
-				["min"] = 50, 
-			}, 
-			["Wand"] = {
-				["max"] = 50, 
-				["min"] = 50, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -62835,55 +57425,11 @@ return {
 			}, 
 		}, 
 		["implicit.stat_563547620"] = {
-			["1HAxe"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["1HMace"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["1HSword"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["1HWeapon"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HMace"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["2HSword"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
 			["2HWeapon"] = {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["Bow"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Claw"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Dagger"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
 			["Staff"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-			}, 
-			["Wand"] = {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
@@ -62896,65 +57442,17 @@ return {
 			}, 
 		}, 
 		["implicit.stat_587431675"] = {
-			["1HAxe"] = {
-				["max"] = 100, 
-				["min"] = 30, 
-				["subType"] = "Rune", 
-			}, 
-			["1HMace"] = {
-				["max"] = 100, 
-				["min"] = 30, 
-				["subType"] = "Rune", 
-			}, 
-			["1HSword"] = {
-				["max"] = 100, 
-				["min"] = 30, 
-				["subType"] = "Rune", 
-			}, 
 			["1HWeapon"] = {
-				["max"] = 100, 
+				["max"] = 50, 
 				["min"] = 30, 
-				["subType"] = "Rune", 
-			}, 
-			["2HAxe"] = {
-				["max"] = 100, 
-				["min"] = 30, 
-				["subType"] = "Rune", 
-			}, 
-			["2HMace"] = {
-				["max"] = 100, 
-				["min"] = 30, 
-				["subType"] = "Rune", 
-			}, 
-			["2HSword"] = {
-				["max"] = 100, 
-				["min"] = 30, 
-				["subType"] = "Rune", 
 			}, 
 			["2HWeapon"] = {
 				["max"] = 100, 
-				["min"] = 30, 
-				["subType"] = "Rune", 
-			}, 
-			["Amulet"] = {
-				["max"] = 50, 
-				["min"] = 40, 
-				["subType"] = "Talisman", 
-			}, 
-			["Bow"] = {
-				["max"] = 100, 
-				["min"] = 30, 
-				["subType"] = "Rune", 
-			}, 
-			["Claw"] = {
-				["max"] = 100, 
-				["min"] = 30, 
-				["subType"] = "Rune", 
+				["min"] = 80, 
 			}, 
 			["Dagger"] = {
-				["max"] = 100, 
+				["max"] = 50, 
 				["min"] = 30, 
-				["subType"] = "Rune", 
 			}, 
 			["Ring"] = {
 				["max"] = 30, 
@@ -62962,15 +57460,8 @@ return {
 			}, 
 			["Staff"] = {
 				["max"] = 100, 
-				["min"] = 30, 
-				["subType"] = "Rune", 
+				["min"] = 80, 
 			}, 
-			["Wand"] = {
-				["max"] = 100, 
-				["min"] = 30, 
-				["subType"] = "Rune", 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -62993,28 +57484,12 @@ return {
 			}, 
 		}, 
 		["implicit.stat_624954515"] = {
-			["1HAxe"] = {
-				["max"] = 60, 
-				["min"] = 40, 
-			}, 
-			["1HMace"] = {
-				["max"] = 60, 
-				["min"] = 40, 
-			}, 
 			["1HSword"] = {
-				["max"] = 60, 
+				["max"] = 40, 
 				["min"] = 40, 
 			}, 
 			["1HWeapon"] = {
-				["max"] = 60, 
-				["min"] = 40, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 60, 
-				["min"] = 40, 
-			}, 
-			["2HMace"] = {
-				["max"] = 60, 
+				["max"] = 40, 
 				["min"] = 40, 
 			}, 
 			["2HSword"] = {
@@ -63025,31 +57500,10 @@ return {
 				["max"] = 60, 
 				["min"] = 40, 
 			}, 
-			["Bow"] = {
-				["max"] = 60, 
-				["min"] = 40, 
-			}, 
-			["Claw"] = {
-				["max"] = 60, 
-				["min"] = 40, 
-			}, 
-			["Dagger"] = {
-				["max"] = 60, 
-				["min"] = 40, 
-			}, 
 			["Quiver"] = {
 				["max"] = 30, 
 				["min"] = 20, 
 			}, 
-			["Staff"] = {
-				["max"] = 60, 
-				["min"] = 40, 
-			}, 
-			["Wand"] = {
-				["max"] = 60, 
-				["min"] = 40, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -63059,39 +57513,7 @@ return {
 			}, 
 		}, 
 		["implicit.stat_640052854"] = {
-			["1HAxe"] = {
-				["max"] = 14, 
-				["min"] = 6, 
-			}, 
-			["1HMace"] = {
-				["max"] = 14, 
-				["min"] = 6, 
-			}, 
-			["1HSword"] = {
-				["max"] = 14, 
-				["min"] = 6, 
-			}, 
 			["1HWeapon"] = {
-				["max"] = 14, 
-				["min"] = 6, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 14, 
-				["min"] = 6, 
-			}, 
-			["2HMace"] = {
-				["max"] = 14, 
-				["min"] = 6, 
-			}, 
-			["2HSword"] = {
-				["max"] = 14, 
-				["min"] = 6, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 14, 
-				["min"] = 6, 
-			}, 
-			["Bow"] = {
 				["max"] = 14, 
 				["min"] = 6, 
 			}, 
@@ -63099,19 +57521,6 @@ return {
 				["max"] = 14, 
 				["min"] = 6, 
 			}, 
-			["Dagger"] = {
-				["max"] = 14, 
-				["min"] = 6, 
-			}, 
-			["Staff"] = {
-				["max"] = 14, 
-				["min"] = 6, 
-			}, 
-			["Wand"] = {
-				["max"] = 14, 
-				["min"] = 6, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -63120,16 +57529,22 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
+		["implicit.stat_680068163"] = {
+			["Boots"] = {
+				["max"] = -20, 
+				["min"] = -20, 
+			}, 
+			["invertOnNegative"] = true, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_680068163", 
+				["text"] = "#% increased Stun Threshold", 
+				["type"] = "implicit", 
+			}, 
+		}, 
 		["implicit.stat_681332047"] = {
-			["1HAxe"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
 			["1HMace"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["1HSword"] = {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
@@ -63137,47 +57552,10 @@ return {
 				["max"] = 6, 
 				["min"] = 4, 
 			}, 
-			["2HAxe"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["2HMace"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["2HSword"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["Bow"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["Claw"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["Dagger"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
 			["Quiver"] = {
 				["max"] = 10, 
 				["min"] = 8, 
 			}, 
-			["Staff"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["Wand"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -63188,15 +57566,15 @@ return {
 		}, 
 		["implicit.stat_718638445"] = {
 			["Amulet"] = {
-				["max"] = 1, 
-				["min"] = 1, 
+				["max"] = -1, 
+				["min"] = -2, 
 			}, 
 			["Ring"] = {
-				["max"] = 1, 
-				["min"] = 1, 
+				["max"] = 3, 
+				["min"] = -3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
+				["overrideModLinePlural"] = "+# Suffix Modifiers allowed", 
 			}, 
 			["tradeMod"] = {
 				["id"] = "implicit.stat_718638445", 
@@ -63205,31 +57583,7 @@ return {
 			}, 
 		}, 
 		["implicit.stat_734614379"] = {
-			["1HAxe"] = {
-				["max"] = 10, 
-				["min"] = 10, 
-			}, 
-			["1HMace"] = {
-				["max"] = 10, 
-				["min"] = 10, 
-			}, 
-			["1HSword"] = {
-				["max"] = 10, 
-				["min"] = 10, 
-			}, 
-			["1HWeapon"] = {
-				["max"] = 10, 
-				["min"] = 10, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 10, 
-				["min"] = 10, 
-			}, 
 			["2HMace"] = {
-				["max"] = 10, 
-				["min"] = 10, 
-			}, 
-			["2HSword"] = {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
@@ -63237,27 +57591,6 @@ return {
 				["max"] = 10, 
 				["min"] = 10, 
 			}, 
-			["Bow"] = {
-				["max"] = 10, 
-				["min"] = 10, 
-			}, 
-			["Claw"] = {
-				["max"] = 10, 
-				["min"] = 10, 
-			}, 
-			["Dagger"] = {
-				["max"] = 10, 
-				["min"] = 10, 
-			}, 
-			["Staff"] = {
-				["max"] = 10, 
-				["min"] = 10, 
-			}, 
-			["Wand"] = {
-				["max"] = 10, 
-				["min"] = 10, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -63267,16 +57600,10 @@ return {
 			}, 
 		}, 
 		["implicit.stat_736967255"] = {
-			["Amulet"] = {
-				["max"] = 31, 
-				["min"] = 19, 
-				["subType"] = "Talisman", 
-			}, 
 			["Ring"] = {
 				["max"] = 23, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -63290,7 +57617,6 @@ return {
 				["max"] = 25, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -63299,22 +57625,11 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_776174407"] = {
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_776174407", 
-				["text"] = "#% increased Damage with Poison from Melee Weapons", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_789117908"] = {
 			["Amulet"] = {
 				["max"] = 56, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -63323,30 +57638,7 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_800141891"] = {
-			["Amulet"] = {
-				["max"] = 6, 
-				["min"] = 4, 
-				["subType"] = "Talisman", 
-			}, 
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_800141891", 
-				["text"] = "#% chance to Freeze, Shock and Ignite", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_803737631"] = {
-			["1HAxe"] = {
-				["max"] = 475, 
-				["min"] = 45, 
-			}, 
-			["1HMace"] = {
-				["max"] = 475, 
-				["min"] = 45, 
-			}, 
 			["1HSword"] = {
 				["max"] = 475, 
 				["min"] = 45, 
@@ -63355,43 +57647,14 @@ return {
 				["max"] = 475, 
 				["min"] = 45, 
 			}, 
-			["2HAxe"] = {
-				["max"] = 475, 
-				["min"] = 45, 
-			}, 
-			["2HMace"] = {
-				["max"] = 475, 
-				["min"] = 45, 
-			}, 
 			["2HSword"] = {
-				["max"] = 475, 
-				["min"] = 45, 
+				["max"] = 470, 
+				["min"] = 60, 
 			}, 
 			["2HWeapon"] = {
-				["max"] = 475, 
-				["min"] = 45, 
+				["max"] = 470, 
+				["min"] = 60, 
 			}, 
-			["Bow"] = {
-				["max"] = 475, 
-				["min"] = 45, 
-			}, 
-			["Claw"] = {
-				["max"] = 475, 
-				["min"] = 45, 
-			}, 
-			["Dagger"] = {
-				["max"] = 475, 
-				["min"] = 45, 
-			}, 
-			["Staff"] = {
-				["max"] = 475, 
-				["min"] = 45, 
-			}, 
-			["Wand"] = {
-				["max"] = 475, 
-				["min"] = 45, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -63401,39 +57664,7 @@ return {
 			}, 
 		}, 
 		["implicit.stat_821021828"] = {
-			["1HAxe"] = {
-				["max"] = 50, 
-				["min"] = 3, 
-			}, 
-			["1HMace"] = {
-				["max"] = 50, 
-				["min"] = 3, 
-			}, 
-			["1HSword"] = {
-				["max"] = 50, 
-				["min"] = 3, 
-			}, 
 			["1HWeapon"] = {
-				["max"] = 50, 
-				["min"] = 3, 
-			}, 
-			["2HAxe"] = {
-				["max"] = 50, 
-				["min"] = 3, 
-			}, 
-			["2HMace"] = {
-				["max"] = 50, 
-				["min"] = 3, 
-			}, 
-			["2HSword"] = {
-				["max"] = 50, 
-				["min"] = 3, 
-			}, 
-			["2HWeapon"] = {
-				["max"] = 50, 
-				["min"] = 3, 
-			}, 
-			["Bow"] = {
 				["max"] = 50, 
 				["min"] = 3, 
 			}, 
@@ -63441,19 +57672,6 @@ return {
 				["max"] = 50, 
 				["min"] = 3, 
 			}, 
-			["Dagger"] = {
-				["max"] = 50, 
-				["min"] = 3, 
-			}, 
-			["Staff"] = {
-				["max"] = 50, 
-				["min"] = 3, 
-			}, 
-			["Wand"] = {
-				["max"] = 50, 
-				["min"] = 3, 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -63464,11 +57682,9 @@ return {
 		}, 
 		["implicit.stat_836936635"] = {
 			["Amulet"] = {
-				["max"] = 2, 
+				["max"] = 1.6, 
 				["min"] = 1.2, 
-				["subType"] = "Talisman", 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -63478,25 +57694,9 @@ return {
 			}, 
 		}, 
 		["implicit.stat_846313030"] = {
-			["Boots"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-				["subType"] = "Armour/Evasion", 
-			}, 
-			["Chest"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-				["subType"] = "Armour/Evasion", 
-			}, 
-			["Gloves"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-				["subType"] = "Armour/Evasion", 
-			}, 
 			["Helmet"] = {
 				["max"] = 1, 
 				["min"] = 1, 
-				["subType"] = "Armour/Evasion", 
 			}, 
 			["specialCaseData"] = {
 			}, 
@@ -63506,43 +57706,11 @@ return {
 				["type"] = "implicit", 
 			}, 
 		}, 
-		["implicit.stat_966747987"] = {
-			["Amulet"] = {
-				["max"] = 1, 
-				["min"] = 1, 
-				["subType"] = "Talisman", 
-			}, 
-			["sign"] = "", 
-			["specialCaseData"] = {
-			}, 
-			["tradeMod"] = {
-				["id"] = "implicit.stat_966747987", 
-				["text"] = "+# to maximum number of Raised Zombies", 
-				["type"] = "implicit", 
-			}, 
-		}, 
 		["implicit.stat_967627487"] = {
-			["Boots"] = {
-				["max"] = 18, 
-				["min"] = 14, 
-				["subType"] = "Armour/Energy Shield", 
-			}, 
-			["Chest"] = {
-				["max"] = 18, 
-				["min"] = 14, 
-				["subType"] = "Armour/Energy Shield", 
-			}, 
 			["Gloves"] = {
 				["max"] = 18, 
 				["min"] = 14, 
-				["subType"] = "Armour/Energy Shield", 
 			}, 
-			["Helmet"] = {
-				["max"] = 18, 
-				["min"] = 14, 
-				["subType"] = "Armour/Energy Shield", 
-			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -63552,16 +57720,10 @@ return {
 			}, 
 		}, 
 		["implicit.stat_983749596"] = {
-			["Amulet"] = {
-				["max"] = 12, 
-				["min"] = 8, 
-				["subType"] = "Talisman", 
-			}, 
 			["Ring"] = {
 				["max"] = 7, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -66282,7 +60444,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -66296,7 +60457,6 @@ return {
 				["max"] = 9, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -66370,7 +60530,6 @@ return {
 				["max"] = 35, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -66444,7 +60603,6 @@ return {
 				["max"] = 35, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -66506,7 +60664,6 @@ return {
 				["max"] = 35, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -66520,7 +60677,6 @@ return {
 				["max"] = 7, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -66534,7 +60690,6 @@ return {
 				["max"] = 7, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -66548,7 +60703,6 @@ return {
 				["max"] = 7, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -66582,7 +60736,6 @@ return {
 				["max"] = 50, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -66616,7 +60769,6 @@ return {
 				["max"] = 50, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -66630,7 +60782,6 @@ return {
 				["max"] = 16, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -66660,7 +60811,6 @@ return {
 				["max"] = 16, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -66690,7 +60840,6 @@ return {
 				["max"] = 16, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -66720,7 +60869,6 @@ return {
 				["max"] = 16, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -66750,7 +60898,6 @@ return {
 				["max"] = 16, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -66812,7 +60959,6 @@ return {
 				["max"] = 10.5, 
 				["min"] = 3.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Physical Damage", 
 			}, 
@@ -66847,7 +60993,6 @@ return {
 				["max"] = 50, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -66909,7 +61054,6 @@ return {
 				["max"] = 53.5, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Fire Damage", 
 			}, 
@@ -66944,7 +61088,6 @@ return {
 				["max"] = 50, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67006,7 +61149,6 @@ return {
 				["max"] = 50, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Cold Damage", 
 			}, 
@@ -67041,7 +61183,6 @@ return {
 				["max"] = 50, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67103,7 +61244,6 @@ return {
 				["max"] = 59.5, 
 				["min"] = 20.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Lightning Damage", 
 			}, 
@@ -67138,7 +61278,6 @@ return {
 				["max"] = 50, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67200,7 +61339,6 @@ return {
 				["max"] = 24, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Chaos Damage", 
 			}, 
@@ -67235,7 +61373,6 @@ return {
 				["max"] = 30.5, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67269,7 +61406,6 @@ return {
 				["max"] = 30.5, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67303,7 +61439,6 @@ return {
 				["max"] = 30.5, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67337,7 +61472,6 @@ return {
 				["max"] = 32.5, 
 				["min"] = 17.5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67359,7 +61493,6 @@ return {
 				["max"] = 10, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67377,7 +61510,6 @@ return {
 				["max"] = 20, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67391,7 +61523,6 @@ return {
 				["max"] = 8, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67405,7 +61536,6 @@ return {
 				["max"] = 25, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67419,7 +61549,6 @@ return {
 				["max"] = 25, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67433,7 +61562,6 @@ return {
 				["max"] = 25, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67447,7 +61575,6 @@ return {
 				["max"] = 25, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67461,7 +61588,6 @@ return {
 				["max"] = 25, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67511,7 +61637,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67525,7 +61650,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67539,7 +61663,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67565,7 +61688,6 @@ return {
 				["max"] = 150, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to Armour", 
 			}, 
@@ -67592,7 +61714,6 @@ return {
 				["max"] = 150, 
 				["min"] = 30, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to Evasion Rating", 
 			}, 
@@ -67607,7 +61728,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67633,7 +61753,6 @@ return {
 				["max"] = 30, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to maximum Energy Shield", 
 			}, 
@@ -67648,7 +61767,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67674,7 +61792,6 @@ return {
 				["max"] = 25, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67688,7 +61805,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67698,7 +61814,6 @@ return {
 			}, 
 		}, 
 		["1429_IncreasedLife"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67716,7 +61831,6 @@ return {
 				["max"] = 8, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67726,7 +61840,6 @@ return {
 			}, 
 		}, 
 		["1434_LifeRegeneration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67752,7 +61865,6 @@ return {
 				["max"] = 15, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67766,7 +61878,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67788,7 +61899,6 @@ return {
 				["max"] = 40, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67806,7 +61916,6 @@ return {
 				["max"] = 8, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67820,7 +61929,6 @@ return {
 				["max"] = 9.2, 
 				["min"] = 0.8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67870,7 +61978,6 @@ return {
 				["max"] = 45, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67884,7 +61991,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67902,7 +62008,6 @@ return {
 				["max"] = 15, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67936,7 +62041,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67950,7 +62054,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -67984,7 +62087,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68018,7 +62120,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68052,7 +62153,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68086,7 +62186,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68108,7 +62207,6 @@ return {
 				["max"] = 12, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68122,7 +62220,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68136,7 +62233,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68214,7 +62310,6 @@ return {
 				["max"] = 35, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68228,7 +62323,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68242,7 +62336,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68320,7 +62413,6 @@ return {
 				["max"] = 35, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68334,7 +62426,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68412,7 +62503,6 @@ return {
 				["max"] = 35, 
 				["min"] = 18, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68426,7 +62516,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68440,7 +62529,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68518,7 +62606,6 @@ return {
 				["max"] = 25, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68532,7 +62619,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68546,7 +62632,6 @@ return {
 				["max"] = 40, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68572,7 +62657,6 @@ return {
 				["max"] = 0.5, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68586,7 +62670,6 @@ return {
 				["max"] = 0.5, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68600,7 +62683,6 @@ return {
 				["max"] = 0.5, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68614,7 +62696,6 @@ return {
 				["max"] = 0.5, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68628,7 +62709,6 @@ return {
 				["max"] = 0.5, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68642,7 +62722,6 @@ return {
 				["max"] = 0.5, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68656,7 +62735,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68682,7 +62760,6 @@ return {
 				["max"] = 0.5, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68696,7 +62773,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68710,7 +62786,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68724,7 +62799,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68738,7 +62812,6 @@ return {
 				["max"] = 10, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68752,7 +62825,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68766,7 +62838,6 @@ return {
 				["max"] = 5, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68780,7 +62851,6 @@ return {
 				["max"] = 4, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68794,7 +62864,6 @@ return {
 				["max"] = 4, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68808,7 +62877,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68822,7 +62890,6 @@ return {
 				["max"] = 4, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68836,7 +62903,6 @@ return {
 				["max"] = 60, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68850,7 +62916,6 @@ return {
 				["max"] = 60, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68864,7 +62929,6 @@ return {
 				["max"] = 60, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68878,7 +62942,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68896,7 +62959,6 @@ return {
 				["max"] = 15, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68914,7 +62976,6 @@ return {
 				["max"] = 20, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68928,7 +62989,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68942,7 +63002,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68956,7 +63015,6 @@ return {
 				["max"] = 2, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -68978,7 +63036,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLineSingular"] = "Bow Attacks fire an additional Arrow", 
 			}, 
@@ -68993,7 +63050,6 @@ return {
 				["max"] = 25, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69007,7 +63063,6 @@ return {
 				["max"] = 15, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69021,7 +63076,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69035,7 +63089,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69049,7 +63102,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69063,7 +63115,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69077,7 +63128,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69104,7 +63154,6 @@ return {
 				["max"] = 25, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69118,7 +63167,6 @@ return {
 				["max"] = 40, 
 				["min"] = 26, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69132,7 +63180,6 @@ return {
 				["max"] = 40, 
 				["min"] = 26, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69146,7 +63193,6 @@ return {
 				["max"] = 40, 
 				["min"] = 26, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69160,7 +63206,6 @@ return {
 				["max"] = 40, 
 				["min"] = 26, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69174,7 +63219,6 @@ return {
 				["max"] = 40, 
 				["min"] = 26, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69192,7 +63236,6 @@ return {
 				["max"] = 25, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69206,7 +63249,6 @@ return {
 				["max"] = 12, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69220,7 +63262,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69290,7 +63331,6 @@ return {
 				["max"] = 25, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69304,7 +63344,6 @@ return {
 				["max"] = 25, 
 				["min"] = 17, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69318,7 +63357,6 @@ return {
 				["max"] = 40, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69332,7 +63370,6 @@ return {
 				["max"] = 40, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69346,7 +63383,6 @@ return {
 				["max"] = 13, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69360,7 +63396,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69374,7 +63409,6 @@ return {
 				["max"] = 15, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69388,7 +63422,6 @@ return {
 				["max"] = 15, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69402,7 +63435,6 @@ return {
 				["max"] = 25, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69416,7 +63448,6 @@ return {
 				["max"] = 25, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69430,7 +63461,6 @@ return {
 				["max"] = 25, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69444,7 +63474,6 @@ return {
 				["max"] = 25, 
 				["min"] = 25, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69458,7 +63487,6 @@ return {
 				["max"] = 15, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69492,7 +63520,6 @@ return {
 				["max"] = 50, 
 				["min"] = 23, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69558,7 +63585,6 @@ return {
 				["max"] = 12, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69572,7 +63598,6 @@ return {
 				["max"] = 30, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69586,7 +63611,6 @@ return {
 				["max"] = 15, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69616,7 +63640,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69646,7 +63669,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69676,7 +63698,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69690,7 +63711,6 @@ return {
 				["max"] = 30, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69765,7 +63785,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69779,7 +63798,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69793,7 +63811,6 @@ return {
 				["max"] = 25, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69807,7 +63824,6 @@ return {
 				["max"] = 6, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69821,7 +63837,6 @@ return {
 				["max"] = 25, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69835,7 +63850,6 @@ return {
 				["max"] = 20, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69849,7 +63863,6 @@ return {
 				["max"] = 20, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69875,7 +63888,6 @@ return {
 				["max"] = 100, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69889,7 +63901,6 @@ return {
 				["max"] = 12, 
 				["min"] = 6, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69903,7 +63914,6 @@ return {
 				["max"] = 5, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69917,7 +63927,6 @@ return {
 				["max"] = 5, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69931,7 +63940,6 @@ return {
 				["max"] = 5, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69945,7 +63953,6 @@ return {
 				["max"] = 5, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69959,7 +63966,6 @@ return {
 				["max"] = 9, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69973,7 +63979,6 @@ return {
 				["max"] = 20, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -69987,7 +63992,6 @@ return {
 				["max"] = 35, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70043,7 +64047,6 @@ return {
 				["max"] = 9, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70061,7 +64064,6 @@ return {
 				["max"] = 30, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70075,7 +64077,6 @@ return {
 				["max"] = 12, 
 				["min"] = 9, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70089,7 +64090,6 @@ return {
 				["max"] = 12, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70103,7 +64103,6 @@ return {
 				["max"] = 12, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70117,7 +64116,6 @@ return {
 				["max"] = 12, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70179,7 +64177,6 @@ return {
 				["max"] = 0.4, 
 				["min"] = 0.1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70197,7 +64194,6 @@ return {
 				["max"] = 35, 
 				["min"] = 21, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70215,7 +64211,6 @@ return {
 				["max"] = 25, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70242,7 +64237,6 @@ return {
 				["max"] = 4, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70256,7 +64250,6 @@ return {
 				["max"] = 16, 
 				["min"] = 13, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70270,7 +64263,6 @@ return {
 				["max"] = 25, 
 				["min"] = 20, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70284,7 +64276,6 @@ return {
 				["max"] = 19, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70298,7 +64289,6 @@ return {
 				["max"] = 19, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70312,7 +64302,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70326,7 +64315,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70340,7 +64328,6 @@ return {
 				["max"] = 0.7, 
 				["min"] = 0.2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70354,7 +64341,6 @@ return {
 				["max"] = 3.5, 
 				["min"] = 2, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70368,7 +64354,6 @@ return {
 				["max"] = 15, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70382,7 +64367,6 @@ return {
 				["max"] = 25, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70400,7 +64384,6 @@ return {
 				["max"] = 12, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70438,7 +64421,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70476,7 +64458,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70514,7 +64495,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70532,7 +64512,6 @@ return {
 				["max"] = 10, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70546,7 +64525,6 @@ return {
 				["max"] = 20, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70560,7 +64538,6 @@ return {
 				["max"] = 79, 
 				["min"] = 70, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70574,7 +64551,6 @@ return {
 				["max"] = 30, 
 				["min"] = 16, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70588,7 +64564,6 @@ return {
 				["max"] = 15, 
 				["min"] = 15, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70618,7 +64593,6 @@ return {
 				["max"] = 7, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70632,7 +64606,6 @@ return {
 				["max"] = 19, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70646,7 +64619,6 @@ return {
 				["max"] = 25, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70660,7 +64632,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70674,7 +64645,6 @@ return {
 				["max"] = 12, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70688,7 +64658,6 @@ return {
 				["max"] = 19, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70702,7 +64671,6 @@ return {
 				["max"] = 22, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70716,7 +64684,6 @@ return {
 				["max"] = 22, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70730,7 +64697,6 @@ return {
 				["max"] = 40, 
 				["min"] = 26, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70744,7 +64710,6 @@ return {
 				["max"] = 8, 
 				["min"] = 5, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70758,7 +64723,6 @@ return {
 				["max"] = 22, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70784,7 +64748,6 @@ return {
 				["max"] = 25, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70798,7 +64761,6 @@ return {
 				["max"] = 12, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70860,7 +64822,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70874,7 +64835,6 @@ return {
 				["max"] = 6, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70908,7 +64868,6 @@ return {
 				["max"] = 12, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70942,7 +64901,6 @@ return {
 				["max"] = 12, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70976,7 +64934,6 @@ return {
 				["max"] = 12, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -70990,7 +64947,6 @@ return {
 				["max"] = 40, 
 				["min"] = 11, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71017,7 +64973,6 @@ return {
 				["max"] = 12, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71031,7 +64986,6 @@ return {
 				["max"] = 12, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71045,7 +64999,6 @@ return {
 				["max"] = 25, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71059,7 +65012,6 @@ return {
 				["max"] = 12, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71073,7 +65025,6 @@ return {
 				["max"] = 30, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71099,7 +65050,6 @@ return {
 				["max"] = 24, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71113,7 +65063,6 @@ return {
 				["max"] = 60, 
 				["min"] = 41, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71127,7 +65076,6 @@ return {
 				["max"] = 20, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71173,7 +65121,6 @@ return {
 				["max"] = 13, 
 				["min"] = 8, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71207,7 +65154,6 @@ return {
 				["max"] = 9, 
 				["min"] = 4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71221,7 +65167,6 @@ return {
 				["max"] = 19, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71275,7 +65220,6 @@ return {
 				["max"] = 18, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71289,7 +65233,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71300,10 +65243,9 @@ return {
 		}, 
 		["7356_NearbyEnemyChaosDamageResistance"] = {
 			["Helmet"] = {
-				["max"] = 4, 
-				["min"] = 3, 
+				["max"] = -3, 
+				["min"] = -4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71314,10 +65256,9 @@ return {
 		}, 
 		["7357_NearbyEnemyColdDamageResistance"] = {
 			["Helmet"] = {
-				["max"] = 4, 
-				["min"] = 3, 
+				["max"] = -3, 
+				["min"] = -4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71328,10 +65269,9 @@ return {
 		}, 
 		["7359_NearbyEnemyFireDamageResistance"] = {
 			["Helmet"] = {
-				["max"] = 4, 
-				["min"] = 3, 
+				["max"] = -3, 
+				["min"] = -4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71342,10 +65282,9 @@ return {
 		}, 
 		["7361_NearbyEnemyLightningDamageResistance"] = {
 			["Helmet"] = {
-				["max"] = 4, 
-				["min"] = 3, 
+				["max"] = -3, 
+				["min"] = -4, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71359,7 +65298,6 @@ return {
 				["max"] = 4, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71373,7 +65311,6 @@ return {
 				["max"] = 12, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71387,7 +65324,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71401,7 +65337,6 @@ return {
 				["max"] = 18, 
 				["min"] = 10, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71415,7 +65350,6 @@ return {
 				["max"] = 60, 
 				["min"] = 41, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71429,7 +65363,6 @@ return {
 				["max"] = 1, 
 				["min"] = 1, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71467,7 +65400,6 @@ return {
 				["max"] = 5, 
 				["min"] = 3, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71481,7 +65413,6 @@ return {
 				["max"] = 25, 
 				["min"] = 14, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71495,7 +65426,6 @@ return {
 				["max"] = 40, 
 				["min"] = 31, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71513,7 +65443,6 @@ return {
 				["max"] = 20, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71531,7 +65460,6 @@ return {
 				["max"] = 20, 
 				["min"] = 12, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71545,7 +65473,6 @@ return {
 				["max"] = 12, 
 				["min"] = 7, 
 			}, 
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -71627,7 +65554,7 @@ return {
 				["max"] = -12, 
 				["min"] = -20, 
 			}, 
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72172,7 +66099,6 @@ return {
 	}, 
 	["Synthesis"] = {
 		["1009_BlockPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72182,7 +66108,6 @@ return {
 			}, 
 		}, 
 		["1012_SpellDamageSuppressed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72192,7 +66117,6 @@ return {
 			}, 
 		}, 
 		["1013_ChanceToSuppressSpellsOld"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72202,7 +66126,6 @@ return {
 			}, 
 		}, 
 		["1028_SpellBlockPercentage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72212,7 +66135,6 @@ return {
 			}, 
 		}, 
 		["1043_AllAttributes"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72222,7 +66144,6 @@ return {
 			}, 
 		}, 
 		["1044_StrengthImplicit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72232,7 +66153,6 @@ return {
 			}, 
 		}, 
 		["1045_DexterityImplicit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72242,7 +66162,6 @@ return {
 			}, 
 		}, 
 		["1046_IntelligenceImplicit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72252,7 +66171,6 @@ return {
 			}, 
 		}, 
 		["1050_PercentageAllAttributes"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72262,7 +66180,6 @@ return {
 			}, 
 		}, 
 		["1051_PercentageStrength"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72272,7 +66189,6 @@ return {
 			}, 
 		}, 
 		["1052_PercentageDexterity"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72282,7 +66198,6 @@ return {
 			}, 
 		}, 
 		["1053_PercentageIntelligence"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72292,7 +66207,6 @@ return {
 			}, 
 		}, 
 		["1058_AllDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72302,7 +66216,6 @@ return {
 			}, 
 		}, 
 		["1065_AttackDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72312,7 +66225,6 @@ return {
 			}, 
 		}, 
 		["1077_DegenerationDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72322,7 +66234,6 @@ return {
 			}, 
 		}, 
 		["1084_DamageWhileLeechingLife"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72332,7 +66243,6 @@ return {
 			}, 
 		}, 
 		["1086_DamageWhileLeechingMana"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72342,7 +66252,6 @@ return {
 			}, 
 		}, 
 		["1090_SpellDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72352,7 +66261,6 @@ return {
 			}, 
 		}, 
 		["1093_SpellDamageWithStaff"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72362,7 +66270,6 @@ return {
 			}, 
 		}, 
 		["1095_SpellDamageWithShield"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72372,7 +66279,6 @@ return {
 			}, 
 		}, 
 		["1096_SpellDamageWithDualWield"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72382,7 +66288,6 @@ return {
 			}, 
 		}, 
 		["1097_PhysicalDamagePercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72392,7 +66297,6 @@ return {
 			}, 
 		}, 
 		["1098_LocalPhysicalDamagePercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72402,7 +66306,6 @@ return {
 			}, 
 		}, 
 		["1100_MeleeDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72412,7 +66315,6 @@ return {
 			}, 
 		}, 
 		["1121_ColdDamageOverTimeMultiplier"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72422,7 +66324,6 @@ return {
 			}, 
 		}, 
 		["1124_ChaosDamageOverTimeMultiplier"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72432,7 +66333,6 @@ return {
 			}, 
 		}, 
 		["1140_LocalPhysicalDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Physical Damage", 
 			}, 
@@ -72443,7 +66343,6 @@ return {
 			}, 
 		}, 
 		["1140_LocalPhysicalDamageTwoHanded"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Physical Damage", 
 			}, 
@@ -72454,7 +66353,6 @@ return {
 			}, 
 		}, 
 		["1167_AxeIncreasedPhysicalDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72464,7 +66362,6 @@ return {
 			}, 
 		}, 
 		["1171_StaffIncreasedPhysicalDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72474,7 +66371,6 @@ return {
 			}, 
 		}, 
 		["1179_ClawIncreasedPhysicalDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72484,7 +66380,6 @@ return {
 			}, 
 		}, 
 		["1185_DaggerIncreasedPhysicalDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72494,7 +66389,6 @@ return {
 			}, 
 		}, 
 		["1191_MaceIncreasedPhysicalDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72504,7 +66398,6 @@ return {
 			}, 
 		}, 
 		["1197_BowIncreasedPhysicalDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72514,7 +66407,6 @@ return {
 			}, 
 		}, 
 		["1202_SwordIncreasedPhysicalDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72524,7 +66416,6 @@ return {
 			}, 
 		}, 
 		["1209_WandIncreasedPhysicalDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72534,7 +66425,6 @@ return {
 			}, 
 		}, 
 		["1221_FireDamagePercentage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72544,7 +66434,6 @@ return {
 			}, 
 		}, 
 		["1223_GlobalAddedFireDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72554,7 +66443,6 @@ return {
 			}, 
 		}, 
 		["1226_LocalFireDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Fire Damage", 
 			}, 
@@ -72565,7 +66453,6 @@ return {
 			}, 
 		}, 
 		["1226_LocalFireDamageTwoHand"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Fire Damage", 
 			}, 
@@ -72576,7 +66463,6 @@ return {
 			}, 
 		}, 
 		["1230_ColdDamagePercentage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72586,7 +66472,6 @@ return {
 			}, 
 		}, 
 		["1232_GlobalAddedColdDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72596,7 +66481,6 @@ return {
 			}, 
 		}, 
 		["1235_LocalColdDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Cold Damage", 
 			}, 
@@ -72607,7 +66491,6 @@ return {
 			}, 
 		}, 
 		["1235_LocalColdDamageTwoHand"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Cold Damage", 
 			}, 
@@ -72618,7 +66501,6 @@ return {
 			}, 
 		}, 
 		["1241_LightningDamagePercentage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72628,7 +66510,6 @@ return {
 			}, 
 		}, 
 		["1243_GlobalAddedLightningDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72638,7 +66519,6 @@ return {
 			}, 
 		}, 
 		["1246_LocalLightningDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Lightning Damage", 
 			}, 
@@ -72649,7 +66529,6 @@ return {
 			}, 
 		}, 
 		["1246_LocalLightningDamageTwoHand"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Lightning Damage", 
 			}, 
@@ -72660,7 +66539,6 @@ return {
 			}, 
 		}, 
 		["1249_IncreasedChaosDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72670,7 +66548,6 @@ return {
 			}, 
 		}, 
 		["1250_GlobalAddedChaosDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72680,7 +66557,6 @@ return {
 			}, 
 		}, 
 		["1253_LocalChaosDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Chaos Damage", 
 			}, 
@@ -72691,7 +66567,6 @@ return {
 			}, 
 		}, 
 		["1253_LocalChaosDamageTwoHand"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "Adds # to # Chaos Damage", 
 			}, 
@@ -72702,7 +66577,6 @@ return {
 			}, 
 		}, 
 		["1267_SpellAddedFireDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72712,7 +66586,6 @@ return {
 			}, 
 		}, 
 		["1267_SpellAddedFireDamageTwoHand"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72722,7 +66595,6 @@ return {
 			}, 
 		}, 
 		["1268_SpellAddedColdDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72732,7 +66604,6 @@ return {
 			}, 
 		}, 
 		["1268_SpellAddedColdDamageTwoHand"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72742,7 +66613,6 @@ return {
 			}, 
 		}, 
 		["1269_SpellAddedLightningDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72752,7 +66622,6 @@ return {
 			}, 
 		}, 
 		["1269_SpellAddedLightningDamageTwoHand"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72762,7 +66631,6 @@ return {
 			}, 
 		}, 
 		["1273_IncreasedAttackSpeed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72772,7 +66640,6 @@ return {
 			}, 
 		}, 
 		["1276_LocalIncreasedAttackSpeed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Attack Speed", 
 			}, 
@@ -72783,7 +66650,6 @@ return {
 			}, 
 		}, 
 		["1283_AxeIncreasedAttackSpeed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72793,7 +66659,6 @@ return {
 			}, 
 		}, 
 		["1284_StaffIncreasedAttackSpeed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72803,7 +66668,6 @@ return {
 			}, 
 		}, 
 		["1285_ClawIncreasedAttackSpeed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72813,7 +66677,6 @@ return {
 			}, 
 		}, 
 		["1286_DaggerIncreasedAttackSpeed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72823,7 +66686,6 @@ return {
 			}, 
 		}, 
 		["1287_MaceIncreasedAttackSpeed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72833,7 +66695,6 @@ return {
 			}, 
 		}, 
 		["1288_BowIncreasedAttackSpeed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72843,7 +66704,6 @@ return {
 			}, 
 		}, 
 		["1289_SwordIncreasedAttackSpeed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72853,7 +66713,6 @@ return {
 			}, 
 		}, 
 		["1290_WandIncreasedAttackSpeed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72863,7 +66722,6 @@ return {
 			}, 
 		}, 
 		["1295_IncreasedAccuracy"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72873,7 +66731,6 @@ return {
 			}, 
 		}, 
 		["1296_IncreasedAccuracyPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72883,7 +66740,6 @@ return {
 			}, 
 		}, 
 		["1296_LocalAccuracyRatingIncrease"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72893,7 +66749,6 @@ return {
 			}, 
 		}, 
 		["1300_AxeIncreasedAccuracyRating"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72903,7 +66758,6 @@ return {
 			}, 
 		}, 
 		["1301_StaffIncreasedAccuracyRating"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72913,7 +66767,6 @@ return {
 			}, 
 		}, 
 		["1302_ClawIncreasedAccuracyRating"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72923,7 +66776,6 @@ return {
 			}, 
 		}, 
 		["1303_DaggerIncreasedAccuracyRating"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72933,7 +66785,6 @@ return {
 			}, 
 		}, 
 		["1304_MaceIncreasedAccuracyRating"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72943,7 +66794,6 @@ return {
 			}, 
 		}, 
 		["1305_BowIncreasedAccuracyRating"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72953,7 +66803,6 @@ return {
 			}, 
 		}, 
 		["1306_SwordIncreasedAccuracyRating"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72963,7 +66812,6 @@ return {
 			}, 
 		}, 
 		["1307_WandIncreasedAccuracyRating"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72973,7 +66821,6 @@ return {
 			}, 
 		}, 
 		["1308_IncreasedCastSpeed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72983,7 +66830,6 @@ return {
 			}, 
 		}, 
 		["1309_CastSpeedWithDualWield"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -72993,7 +66839,6 @@ return {
 			}, 
 		}, 
 		["1310_CastSpeedWithShield"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73003,7 +66848,6 @@ return {
 			}, 
 		}, 
 		["1311_CastSpeedWithStaff"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73013,7 +66857,6 @@ return {
 			}, 
 		}, 
 		["1320_SpellCriticalStrikeChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73023,7 +66866,6 @@ return {
 			}, 
 		}, 
 		["1321_CriticalStrikeChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73033,7 +66875,6 @@ return {
 			}, 
 		}, 
 		["1326_LocalCriticalStrikeChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73043,7 +66884,6 @@ return {
 			}, 
 		}, 
 		["1350_CriticalStrikeMultiplier"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73053,7 +66893,6 @@ return {
 			}, 
 		}, 
 		["1354_DaggerCriticalStrikeMultiplier"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73063,7 +66902,6 @@ return {
 			}, 
 		}, 
 		["1355_MaceCriticalStrikeMultiplier"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73073,7 +66911,6 @@ return {
 			}, 
 		}, 
 		["1356_AxeCriticalStrikeMultiplier"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73083,7 +66920,6 @@ return {
 			}, 
 		}, 
 		["1357_BowCriticalStrikeMultiplier"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73093,7 +66929,6 @@ return {
 			}, 
 		}, 
 		["1358_SwordCriticalStrikeMultiplier"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73103,7 +66938,6 @@ return {
 			}, 
 		}, 
 		["1359_WandCriticalStrikeMultiplier"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73113,7 +66947,6 @@ return {
 			}, 
 		}, 
 		["1360_ClawCriticalStrikeMultiplier"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73123,7 +66956,6 @@ return {
 			}, 
 		}, 
 		["1361_StaffCriticalStrikeMultiplier"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73133,7 +66965,6 @@ return {
 			}, 
 		}, 
 		["1373_ReducedExtraDamageFromCrits"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73143,7 +66974,6 @@ return {
 			}, 
 		}, 
 		["1378_StunThresholdReduction"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73153,7 +66983,6 @@ return {
 			}, 
 		}, 
 		["138_LocalIncreaseSocketedStrengthGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73163,7 +66992,6 @@ return {
 			}, 
 		}, 
 		["139_LocalIncreaseSocketedDexterityGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73173,7 +67001,6 @@ return {
 			}, 
 		}, 
 		["1401_LocalPhysicalDamageReductionRating"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to Armour", 
 			}, 
@@ -73184,7 +67011,6 @@ return {
 			}, 
 		}, 
 		["1402_GlobalPhysicalDamageReductionRatingPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73194,7 +67020,6 @@ return {
 			}, 
 		}, 
 		["1403_LocalPhysicalDamageReductionRatingPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Armour", 
 			}, 
@@ -73205,7 +67030,6 @@ return {
 			}, 
 		}, 
 		["1409_LocalEvasionRating"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to Evasion Rating", 
 			}, 
@@ -73216,7 +67040,6 @@ return {
 			}, 
 		}, 
 		["140_LocalIncreaseSocketedIntelligenceGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73226,7 +67049,6 @@ return {
 			}, 
 		}, 
 		["1410_GlobalEvasionRatingPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73236,7 +67058,6 @@ return {
 			}, 
 		}, 
 		["1411_LocalEvasionRatingIncreasePercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Evasion Rating", 
 			}, 
@@ -73247,7 +67068,6 @@ return {
 			}, 
 		}, 
 		["1417_IncreasedEvasionRatingPerFrenzyCharge"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73257,7 +67077,6 @@ return {
 			}, 
 		}, 
 		["1418_EnergyShield"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73267,7 +67086,6 @@ return {
 			}, 
 		}, 
 		["1419_LocalEnergyShield"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "+# to maximum Energy Shield", 
 			}, 
@@ -73278,7 +67096,6 @@ return {
 			}, 
 		}, 
 		["141_LocalIncreaseSocketedGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73288,7 +67105,6 @@ return {
 			}, 
 		}, 
 		["1420_LocalEnergyShieldPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% increased Energy Shield", 
 			}, 
@@ -73299,7 +67115,6 @@ return {
 			}, 
 		}, 
 		["1421_GlobalEnergyShieldPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73309,7 +67124,6 @@ return {
 			}, 
 		}, 
 		["1422_EnergyShieldDelay"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73319,7 +67133,6 @@ return {
 			}, 
 		}, 
 		["1425_EnergyShieldRegeneration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73329,7 +67142,6 @@ return {
 			}, 
 		}, 
 		["1428_EnergyShieldRecoveryRate"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73339,7 +67151,6 @@ return {
 			}, 
 		}, 
 		["1429_IncreasedLife"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73349,7 +67160,6 @@ return {
 			}, 
 		}, 
 		["1431_MaximumLifeIncreasePercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73359,7 +67169,6 @@ return {
 			}, 
 		}, 
 		["1434_LifeRegeneration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73369,7 +67178,6 @@ return {
 			}, 
 		}, 
 		["1436_LifeRegenerationPercentPerEnduranceCharge"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73379,7 +67187,6 @@ return {
 			}, 
 		}, 
 		["1438_LifeRecoveryRate"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73389,7 +67196,6 @@ return {
 			}, 
 		}, 
 		["1439_IncreasedMana"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73399,7 +67205,6 @@ return {
 			}, 
 		}, 
 		["1440_MaximumManaIncreasePercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73409,7 +67214,6 @@ return {
 			}, 
 		}, 
 		["1441_BaseManaRegeneration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73419,7 +67223,6 @@ return {
 			}, 
 		}, 
 		["1442_AddedManaRegeneration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73429,7 +67232,6 @@ return {
 			}, 
 		}, 
 		["1444_ManaRegeneration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73439,7 +67241,6 @@ return {
 			}, 
 		}, 
 		["1446_ManaRecoveryRate"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73449,7 +67250,6 @@ return {
 			}, 
 		}, 
 		["1452_ItemFoundQuantityIncrease"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73459,7 +67259,6 @@ return {
 			}, 
 		}, 
 		["1456_ItemFoundRarityIncrease"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73469,7 +67268,6 @@ return {
 			}, 
 		}, 
 		["1463_ExperienceIncrease"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73479,7 +67277,6 @@ return {
 			}, 
 		}, 
 		["146_LocalIncreaseSocketedFireGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73489,7 +67286,6 @@ return {
 			}, 
 		}, 
 		["1479_AllResistances"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73499,7 +67295,6 @@ return {
 			}, 
 		}, 
 		["147_LocalIncreaseSocketedColdGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73509,7 +67304,6 @@ return {
 			}, 
 		}, 
 		["1483_MaximumFireResistanceImplicit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73519,7 +67313,6 @@ return {
 			}, 
 		}, 
 		["1485_FireResistance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73529,7 +67322,6 @@ return {
 			}, 
 		}, 
 		["1489_MaximumColdResistanceImplicit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73539,7 +67331,6 @@ return {
 			}, 
 		}, 
 		["148_LocalIncreaseSocketedLightningGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73549,7 +67340,6 @@ return {
 			}, 
 		}, 
 		["1491_ColdResistance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73559,7 +67349,6 @@ return {
 			}, 
 		}, 
 		["1494_MaximumLightningResistanceImplicit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73569,7 +67358,6 @@ return {
 			}, 
 		}, 
 		["1496_LightningResistance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73579,7 +67367,6 @@ return {
 			}, 
 		}, 
 		["1499_MaximumChaosResistanceImplicit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73589,7 +67376,6 @@ return {
 			}, 
 		}, 
 		["149_LocalIncreaseSocketedChaosGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73599,7 +67385,6 @@ return {
 			}, 
 		}, 
 		["1500_ChaosResistance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73609,7 +67394,6 @@ return {
 			}, 
 		}, 
 		["1501_MaximumElementalResistanceImplicit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73619,7 +67403,6 @@ return {
 			}, 
 		}, 
 		["1508_LifeLeechPermyriad"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73629,7 +67412,6 @@ return {
 			}, 
 		}, 
 		["1510_LifeLeechLocalPermyriad"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% of Physical Attack Damage Leeched as Life", 
 			}, 
@@ -73640,7 +67422,6 @@ return {
 			}, 
 		}, 
 		["1523_LifeLeechFromAttacksPermyriad"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73650,7 +67431,6 @@ return {
 			}, 
 		}, 
 		["1525_PhysicalDamageLifeLeechPermyriad"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73660,7 +67440,6 @@ return {
 			}, 
 		}, 
 		["1529_FireDamageLifeLeechPermyriad"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73670,7 +67449,6 @@ return {
 			}, 
 		}, 
 		["1534_ColdDamageLifeLeechPermyriad"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73680,7 +67458,6 @@ return {
 			}, 
 		}, 
 		["1538_LightningDamageLifeLeechPermyriad"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73690,7 +67467,6 @@ return {
 			}, 
 		}, 
 		["1541_ChaosDamageLifeLeechPermyriad"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73700,7 +67476,6 @@ return {
 			}, 
 		}, 
 		["1545_ElementalDamageLeechedAsLifePermyriad"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73710,7 +67485,6 @@ return {
 			}, 
 		}, 
 		["1558_ManaLeechPermyriad"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73720,7 +67494,6 @@ return {
 			}, 
 		}, 
 		["155_IncreasedSocketedAoEGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73730,7 +67503,6 @@ return {
 			}, 
 		}, 
 		["1560_ManaLeechLocalPermyriad"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% of Physical Attack Damage Leeched as Mana", 
 			}, 
@@ -73741,7 +67513,6 @@ return {
 			}, 
 		}, 
 		["1564_AttackDamageManaLeech"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73751,7 +67522,6 @@ return {
 			}, 
 		}, 
 		["156_LocalIncreaseSocketedProjectileGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73761,7 +67531,6 @@ return {
 			}, 
 		}, 
 		["157_LocalIncreaseSocketedBowGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73771,7 +67540,6 @@ return {
 			}, 
 		}, 
 		["1581_EnergyShieldLeechPermyriad"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73781,7 +67549,6 @@ return {
 			}, 
 		}, 
 		["158_LocalIncreaseSocketedMeleeGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73791,7 +67558,6 @@ return {
 			}, 
 		}, 
 		["1590_MaximumLifeLeechRate"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73801,7 +67567,6 @@ return {
 			}, 
 		}, 
 		["1592_MaximumManaLeechRate"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73811,7 +67576,6 @@ return {
 			}, 
 		}, 
 		["1593_MaximumEnergyShieldLeechRate"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73821,7 +67585,6 @@ return {
 			}, 
 		}, 
 		["1597_LifeGainPerTargetLocal"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73831,7 +67594,6 @@ return {
 			}, 
 		}, 
 		["1599_LifeGainPerTarget"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73841,7 +67603,6 @@ return {
 			}, 
 		}, 
 		["159_LocalIncreaseSocketedMinionGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73851,7 +67612,6 @@ return {
 			}, 
 		}, 
 		["1603_ManaGainPerTarget"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73861,7 +67621,6 @@ return {
 			}, 
 		}, 
 		["1606_EnergyShieldGainPerTarget"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73871,7 +67630,6 @@ return {
 			}, 
 		}, 
 		["1607_LifeGainedFromEnemyDeath"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73881,7 +67639,6 @@ return {
 			}, 
 		}, 
 		["1608_MaximumLifeOnKillPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73891,7 +67648,6 @@ return {
 			}, 
 		}, 
 		["160_LocalIncreaseSocketedAuraLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73901,7 +67657,6 @@ return {
 			}, 
 		}, 
 		["1610_MaximumManaOnKillPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73911,7 +67666,6 @@ return {
 			}, 
 		}, 
 		["1616_GainLifeOnBlock"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73921,7 +67675,6 @@ return {
 			}, 
 		}, 
 		["1617_GainManaOnBlock"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73931,7 +67684,6 @@ return {
 			}, 
 		}, 
 		["1622_ManaGainedFromEnemyDeath"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73941,7 +67693,6 @@ return {
 			}, 
 		}, 
 		["1625_MinionLife"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73951,7 +67702,6 @@ return {
 			}, 
 		}, 
 		["1628_MinionMovementSpeed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73961,7 +67711,6 @@ return {
 			}, 
 		}, 
 		["1649_AdditionalPierce"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -73980,7 +67729,6 @@ return {
 			}, 
 		}, 
 		["1653_AdditionalArrows"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLineSingular"] = "Bow Attacks fire an additional Arrow", 
 			}, 
@@ -73991,7 +67739,6 @@ return {
 			}, 
 		}, 
 		["1655_ProjectileSpeed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74001,7 +67748,6 @@ return {
 			}, 
 		}, 
 		["1657_MovementVelocity"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74011,7 +67757,6 @@ return {
 			}, 
 		}, 
 		["1662_MinimumEnduranceCharges"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74021,7 +67766,6 @@ return {
 			}, 
 		}, 
 		["1663_MaximumEnduranceCharges"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74031,7 +67775,6 @@ return {
 			}, 
 		}, 
 		["1667_MinimumFrenzyCharges"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74041,7 +67784,6 @@ return {
 			}, 
 		}, 
 		["1668_MaximumFrenzyCharges"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74051,7 +67793,6 @@ return {
 			}, 
 		}, 
 		["1672_MinimumPowerCharges"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74061,7 +67802,6 @@ return {
 			}, 
 		}, 
 		["1673_IncreasedMaximumPowerCharges"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74071,7 +67811,6 @@ return {
 			}, 
 		}, 
 		["1689_PowerChargeOnCriticalStrikeChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74081,7 +67820,6 @@ return {
 			}, 
 		}, 
 		["168_LocalIncreaseSocketedSupportGemLevel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74091,7 +67829,6 @@ return {
 			}, 
 		}, 
 		["1692_FrenzyChargeOnHitChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74128,7 +67865,6 @@ return {
 			}, 
 		}, 
 		["1702_AvoidElementalStatusAilments"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74138,7 +67874,6 @@ return {
 			}, 
 		}, 
 		["1703_AvoidChill"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74148,7 +67883,6 @@ return {
 			}, 
 		}, 
 		["1704_AvoidFreeze"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74158,7 +67892,6 @@ return {
 			}, 
 		}, 
 		["1705_AvoidIgnite"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74168,7 +67901,6 @@ return {
 			}, 
 		}, 
 		["1707_AvoidShock"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74178,7 +67910,6 @@ return {
 			}, 
 		}, 
 		["1708_ChanceToAvoidPoison"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74188,7 +67919,6 @@ return {
 			}, 
 		}, 
 		["1710_AvoidStun"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74198,7 +67928,6 @@ return {
 			}, 
 		}, 
 		["1715_ChillAndFreezeDuration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74208,7 +67937,6 @@ return {
 			}, 
 		}, 
 		["1716_ShockDuration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74218,7 +67946,6 @@ return {
 			}, 
 		}, 
 		["1717_ChillAndFreezeDuration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74228,7 +67955,6 @@ return {
 			}, 
 		}, 
 		["1718_BurnDuration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74238,7 +67964,6 @@ return {
 			}, 
 		}, 
 		["1722_StunDurationIncreasePercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74248,7 +67973,6 @@ return {
 			}, 
 		}, 
 		["1726_SelfStatusAilmentDuration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74258,7 +67982,6 @@ return {
 			}, 
 		}, 
 		["1736_BurnDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74268,7 +67991,6 @@ return {
 			}, 
 		}, 
 		["1739_AreaOfEffect"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74278,7 +68000,6 @@ return {
 			}, 
 		}, 
 		["1742_ManaCostReduction"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74288,7 +68009,6 @@ return {
 			}, 
 		}, 
 		["1750_IncreaseManaCostFlat"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74298,7 +68018,6 @@ return {
 			}, 
 		}, 
 		["1757_AvoidInterruptionWhileCasting"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74308,7 +68027,6 @@ return {
 			}, 
 		}, 
 		["1759_StunRecovery"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74318,7 +68036,6 @@ return {
 			}, 
 		}, 
 		["1784_TrapThrowSpeed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74328,7 +68045,6 @@ return {
 			}, 
 		}, 
 		["1785_MineLayingSpeed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74338,7 +68054,6 @@ return {
 			}, 
 		}, 
 		["1789_PhysicalAddedAsFire"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74348,7 +68063,6 @@ return {
 			}, 
 		}, 
 		["1791_PhysicalAddedAsLightning"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74358,7 +68072,6 @@ return {
 			}, 
 		}, 
 		["1792_PhysicalAddedAsChaos"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74368,7 +68081,6 @@ return {
 			}, 
 		}, 
 		["1795_LightningAddedAsChaos"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74378,7 +68090,6 @@ return {
 			}, 
 		}, 
 		["1797_ColdAddedAsChaos"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74388,7 +68099,6 @@ return {
 			}, 
 		}, 
 		["1798_FireAddedAsChaos"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74398,7 +68108,6 @@ return {
 			}, 
 		}, 
 		["1801_LifeRegenerationRatePercentage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74408,7 +68117,6 @@ return {
 			}, 
 		}, 
 		["1812_ConvertPhysicalToFireImplicit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74418,7 +68126,6 @@ return {
 			}, 
 		}, 
 		["1814_ConvertPhysicalToColdImplicit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74428,7 +68135,6 @@ return {
 			}, 
 		}, 
 		["1816_ConvertPhysicalToLightningImplicit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74438,7 +68144,6 @@ return {
 			}, 
 		}, 
 		["1819_PhysicalDamageConvertToChaosImplicit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74448,7 +68153,6 @@ return {
 			}, 
 		}, 
 		["182_SocketedGemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74458,7 +68162,6 @@ return {
 			}, 
 		}, 
 		["1830_MinionDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74468,7 +68171,6 @@ return {
 			}, 
 		}, 
 		["1835_ElementalDamagePercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74478,7 +68180,6 @@ return {
 			}, 
 		}, 
 		["183_IncreaseSocketedSupportGemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74488,7 +68189,6 @@ return {
 			}, 
 		}, 
 		["1843_MaximumBlockChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74498,7 +68198,6 @@ return {
 			}, 
 		}, 
 		["1844_MaximumSpellBlockChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74508,7 +68207,6 @@ return {
 			}, 
 		}, 
 		["1849_GlobalKnockbackChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74518,7 +68216,6 @@ return {
 			}, 
 		}, 
 		["1850_ProjectileDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74528,7 +68225,6 @@ return {
 			}, 
 		}, 
 		["185_SocketedAoEGemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74538,7 +68234,6 @@ return {
 			}, 
 		}, 
 		["186_SocketedAuraGemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74548,7 +68243,6 @@ return {
 			}, 
 		}, 
 		["187_SocketedBowGemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74558,7 +68252,6 @@ return {
 			}, 
 		}, 
 		["1880_ChanceToIgnite"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74568,7 +68261,6 @@ return {
 			}, 
 		}, 
 		["1883_ChanceToFreeze"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74578,7 +68270,6 @@ return {
 			}, 
 		}, 
 		["1887_ChanceToShock"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74588,7 +68279,6 @@ return {
 			}, 
 		}, 
 		["1889_AreaDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74598,7 +68288,6 @@ return {
 			}, 
 		}, 
 		["188_SocketedChaosGemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74608,7 +68297,6 @@ return {
 			}, 
 		}, 
 		["189_SocketedColdGemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74618,7 +68306,6 @@ return {
 			}, 
 		}, 
 		["1900_AttackAndCastSpeed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74628,7 +68315,6 @@ return {
 			}, 
 		}, 
 		["190_SocketedDexterityGemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74638,7 +68324,6 @@ return {
 			}, 
 		}, 
 		["1913_GlobalFlaskLifeRecovery"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74648,7 +68333,6 @@ return {
 			}, 
 		}, 
 		["192_SocketedFireGemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74658,7 +68342,6 @@ return {
 			}, 
 		}, 
 		["193_SocketedIntelligenceGemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74668,7 +68351,6 @@ return {
 			}, 
 		}, 
 		["194_SocketedLightningGemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74678,7 +68360,6 @@ return {
 			}, 
 		}, 
 		["195_SocketedMeleeGemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74688,7 +68369,6 @@ return {
 			}, 
 		}, 
 		["1979_EnduranceChargeDuration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74698,7 +68378,6 @@ return {
 			}, 
 		}, 
 		["197_SocketedProjectileGemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74708,7 +68387,6 @@ return {
 			}, 
 		}, 
 		["1981_FrenzyChargeDuration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74718,7 +68396,6 @@ return {
 			}, 
 		}, 
 		["198_SocketedStrengthGemQuality"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74728,7 +68405,6 @@ return {
 			}, 
 		}, 
 		["1994_IncreasedSpellDamagePerPowerCharge"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74738,7 +68414,6 @@ return {
 			}, 
 		}, 
 		["1996_IncreasedPowerChargeDuration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74748,7 +68423,6 @@ return {
 			}, 
 		}, 
 		["199_AbyssJewelEffect"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74758,7 +68432,6 @@ return {
 			}, 
 		}, 
 		["2011_IncreasedLifeLeechRate"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74768,7 +68441,6 @@ return {
 			}, 
 		}, 
 		["2012_IncreasedManaLeechRate"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74778,7 +68450,6 @@ return {
 			}, 
 		}, 
 		["2037_BeltIncreasedFlaskChargesGained"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74788,7 +68459,6 @@ return {
 			}, 
 		}, 
 		["2038_BeltReducedFlaskChargesUsed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74798,7 +68468,6 @@ return {
 			}, 
 		}, 
 		["2041_BeltIncreasedFlaskDuration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74808,7 +68477,6 @@ return {
 			}, 
 		}, 
 		["2056_AttackerTakesDamageNoRange"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74818,7 +68486,6 @@ return {
 			}, 
 		}, 
 		["2081_ManaReservationEfficiency"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74828,7 +68495,6 @@ return {
 			}, 
 		}, 
 		["2085_ReducedReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74838,7 +68504,6 @@ return {
 			}, 
 		}, 
 		["2087_PhysicalAttackDamageTaken"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74848,7 +68513,6 @@ return {
 			}, 
 		}, 
 		["2090_FlatFireDamageTaken"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74858,7 +68522,6 @@ return {
 			}, 
 		}, 
 		["2098_DegenDamageTaken"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74868,7 +68531,6 @@ return {
 			}, 
 		}, 
 		["2125_ReducedPhysicalDamageTaken"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74878,7 +68540,6 @@ return {
 			}, 
 		}, 
 		["2298_PhysicalDamageTakenAsFirePercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74888,7 +68549,6 @@ return {
 			}, 
 		}, 
 		["2299_PhysicalDamageTakenAsCold"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74898,7 +68558,6 @@ return {
 			}, 
 		}, 
 		["2300_PhysicalDamageTakenAsLightningPercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74908,7 +68567,6 @@ return {
 			}, 
 		}, 
 		["2302_PhysicalDamageTakenAsChaos"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74918,7 +68576,6 @@ return {
 			}, 
 		}, 
 		["2309_AdditionalBlock"] = {
-			["sign"] = "+", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74928,7 +68585,6 @@ return {
 			}, 
 		}, 
 		["2334_LocalChanceToBleed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74938,7 +68594,6 @@ return {
 			}, 
 		}, 
 		["2340_ChanceToBleed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -74948,7 +68603,6 @@ return {
 			}, 
 		}, 
 		["2351_LightRadius"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75012,7 +68666,6 @@ return {
 			}, 
 		}, 
 		["2385_MeleeWeaponAndUnarmedRange"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75031,7 +68684,6 @@ return {
 			}, 
 		}, 
 		["2415_FasterIgniteDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75041,7 +68693,6 @@ return {
 			}, 
 		}, 
 		["2429_SummonTotemCastSpeed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75051,7 +68702,6 @@ return {
 			}, 
 		}, 
 		["2447_CurseEffectiveness"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75061,7 +68711,6 @@ return {
 			}, 
 		}, 
 		["2460_MovementSpeedWhilePhased"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75071,7 +68720,6 @@ return {
 			}, 
 		}, 
 		["2478_EnduranceChargeOnKillChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75081,7 +68729,6 @@ return {
 			}, 
 		}, 
 		["2480_FrenzyChargeOnKillChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75091,7 +68738,6 @@ return {
 			}, 
 		}, 
 		["2482_PowerChargeOnKillChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75101,7 +68747,6 @@ return {
 			}, 
 		}, 
 		["2495_EnergyShieldRegenerationPerMinute"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75120,7 +68765,6 @@ return {
 			}, 
 		}, 
 		["2587_SpellDamagePer10Intelligence"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75130,7 +68774,6 @@ return {
 			}, 
 		}, 
 		["2594_LocalMeleeWeaponRange"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75140,7 +68783,6 @@ return {
 			}, 
 		}, 
 		["2636_TotemElementalResistances"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75150,7 +68792,6 @@ return {
 			}, 
 		}, 
 		["2686_ChaosDamageTaken"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75160,7 +68801,6 @@ return {
 			}, 
 		}, 
 		["2755_MinionAttackSpeed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75170,7 +68810,6 @@ return {
 			}, 
 		}, 
 		["2756_MinionCastSpeed"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75180,7 +68819,6 @@ return {
 			}, 
 		}, 
 		["2759_MinionLifeRegeneration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75190,7 +68828,6 @@ return {
 			}, 
 		}, 
 		["2760_MinionElementalResistancesForJewel"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75200,7 +68837,6 @@ return {
 			}, 
 		}, 
 		["2783_PhysicalDamageAddedAsRandomElement"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75210,7 +68846,6 @@ return {
 			}, 
 		}, 
 		["2804_GlobalChanceToBlindOnHit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75220,7 +68855,6 @@ return {
 			}, 
 		}, 
 		["2826_ElementalPenetration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75230,7 +68864,6 @@ return {
 			}, 
 		}, 
 		["2827_FireResistancePenetration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75240,7 +68873,6 @@ return {
 			}, 
 		}, 
 		["2828_ColdResistancePenetration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75250,7 +68882,6 @@ return {
 			}, 
 		}, 
 		["2829_LightningResistancePenetration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75260,7 +68891,6 @@ return {
 			}, 
 		}, 
 		["2838_ChanceToGainOnslaughtOnKill"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75270,7 +68900,6 @@ return {
 			}, 
 		}, 
 		["2873_AttackAndCastSpeedWithOnslaught"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75280,7 +68909,6 @@ return {
 			}, 
 		}, 
 		["2902_RecoverLifePercentOnBlock"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75290,7 +68918,6 @@ return {
 			}, 
 		}, 
 		["2905_DamageWhileLeeching"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75300,7 +68927,6 @@ return {
 			}, 
 		}, 
 		["2934_VaalSkillDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75310,7 +68936,6 @@ return {
 			}, 
 		}, 
 		["2943_AdditionalVaalSoulOnKill"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75320,7 +68945,6 @@ return {
 			}, 
 		}, 
 		["2944_VaalSkillDuration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75330,7 +68954,6 @@ return {
 			}, 
 		}, 
 		["2946_VaalSkillCriticalStrikeChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75340,7 +68963,6 @@ return {
 			}, 
 		}, 
 		["3008_BleedingDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75350,7 +68972,6 @@ return {
 			}, 
 		}, 
 		["3009_PoisonDuration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75360,7 +68981,6 @@ return {
 			}, 
 		}, 
 		["3012_PoisonOnHit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75370,7 +68990,6 @@ return {
 			}, 
 		}, 
 		["3020_PoisonDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75380,7 +68999,6 @@ return {
 			}, 
 		}, 
 		["3038_DamagePerEnduranceCharge"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75390,7 +69008,6 @@ return {
 			}, 
 		}, 
 		["3127_DamagePerFrenzyCharge"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75400,7 +69017,6 @@ return {
 			}, 
 		}, 
 		["3145_EnemiesExplodeOnDeathPhysicalChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75410,7 +69026,6 @@ return {
 			}, 
 		}, 
 		["3203_IncreasedAuraEffectGraceCorrupted"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75420,7 +69035,6 @@ return {
 			}, 
 		}, 
 		["3207_IncreasedAuraEffectDeterminationCorrupted"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75430,7 +69044,6 @@ return {
 			}, 
 		}, 
 		["3208_IncreasedAuraEffectDisciplineCorrupted"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75449,7 +69062,6 @@ return {
 			}, 
 		}, 
 		["3213_FireDamageAvoidance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75459,7 +69071,6 @@ return {
 			}, 
 		}, 
 		["3214_ColdDamageAvoidance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75469,7 +69080,6 @@ return {
 			}, 
 		}, 
 		["3215_LightningDamageAvoidance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75479,7 +69089,6 @@ return {
 			}, 
 		}, 
 		["3217_UnholyMightOnKillPercentChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75489,7 +69098,6 @@ return {
 			}, 
 		}, 
 		["3294_SpectreDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75499,7 +69107,6 @@ return {
 			}, 
 		}, 
 		["3402_AuraEffect"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75509,7 +69116,6 @@ return {
 			}, 
 		}, 
 		["3425_ColdPenetrationWeapon"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75519,7 +69125,6 @@ return {
 			}, 
 		}, 
 		["3426_FirePenetrationWeapon"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75529,7 +69134,6 @@ return {
 			}, 
 		}, 
 		["3427_LightningPenetrationWeapon"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75548,7 +69152,6 @@ return {
 			}, 
 		}, 
 		["3479_ZombieIncreasedDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75558,7 +69161,6 @@ return {
 			}, 
 		}, 
 		["3495_SkeletonDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75568,7 +69170,6 @@ return {
 			}, 
 		}, 
 		["3594_LocalAttackReduceEnemyElementalResistance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75578,7 +69179,6 @@ return {
 			}, 
 		}, 
 		["3821_AnimateGuardianResistances"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75588,7 +69188,6 @@ return {
 			}, 
 		}, 
 		["3842_CurseEffectConductivity"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75598,7 +69197,6 @@ return {
 			}, 
 		}, 
 		["3843_CurseEffectElementalWeakness"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75608,7 +69206,6 @@ return {
 			}, 
 		}, 
 		["3845_CurseEffectFlammability"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75618,7 +69215,6 @@ return {
 			}, 
 		}, 
 		["3846_CurseEffectFrostbite"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75628,7 +69224,6 @@ return {
 			}, 
 		}, 
 		["3848_CurseEffectVulnerability"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75638,7 +69233,6 @@ return {
 			}, 
 		}, 
 		["3900_DamageAffectedByAuras"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75648,7 +69242,6 @@ return {
 			}, 
 		}, 
 		["3913_DamageDuringFlaskEffect"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75658,7 +69251,6 @@ return {
 			}, 
 		}, 
 		["3999_PhysicalDamageRemovedFromManaBeforeLife"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75677,7 +69269,6 @@ return {
 			}, 
 		}, 
 		["4046_ChanceToAvoidBleeding"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75687,7 +69278,6 @@ return {
 			}, 
 		}, 
 		["4103_AddedColdDamagePerFrenzyCharge"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75697,7 +69287,6 @@ return {
 			}, 
 		}, 
 		["4342_ReducedPhysicalDamageTakenVsAbyssMonsters"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75707,7 +69296,6 @@ return {
 			}, 
 		}, 
 		["4343_DeterminationPhysicalDamageReduction"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75717,7 +69305,6 @@ return {
 			}, 
 		}, 
 		["4457_AreaOfEffectIfStunnedEnemyRecently"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75727,7 +69314,6 @@ return {
 			}, 
 		}, 
 		["445_DisplaySocketedGemsGetReducedReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75737,7 +69323,6 @@ return {
 			}, 
 		}, 
 		["447_SocketedSkillsManaMultiplier"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75747,7 +69332,6 @@ return {
 			}, 
 		}, 
 		["4485_ArmourEvasionWithFortify"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75757,7 +69341,6 @@ return {
 			}, 
 		}, 
 		["4518_AdditionalCriticalStrikeChanceWithAttacks"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75767,7 +69350,6 @@ return {
 			}, 
 		}, 
 		["4571_AttackDamagePerMana"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75777,7 +69359,6 @@ return {
 			}, 
 		}, 
 		["4590_AddedFireDamagePerStrength"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75787,7 +69368,6 @@ return {
 			}, 
 		}, 
 		["4593_AddedLightningDamagePerIntelligence"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75797,7 +69377,6 @@ return {
 			}, 
 		}, 
 		["4635_AttacksBlindOnHitChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75807,7 +69386,6 @@ return {
 			}, 
 		}, 
 		["4636_AttacksTauntOnHitChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75817,7 +69395,6 @@ return {
 			}, 
 		}, 
 		["4638_AttackImpaleChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75827,7 +69404,6 @@ return {
 			}, 
 		}, 
 		["4644_AddedColdDamagePerDexterity"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75837,7 +69413,6 @@ return {
 			}, 
 		}, 
 		["4697_AilmentDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75847,7 +69422,6 @@ return {
 			}, 
 		}, 
 		["4706_BleedDuration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75866,7 +69440,6 @@ return {
 			}, 
 		}, 
 		["5249_DoubleDamageChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75876,7 +69449,6 @@ return {
 			}, 
 		}, 
 		["5260_ChanceWhenHitForArmourToBeDoubled"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75886,7 +69458,6 @@ return {
 			}, 
 		}, 
 		["5262_AdditionalChanceToEvade"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75896,7 +69467,6 @@ return {
 			}, 
 		}, 
 		["5264_GraceAdditionalChanceToEvade"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75906,7 +69476,6 @@ return {
 			}, 
 		}, 
 		["5335_ChaosDamageAttackSkills"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75916,7 +69485,6 @@ return {
 			}, 
 		}, 
 		["5336_ChaosDamageSpellSkills"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75926,7 +69494,6 @@ return {
 			}, 
 		}, 
 		["5384_ChillEffect"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75936,7 +69503,6 @@ return {
 			}, 
 		}, 
 		["5403_FlatColdDamageTaken"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75946,7 +69512,6 @@ return {
 			}, 
 		}, 
 		["5405_ColdDamageAttackSkills"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75956,7 +69521,6 @@ return {
 			}, 
 		}, 
 		["5406_ColdDamageSpellSkills"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75966,7 +69530,6 @@ return {
 			}, 
 		}, 
 		["5521_SpellCriticalChanceWithDualWield"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75976,7 +69539,6 @@ return {
 			}, 
 		}, 
 		["5522_SpellCriticalChanceWithShield"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75986,7 +69548,6 @@ return {
 			}, 
 		}, 
 		["5523_SpellCriticalChanceWithStaff"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -75996,7 +69557,6 @@ return {
 			}, 
 		}, 
 		["5547_SpellCriticalMultiplierWithDualWield"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76006,7 +69566,6 @@ return {
 			}, 
 		}, 
 		["5548_SpellCriticalMultiplierWithShield"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76016,7 +69575,6 @@ return {
 			}, 
 		}, 
 		["5549_SpellCriticalMultiplierWithStaff"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76026,7 +69584,6 @@ return {
 			}, 
 		}, 
 		["5576_CurseDuration"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76036,7 +69593,6 @@ return {
 			}, 
 		}, 
 		["5629_DamagePer15Dexterity"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76046,7 +69602,6 @@ return {
 			}, 
 		}, 
 		["5630_DamagePer15Intelligence"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76056,7 +69611,6 @@ return {
 			}, 
 		}, 
 		["5631_DamagePer15Strength"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76066,7 +69620,6 @@ return {
 			}, 
 		}, 
 		["5639_IncreasedDamagePerPowerCharge"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76076,7 +69629,6 @@ return {
 			}, 
 		}, 
 		["5642_DamageVSAbyssMonsters"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76086,7 +69638,7 @@ return {
 			}, 
 		}, 
 		["5676_DamageTakenPer250Dexterity"] = {
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76096,7 +69648,7 @@ return {
 			}, 
 		}, 
 		["5677_DamageTakenPer250Intelligence"] = {
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76106,7 +69658,7 @@ return {
 			}, 
 		}, 
 		["5678_DamageTakenPer250Strength"] = {
-			["inverseKey"] = "reduced", 
+			["invertOnNegative"] = true, 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76116,7 +69668,6 @@ return {
 			}, 
 		}, 
 		["5736_DeterminationReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76126,7 +69677,6 @@ return {
 			}, 
 		}, 
 		["5737_DeterminationReservationEfficiency"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76136,7 +69686,6 @@ return {
 			}, 
 		}, 
 		["5748_DisciplineReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76146,7 +69695,6 @@ return {
 			}, 
 		}, 
 		["5749_DisciplineReservationEfficiency"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76156,7 +69704,6 @@ return {
 			}, 
 		}, 
 		["5876_IncreasedWeaponElementalDamagePercent"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76166,7 +69713,6 @@ return {
 			}, 
 		}, 
 		["5922_EnemiesExplodeOnDeathPhysical"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76176,7 +69722,6 @@ return {
 			}, 
 		}, 
 		["6000_DisciplineEnergyShieldRegen"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76186,7 +69731,6 @@ return {
 			}, 
 		}, 
 		["6075_FasterBleedDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76196,7 +69740,6 @@ return {
 			}, 
 		}, 
 		["6076_FasterPoisonDamage"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76206,7 +69749,6 @@ return {
 			}, 
 		}, 
 		["6094_FireDamagePerStrength"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76216,7 +69758,6 @@ return {
 			}, 
 		}, 
 		["6107_FireDamageAttackSkills"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76226,7 +69767,6 @@ return {
 			}, 
 		}, 
 		["6108_FireDamageSpellSkills"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76236,7 +69776,6 @@ return {
 			}, 
 		}, 
 		["6270_EnduranceChargeIfHitRecently"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76246,7 +69785,6 @@ return {
 			}, 
 		}, 
 		["6309_OnslaughtOnHit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76256,7 +69794,6 @@ return {
 			}, 
 		}, 
 		["6401_GraceReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76266,7 +69803,6 @@ return {
 			}, 
 		}, 
 		["6402_GraceReservationEfficiency"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76276,7 +69812,6 @@ return {
 			}, 
 		}, 
 		["6906_FlatLightningDamageTaken"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76286,7 +69821,6 @@ return {
 			}, 
 		}, 
 		["6907_LightningDamageAttackSkills"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76296,7 +69830,6 @@ return {
 			}, 
 		}, 
 		["6908_LightningDamageSpellSkills"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76306,7 +69839,6 @@ return {
 			}, 
 		}, 
 		["7303_AttackAndCastSpeedCorruptedItem"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76316,7 +69848,6 @@ return {
 			}, 
 		}, 
 		["7304_AttackDamageCorruptedItem"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76326,7 +69857,6 @@ return {
 			}, 
 		}, 
 		["7320_LocalChanceToIntimidateOnHit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76336,7 +69866,6 @@ return {
 			}, 
 		}, 
 		["7326_GlobalCriticalStrikeChanceCorruptedItem"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76346,7 +69875,6 @@ return {
 			}, 
 		}, 
 		["7331_AllDamageCorruptedItem"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76356,7 +69884,6 @@ return {
 			}, 
 		}, 
 		["7332_DamageTakenCorruptedItem"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76375,7 +69902,6 @@ return {
 			}, 
 		}, 
 		["7424_IncreasedEnergyShieldCorruptedItem"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76385,7 +69911,6 @@ return {
 			}, 
 		}, 
 		["7426_IncreasedLifeCorruptedItem"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76395,7 +69920,6 @@ return {
 			}, 
 		}, 
 		["7431_MovementVelocityCorruptedItem"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76405,7 +69929,6 @@ return {
 			}, 
 		}, 
 		["7433_LocalChanceToPoisonOnHit"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 				["overrideModLine"] = "#% chance to Poison on Hit", 
 			}, 
@@ -76416,7 +69939,6 @@ return {
 			}, 
 		}, 
 		["7435_AllElementalResistanceCorruptedItem"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76426,7 +69948,6 @@ return {
 			}, 
 		}, 
 		["7446_SpellDamageCorruptedItem"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76436,7 +69957,6 @@ return {
 			}, 
 		}, 
 		["7594_RecoverManaPercentOnBlock"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76446,7 +69966,6 @@ return {
 			}, 
 		}, 
 		["7609_AddedManaRegenWithDualWield"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76456,7 +69975,6 @@ return {
 			}, 
 		}, 
 		["7610_AddedManaRegenWithShield"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76466,7 +69984,6 @@ return {
 			}, 
 		}, 
 		["7612_AddedManaRegenWithStaff"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76476,7 +69993,6 @@ return {
 			}, 
 		}, 
 		["8469_FortifyEffect"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76486,7 +70002,6 @@ return {
 			}, 
 		}, 
 		["8501_LifeAddedAsEnergyShield"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76496,7 +70011,6 @@ return {
 			}, 
 		}, 
 		["8597_MinionAccuracyRating"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76506,7 +70020,6 @@ return {
 			}, 
 		}, 
 		["8793_IncreasedAilmentEffectOnEnemies"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76516,7 +70029,6 @@ return {
 			}, 
 		}, 
 		["8923_PhysicalDamageWithUnholyMight"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76526,7 +70038,6 @@ return {
 			}, 
 		}, 
 		["8942_PhysicalDamageAttackSkills"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76536,7 +70047,6 @@ return {
 			}, 
 		}, 
 		["8943_PhysicalDamageSpellSkills"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76546,7 +70056,6 @@ return {
 			}, 
 		}, 
 		["9036_PurityOfFireReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76556,7 +70065,6 @@ return {
 			}, 
 		}, 
 		["9037_PurityOfFireReservationEfficiency"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76566,7 +70074,6 @@ return {
 			}, 
 		}, 
 		["9039_PurityOfIceReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76576,7 +70083,6 @@ return {
 			}, 
 		}, 
 		["9040_PurityOfIceReservationEfficiency"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76586,7 +70092,6 @@ return {
 			}, 
 		}, 
 		["9042_PurityOfLightningReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76596,7 +70101,6 @@ return {
 			}, 
 		}, 
 		["9043_PurityOfLightningReservationEfficiency"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76606,7 +70110,6 @@ return {
 			}, 
 		}, 
 		["9142_ReflectDamageTaken"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76643,7 +70146,6 @@ return {
 			}, 
 		}, 
 		["9258_ShockEffect"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76653,7 +70155,6 @@ return {
 			}, 
 		}, 
 		["9293_BrandAttachmentRange"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76663,7 +70164,6 @@ return {
 			}, 
 		}, 
 		["9364_AdditionalCriticalStrikeChanceWithSpells"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76673,7 +70173,6 @@ return {
 			}, 
 		}, 
 		["9373_SpellsDoubleDamageChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76683,7 +70182,6 @@ return {
 			}, 
 		}, 
 		["9382_SpellDamagePerMana"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76693,7 +70191,6 @@ return {
 			}, 
 		}, 
 		["9388_SpellDamagePer10Strength"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76703,7 +70200,6 @@ return {
 			}, 
 		}, 
 		["9389_SpellDamagePer16Dexterity"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76713,7 +70209,6 @@ return {
 			}, 
 		}, 
 		["9390_SpellDamagePer16Intelligence"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76723,7 +70218,6 @@ return {
 			}, 
 		}, 
 		["9391_SpellDamagePer16Strength"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76733,7 +70227,6 @@ return {
 			}, 
 		}, 
 		["9421_SpellsHinderOnHitChance"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76743,7 +70236,6 @@ return {
 			}, 
 		}, 
 		["9651_DamageWithTriggeredSpells"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76780,7 +70272,6 @@ return {
 			}, 
 		}, 
 		["9742_VitalityReservation"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76790,7 +70281,6 @@ return {
 			}, 
 		}, 
 		["9743_VitalityReservationEfficiency"] = {
-			["sign"] = "", 
 			["specialCaseData"] = {
 			}, 
 			["tradeMod"] = {
@@ -76805,6 +70295,450 @@ return {
 			["tradeMod"] = {
 				["id"] = "implicit.stat_1683578560", 
 				["text"] = "Unwavering Stance", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+	}, 
+	["Talisman"] = {
+		["implicit.stat_1017730114"] = {
+			["Amulet"] = {
+				["max"] = 50, 
+				["min"] = 50, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_1017730114", 
+				["text"] = "#% of Lightning Damage from Hits taken as Cold Damage", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_1054322244"] = {
+			["Amulet"] = {
+				["max"] = 10, 
+				["min"] = 10, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_1054322244", 
+				["text"] = "#% chance to gain an Endurance Charge on Kill", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_1189760108"] = {
+			["Amulet"] = {
+				["max"] = 50, 
+				["min"] = 50, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_1189760108", 
+				["text"] = "#% of Cold Damage from Hits taken as Fire Damage", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_1296614065"] = {
+			["Amulet"] = {
+				["max"] = 40, 
+				["min"] = 30, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_1296614065", 
+				["text"] = "#% increased Fish Bite Sensitivity", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_1310194496"] = {
+			["Amulet"] = {
+				["max"] = 30, 
+				["min"] = 20, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_1310194496", 
+				["text"] = "#% increased Global Physical Damage", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_1313503107"] = {
+			["Amulet"] = {
+				["max"] = 50, 
+				["min"] = 50, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_1313503107", 
+				["text"] = "#% of Cold Damage from Hits taken as Lightning Damage", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_1389153006"] = {
+			["Amulet"] = {
+				["max"] = 25, 
+				["min"] = 15, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_1389153006", 
+				["text"] = "#% increased Global Defences", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_1504091975"] = {
+			["Amulet"] = {
+				["max"] = 50, 
+				["min"] = 50, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_1504091975", 
+				["text"] = "#% of Fire Damage from Hits taken as Lightning Damage", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_1826802197"] = {
+			["Amulet"] = {
+				["max"] = 10, 
+				["min"] = 10, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_1826802197", 
+				["text"] = "#% chance to gain a Frenzy Charge on Kill", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_2067062068"] = {
+			["Amulet"] = {
+				["max"] = 2, 
+				["min"] = 2, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_2067062068", 
+				["text"] = "Projectiles Pierce # additional Targets", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_2154246560"] = {
+			["Amulet"] = {
+				["max"] = 35, 
+				["min"] = 25, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_2154246560", 
+				["text"] = "#% increased Damage", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_2231156303"] = {
+			["Amulet"] = {
+				["max"] = 30, 
+				["min"] = 20, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_2231156303", 
+				["text"] = "#% increased Lightning Damage", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_2483795307"] = {
+			["Amulet"] = {
+				["max"] = 10, 
+				["min"] = 10, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_2483795307", 
+				["text"] = "#% chance to gain a Power Charge on Kill", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_2522672898"] = {
+			["Amulet"] = {
+				["max"] = 50, 
+				["min"] = 50, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_2522672898", 
+				["text"] = "#% of Fire Damage from Hits taken as Cold Damage", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_2672805335"] = {
+			["Amulet"] = {
+				["max"] = 10, 
+				["min"] = 6, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_2672805335", 
+				["text"] = "#% increased Attack and Cast Speed", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_2748665614"] = {
+			["Amulet"] = {
+				["max"] = 30, 
+				["min"] = 20, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_2748665614", 
+				["text"] = "#% increased maximum Mana", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_280731498"] = {
+			["Amulet"] = {
+				["max"] = 8, 
+				["min"] = 5, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_280731498", 
+				["text"] = "#% increased Area of Effect", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_2843214518"] = {
+			["Amulet"] = {
+				["max"] = 30, 
+				["min"] = 20, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_2843214518", 
+				["text"] = "#% increased Attack Damage", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_2974417149"] = {
+			["Amulet"] = {
+				["max"] = 30, 
+				["min"] = 20, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_2974417149", 
+				["text"] = "#% increased Spell Damage", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_3143208761"] = {
+			["Amulet"] = {
+				["max"] = 16, 
+				["min"] = 12, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_3143208761", 
+				["text"] = "#% increased Attributes", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_3291658075"] = {
+			["Amulet"] = {
+				["max"] = 30, 
+				["min"] = 20, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_3291658075", 
+				["text"] = "#% increased Cold Damage", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_3375859421"] = {
+			["Amulet"] = {
+				["max"] = 50, 
+				["min"] = 50, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_3375859421", 
+				["text"] = "#% of Lightning Damage from Hits taken as Fire Damage", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_3556824919"] = {
+			["Amulet"] = {
+				["max"] = 36, 
+				["min"] = 24, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_3556824919", 
+				["text"] = "+#% to Global Critical Strike Multiplier", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_3753703249"] = {
+			["Amulet"] = {
+				["max"] = 12, 
+				["min"] = 6, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_3753703249", 
+				["text"] = "Gain #% of Physical Damage as Extra Damage of a random Element", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_3771516363"] = {
+			["Amulet"] = {
+				["max"] = 6, 
+				["min"] = 4, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_3771516363", 
+				["text"] = "#% additional Physical Damage Reduction", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_3962278098"] = {
+			["Amulet"] = {
+				["max"] = 30, 
+				["min"] = 20, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_3962278098", 
+				["text"] = "#% increased Fire Damage", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_3988349707"] = {
+			["Amulet"] = {
+				["max"] = 18, 
+				["min"] = 12, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_3988349707", 
+				["text"] = "+#% to Damage over Time Multiplier", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_4077843608"] = {
+			["Amulet"] = {
+				["max"] = 1, 
+				["min"] = 1, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_4077843608", 
+				["text"] = "Has 1 Socket", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_587431675"] = {
+			["Amulet"] = {
+				["max"] = 50, 
+				["min"] = 40, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_587431675", 
+				["text"] = "#% increased Global Critical Strike Chance", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_736967255"] = {
+			["Amulet"] = {
+				["max"] = 31, 
+				["min"] = 19, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_736967255", 
+				["text"] = "#% increased Chaos Damage", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_800141891"] = {
+			["Amulet"] = {
+				["max"] = 6, 
+				["min"] = 4, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_800141891", 
+				["text"] = "#% chance to Freeze, Shock and Ignite", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_836936635"] = {
+			["Amulet"] = {
+				["max"] = 2, 
+				["min"] = 2, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_836936635", 
+				["text"] = "Regenerate #% of Life per second", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_966747987"] = {
+			["Amulet"] = {
+				["max"] = 1, 
+				["min"] = 1, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_966747987", 
+				["text"] = "+# to maximum number of Raised Zombies", 
+				["type"] = "implicit", 
+			}, 
+		}, 
+		["implicit.stat_983749596"] = {
+			["Amulet"] = {
+				["max"] = 12, 
+				["min"] = 8, 
+			}, 
+			["specialCaseData"] = {
+			}, 
+			["tradeMod"] = {
+				["id"] = "implicit.stat_983749596", 
+				["text"] = "#% increased maximum Life", 
 				["type"] = "implicit", 
 			}, 
 		}, 


### PR DESCRIPTION
### Description of the problem being solved:
This refactors how inverted mods are handled, and does away with saving the sign value and subType. This means there is a new section called Talismans.

Implicits has been refactored and now uses ProcessMod this stops them applying to stuff they shouldn't and don't spam the QueryMods with subType stuff.

Several negative value mods now work correctly and some mods that might've been parsed correctly on an item should work for weight generation.

POSESSID is automatically expired.

HTML passed queries were removed in favor of API due to receiving constant 403 from them. This means realmIds and names were hardcoded but this shouldn't be an issue as they are infrequently updated.

Generation no longer uses invert and instead negative values are parsed in the stat weight which is handled by building values in queryMods.

The sign appearing might not be the most correct since it assumes that if a mod appears on the trade site with a + it will have one but there are cases where this isn't the case this can be seen in PoE 2 quite commonly but probably isn't a big deal here. Ideally using their stat descriptions would be ideal to determine this.