### PR TITLE
Stages for vaal skills

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -2129,11 +2129,25 @@ skills["VaalBladeFlurry"] = {
 		["vaal_charged_attack_damage_taken_+%_final"] = {
 			mod("DamageTaken", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
 		},
+		["vaal_charged_attack_radius_+_per_stage"] = {
+			mod("AreaOfEffect", "BASE", nil, 0, 0, { type = "Multiplier", var = "VaalBladeFlurryStage" }),
+		},
+		["charged_attack_damage_per_stack_+%_final"] = {
+			mod("Damage", "MORE", nil, 0, 0, { type = "Multiplier", var = "VaalBladeFlurryStage" }),
+		},
 	},
+--huge/inf used for now, max stages are when aoe reaches 9m. 89% INC AoE made my max stages 11/12 in game
+--secondary radius around enemy unknown, set to 1m for now
 	baseFlags = {
 		attack = true,
 		melee = true,
 		area = true,
+	},
+	baseMods = {
+		skill("numStages", 1, { type = "Multiplier", var = "VaalBladeFlurryStage" }),
+		mod("Multiplier:VaalBladeFlurryMaxStages", "BASE", math.huge ),
+		skill("radius", 10),
+		skill("radiusSecondary", 10),
 	},
 	qualityStats = {
 		Default = {
@@ -2196,6 +2210,7 @@ skills["VaalBladeFlurry"] = {
 		[40] = { 108, attackSpeedMultiplier = 220, baseMultiplier = 10.859, soulPreventionDuration = 3, storedUses = 1, damageEffectiveness = 10.859, vaalStoredUses = 1, cooldown = 0.5, levelRequirement = 100, statInterpolation = { 1, }, cost = { Soul = 30, }, },
 	},
 }
+
 skills["BladeVortex"] = {
 	name = "Blade Vortex",
 	baseTypeName = "Blade Vortex",
@@ -12150,9 +12165,12 @@ skills["Reave"] = {
 		["reave_area_of_effect_+%_final_per_stage"] = {
 			mod("AreaOfEffect", "MORE", nil, 0, 0, { type = "Multiplier", var = "ReaveStage" }),
 		},
+		["display_reave_base_maximum_stacks"] = {
+			mod("Multiplier:ReaveMaxStages", "BASE", nil),
+		},
 		["reave_additional_max_stacks"] = {
 			mod("Multiplier:ReaveMaxStages", "BASE", nil),
-		}
+		},
 	},
 	baseFlags = {
 		attack = true,
@@ -12161,7 +12179,6 @@ skills["Reave"] = {
 	},
 	baseMods = {
 		skill("radius", 20),
-		mod("Multiplier:ReaveMaxStages", "BASE", 8),
 	},
 	qualityStats = {
 		Default = {
@@ -12238,9 +12255,12 @@ skills["ReaveAltX"] = {
 		["reave_area_of_effect_+%_final_per_stage"] = {
 			mod("AreaOfEffect", "MORE", nil, 0, 0, { type = "Multiplier", var = "ReaveofRefractionStage" }),
 		},
+		["display_reave_base_maximum_stacks"] = {
+			mod("Multiplier:ReaveofRefractionMaxStages", "BASE", nil),
+		},
 		["reave_additional_max_stacks"] = {
 			mod("Multiplier:ReaveofRefractionMaxStages", "BASE", nil),
-		}
+		},
 	},
 	baseFlags = {
 		attack = true,
@@ -12249,7 +12269,6 @@ skills["ReaveAltX"] = {
 	},
 	baseMods = {
 		skill("radius", 20),
-		mod("Multiplier:ReaveofRefractionMaxStages", "BASE", 8),
 	},
 	qualityStats = {
 		Default = {
@@ -12325,10 +12344,13 @@ skills["VaalReave"] = {
 	castTime = 1,
 	statMap = {
 		["reave_area_of_effect_+%_final_per_stage"] = {
-			mod("AreaOfEffect", "MORE", nil, 0, 0, { type = "Multiplier", var = "ReaveStage" }),
+			mod("AreaOfEffect", "MORE", nil, 0, 0, { type = "Multiplier", var = "VaalReaveStage" }),
+		},
+		["display_reave_base_maximum_stacks"] = {
+			mod("Multiplier:VaalReaveMaxStages", "BASE", nil),
 		},
 		["reave_additional_max_stacks"] = {
-			mod("Multiplier:ReaveMaxStages", "BASE", nil),
+			mod("Multiplier:VaalReaveMaxStages", "BASE", nil),
 		},
 	},
 	baseFlags = {
@@ -12339,7 +12361,6 @@ skills["VaalReave"] = {
 	},
 	baseMods = {
 		skill("radius", 12),
-		mod("Multiplier:ReaveMaxStages", "BASE", 4),
 	},
 	qualityStats = {
 		Default = {

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -2127,13 +2127,13 @@ skills["VaalBladeFlurry"] = {
 	castTime = 1,
 	statMap = {
 		["vaal_charged_attack_damage_taken_+%_final"] = {
-			mod("DamageTaken", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+			mod("DamageTaken", "MORE", nil, 0, 0, { type = "Condition", var = "ChannellingVaalBladeFlurry"}, { type = "GlobalEffect", effectType = "Buff",  unscalable = true }),
 		},
 		["vaal_charged_attack_radius_+_per_stage"] = {
 			mod("AreaOfEffect", "BASE", nil, 0, 0, { type = "Multiplier", var = "VaalBladeFlurryStage" }),
 		},
 		["charged_attack_damage_per_stack_+%_final"] = {
-			mod("Damage", "MORE", nil, 0, 0, { type = "Multiplier", var = "VaalBladeFlurryStage" }),
+			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "Multiplier", var = "VaalBladeFlurryStage" }),
 		},
 	},
 --huge/inf used for now, max stages are when aoe reaches 9m. 89% INC AoE made my max stages 11/12 in game
@@ -12165,9 +12165,6 @@ skills["Reave"] = {
 		["reave_area_of_effect_+%_final_per_stage"] = {
 			mod("AreaOfEffect", "MORE", nil, 0, 0, { type = "Multiplier", var = "ReaveStage" }),
 		},
-		["display_reave_base_maximum_stacks"] = {
-			mod("Multiplier:ReaveMaxStages", "BASE", nil),
-		},
 		["reave_additional_max_stacks"] = {
 			mod("Multiplier:ReaveMaxStages", "BASE", nil),
 		},
@@ -12179,6 +12176,7 @@ skills["Reave"] = {
 	},
 	baseMods = {
 		skill("radius", 20),
+		mod("Multiplier:ReaveMaxStages", "BASE", 8),
 	},
 	qualityStats = {
 		Default = {
@@ -12255,12 +12253,9 @@ skills["ReaveAltX"] = {
 		["reave_area_of_effect_+%_final_per_stage"] = {
 			mod("AreaOfEffect", "MORE", nil, 0, 0, { type = "Multiplier", var = "ReaveofRefractionStage" }),
 		},
-		["display_reave_base_maximum_stacks"] = {
-			mod("Multiplier:ReaveofRefractionMaxStages", "BASE", nil),
-		},
 		["reave_additional_max_stacks"] = {
 			mod("Multiplier:ReaveofRefractionMaxStages", "BASE", nil),
-		},
+		}
 	},
 	baseFlags = {
 		attack = true,
@@ -12269,6 +12264,7 @@ skills["ReaveAltX"] = {
 	},
 	baseMods = {
 		skill("radius", 20),
+		mod("Multiplier:ReaveofRefractionMaxStages", "BASE", 8),
 	},
 	qualityStats = {
 		Default = {
@@ -12346,9 +12342,6 @@ skills["VaalReave"] = {
 		["reave_area_of_effect_+%_final_per_stage"] = {
 			mod("AreaOfEffect", "MORE", nil, 0, 0, { type = "Multiplier", var = "VaalReaveStage" }),
 		},
-		["display_reave_base_maximum_stacks"] = {
-			mod("Multiplier:VaalReaveMaxStages", "BASE", nil),
-		},
 		["reave_additional_max_stacks"] = {
 			mod("Multiplier:VaalReaveMaxStages", "BASE", nil),
 		},
@@ -12361,6 +12354,7 @@ skills["VaalReave"] = {
 	},
 	baseMods = {
 		skill("radius", 12),
+		mod("Multiplier:VaalReaveMaxStages", "BASE", 4),
 	},
 	qualityStats = {
 		Default = {

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -2261,12 +2261,22 @@ skills["VaalBlight"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Chaos] = true, [SkillType.Area] = true, [SkillType.Totemable] = true, [SkillType.Duration] = true, [SkillType.DamageOverTime] = true, [SkillType.DegenOnlySpellDamage] = true, [SkillType.Vaal] = true, [SkillType.AreaSpell] = true, [SkillType.Nova] = true, },
 	statDescriptionScope = "debuff_skill_stat_descriptions",
 	castTime = 0.6,
+	parts = {
+		{
+			name = "Manual Stacks",
+			stages = true,
+		},
+		{
+			name = "Maximum Sustainable Stacks",
+		},
+	},
 	statMap = {
+		["display_max_blight_stacks"] = {
+			mod("Multiplier:VaalBlightMaxStages", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 1 }),
+			mod("BlightBaseMaxStages", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
+		},
 		["hinder_enemy_chaos_damage_taken_+%"] = {
 			mod("ChaosDamageTaken", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Hinder" }),
-		},
-		["display_max_blight_stacks"] = {
-			mod("Multiplier:BlightMaxStages", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 1 }),
 		},
 	},
 	baseFlags = {
@@ -2275,6 +2285,9 @@ skills["VaalBlight"] = {
 		area = true,
 	},
 	baseMods = {
+		mod("Damage", "MORE", 100, 0, 0, { type = "Multiplier", var = "VaalBlightStageAfterFirst" }),
+		skill("debuff", true),
+		skill("debuffSecondary", true),
 		skill("radius", 20),
 	},
 	qualityStats = {

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -2261,12 +2261,22 @@ skills["VaalBlight"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Chaos] = true, [SkillType.Area] = true, [SkillType.Totemable] = true, [SkillType.Duration] = true, [SkillType.DamageOverTime] = true, [SkillType.DegenOnlySpellDamage] = true, [SkillType.Vaal] = true, [SkillType.AreaSpell] = true, [SkillType.Nova] = true, },
 	statDescriptionScope = "debuff_skill_stat_descriptions",
 	castTime = 0.6,
+	parts = {
+		{
+			name = "Manual Stacks",
+			stages = true,
+		},
+		{
+			name = "Maximum Sustainable Stacks",
+		},
+	},
 	statMap = {
+		["display_max_blight_stacks"] = {
+			mod("Multiplier:VaalBlightMaxStages", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 1 }),
+			mod("BlightBaseMaxStages", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
+		},
 		["hinder_enemy_chaos_damage_taken_+%"] = {
 			mod("ChaosDamageTaken", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Hinder" }),
-		},
-		["display_max_blight_stacks"] = {
-			mod("Multiplier:BlightMaxStages", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 1 }),
 		},
 	},
 	baseFlags = {
@@ -2275,6 +2285,9 @@ skills["VaalBlight"] = {
 		area = true,
 	},
 	baseMods = {
+		mod("Damage", "MORE", 100, 0, 0, { type = "Multiplier", var = "VaalBlightStageAfterFirst" }),
+		skill("debuff", true),
+		skill("debuffSecondary", true),
 		skill("radius", 20),
 	},
 	qualityStats = {
@@ -6870,7 +6883,7 @@ skills["VaalFlameblast"] = {
 			mod("Damage", "MORE", nil, 0, KeywordFlag.Ailment, { type = "Multiplier", var = "VaalFlameblastStage" }),
 		},
 		["vaal_flameblast_radius_+_per_stage"] = {
-			mod("AreaOfEffect", "BASE", nil, 0, 0, { type = "Multiplier", var = "FlameblastStageAfterFirst" }),
+			mod("AreaOfEffect", "BASE", nil, 0, 0, { type = "Multiplier", var = "VaalFlameblastStageAfterFirst" }),
 		},
 	},
 	baseFlags = {

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -394,8 +394,21 @@ local skills, mod, flag, skill = ...
 		["vaal_charged_attack_damage_taken_+%_final"] = {
 			mod("DamageTaken", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
 		},
+		["vaal_charged_attack_radius_+_per_stage"] = {
+			mod("AreaOfEffect", "BASE", nil, 0, 0, { type = "Multiplier", var = "VaalBladeFlurryStage" }),
+		},
+		["charged_attack_damage_per_stack_+%_final"] = {
+			mod("Damage", "MORE", nil, 0, 0, { type = "Multiplier", var = "VaalBladeFlurryStage" }),
+		},
 	},
+--huge/inf used for now, max stages are when aoe reaches 9m. 89% INC AoE made my max stages 11/12 in game
+--secondary radius around enemy unknown, set to 1m for now
+#baseMod skill("numStages", 1, { type = "Multiplier", var = "VaalBladeFlurryStage" })
+#baseMod mod("Multiplier:VaalBladeFlurryMaxStages", "BASE", math.huge )
+#baseMod skill("radius", 10)
+#baseMod skill("radiusSecondary", 10)
 #mods
+
 
 #skill BladeVortex
 #flags spell area duration
@@ -2344,12 +2357,14 @@ local skills, mod, flag, skill = ...
 		["reave_area_of_effect_+%_final_per_stage"] = {
 			mod("AreaOfEffect", "MORE", nil, 0, 0, { type = "Multiplier", var = "ReaveStage" }),
 		},
+		["display_reave_base_maximum_stacks"] = {
+			mod("Multiplier:ReaveMaxStages", "BASE", nil),
+		},
 		["reave_additional_max_stacks"] = {
 			mod("Multiplier:ReaveMaxStages", "BASE", nil),
-		}
+		},
 	},
 #baseMod skill("radius", 20)
-#baseMod mod("Multiplier:ReaveMaxStages", "BASE", 8)
 #mods
 
 #skill ReaveAltX
@@ -2358,26 +2373,30 @@ local skills, mod, flag, skill = ...
 		["reave_area_of_effect_+%_final_per_stage"] = {
 			mod("AreaOfEffect", "MORE", nil, 0, 0, { type = "Multiplier", var = "ReaveofRefractionStage" }),
 		},
+		["display_reave_base_maximum_stacks"] = {
+			mod("Multiplier:ReaveofRefractionMaxStages", "BASE", nil),
+		},
 		["reave_additional_max_stacks"] = {
 			mod("Multiplier:ReaveofRefractionMaxStages", "BASE", nil),
-		}
+		},
 	},
 #baseMod skill("radius", 20)
-#baseMod mod("Multiplier:ReaveofRefractionMaxStages", "BASE", 8)
 #mods
 
 #skill VaalReave
 #flags attack melee area vaal
 	statMap = {
 		["reave_area_of_effect_+%_final_per_stage"] = {
-			mod("AreaOfEffect", "MORE", nil, 0, 0, { type = "Multiplier", var = "ReaveStage" }),
+			mod("AreaOfEffect", "MORE", nil, 0, 0, { type = "Multiplier", var = "VaalReaveStage" }),
+		},
+		["display_reave_base_maximum_stacks"] = {
+			mod("Multiplier:VaalReaveMaxStages", "BASE", nil),
 		},
 		["reave_additional_max_stacks"] = {
-			mod("Multiplier:ReaveMaxStages", "BASE", nil),
+			mod("Multiplier:VaalReaveMaxStages", "BASE", nil),
 		},
 	},
 #baseMod skill("radius", 12)
-#baseMod mod("Multiplier:ReaveMaxStages", "BASE", 4)
 #mods
 
 #skill ScourgeArrow

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -2357,14 +2357,12 @@ local skills, mod, flag, skill = ...
 		["reave_area_of_effect_+%_final_per_stage"] = {
 			mod("AreaOfEffect", "MORE", nil, 0, 0, { type = "Multiplier", var = "ReaveStage" }),
 		},
-		["display_reave_base_maximum_stacks"] = {
-			mod("Multiplier:ReaveMaxStages", "BASE", nil),
-		},
 		["reave_additional_max_stacks"] = {
 			mod("Multiplier:ReaveMaxStages", "BASE", nil),
 		},
 	},
 #baseMod skill("radius", 20)
+#baseMod mod("Multiplier:ReaveMaxStages", "BASE", 8)
 #mods
 
 #skill ReaveAltX
@@ -2373,14 +2371,12 @@ local skills, mod, flag, skill = ...
 		["reave_area_of_effect_+%_final_per_stage"] = {
 			mod("AreaOfEffect", "MORE", nil, 0, 0, { type = "Multiplier", var = "ReaveofRefractionStage" }),
 		},
-		["display_reave_base_maximum_stacks"] = {
-			mod("Multiplier:ReaveofRefractionMaxStages", "BASE", nil),
-		},
 		["reave_additional_max_stacks"] = {
 			mod("Multiplier:ReaveofRefractionMaxStages", "BASE", nil),
-		},
+		}
 	},
 #baseMod skill("radius", 20)
+#baseMod mod("Multiplier:ReaveofRefractionMaxStages", "BASE", 8)
 #mods
 
 #skill VaalReave
@@ -2389,14 +2385,12 @@ local skills, mod, flag, skill = ...
 		["reave_area_of_effect_+%_final_per_stage"] = {
 			mod("AreaOfEffect", "MORE", nil, 0, 0, { type = "Multiplier", var = "VaalReaveStage" }),
 		},
-		["display_reave_base_maximum_stacks"] = {
-			mod("Multiplier:VaalReaveMaxStages", "BASE", nil),
-		},
 		["reave_additional_max_stacks"] = {
 			mod("Multiplier:VaalReaveMaxStages", "BASE", nil),
 		},
 	},
 #baseMod skill("radius", 12)
+#baseMod mod("Multiplier:VaalReaveMaxStages", "BASE", 4)
 #mods
 
 #skill ScourgeArrow

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -505,14 +505,27 @@ local skills, mod, flag, skill = ...
 
 #skill VaalBlight
 #flags spell duration area
+	parts = {
+		{
+			name = "Manual Stacks",
+			stages = true,
+		},
+		{
+			name = "Maximum Sustainable Stacks",
+		},
+	},
 	statMap = {
+		["display_max_blight_stacks"] = {
+			mod("Multiplier:VaalBlightMaxStages", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 1 }),
+			mod("BlightBaseMaxStages", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
+		},
 		["hinder_enemy_chaos_damage_taken_+%"] = {
 			mod("ChaosDamageTaken", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Debuff", effectName = "Hinder" }),
 		},
-		["display_max_blight_stacks"] = {
-			mod("Multiplier:BlightMaxStages", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 1 }),
-		},
 	},
+#baseMod mod("Damage", "MORE", 100, 0, 0, { type = "Multiplier", var = "VaalBlightStageAfterFirst" })
+#baseMod skill("debuff", true)
+#baseMod skill("debuffSecondary", true)
 #baseMod skill("radius", 20)
 #mods
 
@@ -1345,7 +1358,7 @@ local skills, mod, flag, skill = ...
 			mod("Damage", "MORE", nil, 0, KeywordFlag.Ailment, { type = "Multiplier", var = "VaalFlameblastStage" }),
 		},
 		["vaal_flameblast_radius_+_per_stage"] = {
-			mod("AreaOfEffect", "BASE", nil, 0, 0, { type = "Multiplier", var = "FlameblastStageAfterFirst" }),
+			mod("AreaOfEffect", "BASE", nil, 0, 0, { type = "Multiplier", var = "VaalFlameblastStageAfterFirst" }),
 		},
 	},
 #baseMod mod("Multiplier:VaalFlameblastMaxStages", "BASE", 15)

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1867,7 +1867,7 @@ function calcs.perform(env, skipEHP)
 	-- See: https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/5164
 	for _, activeSkill in ipairs(env.player.activeSkillList) do
 		if not activeSkill.skillFlags.disable and not (env.limitedSkills and env.limitedSkills[cacheSkillUUID(activeSkill, env)]) then
-			if (activeSkill.activeEffect.grantedEffect.name == "Blight" or activeSkill.activeEffect.grantedEffect.name == "Blight of Contagion" or activeSkill.activeEffect.grantedEffect.name == "Blight of Atrophy") and activeSkill.skillPart == 2 then
+			if (activeSkill.activeEffect.grantedEffect.name == "Blight" or activeSkill.activeEffect.grantedEffect.name == "Vaal Blight" or activeSkill.activeEffect.grantedEffect.name == "Blight of Contagion" or activeSkill.activeEffect.grantedEffect.name == "Blight of Atrophy") and activeSkill.skillPart == 2 then
 				local rate, duration = getCachedOutputValue(env, activeSkill, "Speed", "Duration")
 				local baseMaxStages = activeSkill.skillModList:Sum("BASE", env.player.mainSkill.skillCfg, "BlightBaseMaxStages")
 				local maximum = m_min((m_floor(rate * duration) - 1), baseMaxStages - 1)

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -659,6 +659,10 @@ return {
 	{ var = "absolutionSkillDamageCountedOnce", type = "check", label = "Absolution: Count skill damage once", ifSkill = "Absolution", includeTransfigured = true, tooltip = "Your Absolution Skill Damage will not be scaled with Count setting.\nBy default it multiplies both minion count and skill hit count which leads to incorrect\nTotal DPS calculation since Absolution cannot inherently shotgun.\nDo not enable if you use Spell Totem support, Spell Cascade support or similar supports", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:AbsolutionSkillDamageCountedOnce", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
+	{ label = "Vaal Blade Flurry", ifSkill = "Vaal Blade Flurry" },
+	{ var = "channellingVaalBladeFlurryCheck", type = "check", label = "Are you Channelling Vaal Blade Flurry?", ifSkill = "Vaal Blade Flurry", includeTransfigured = true, apply = function(val, modList, enemyModList)
+		modList:NewMod("Condition:ChannellingVaalBladeFlurry", "FLAG", true, "Config")
+	end },
 	{ label = "Molten Shell:", ifSkill = "Molten Shell" },
 	{ var = "MoltenShellDamageMitigated", type = "count", label = "Damage mitigated:", tooltip = "Molten Shell reflects damage to the enemy,\nbased on the amount of damage it has mitigated.", ifSkill = "Molten Shell", apply = function(val, modList, enemyModList)
 		modList:NewMod("SkillData", "LIST", { key = "MoltenShellDamageMitigated", value = val }, "Config", { type = "SkillName", skillName = "Molten Shell" })


### PR DESCRIPTION
Fixes #5698 
### Description of the problem being solved:
- Vaal Blight now has selectable Stages in side bar and Calc page.
- Vaal Reave also has Stages in side bar and Calc page.
Vaal Reave and the Reave part of Vaal Reave both scale stacks properly. However, Reave of Refraction only scales to the normal 10 that is possible from a 20q Vaal Reave. Not sure if it's possible, but it would be nice to somehow grab the Vaal Reave max stacks, and apply it to RoR. If the player has enhance linked to the Vaal gem, or has it socketed in Crest of Desire, the stacks would be over 10 and RoR has no idea.
- Vaal Blade Flurry also has stages like above.
Vaal Blade Flurry has no cap on the max stages currently. This is because the skill ends once the circle reaches 9m. Increased AoE affects this. With 89% increased AoE in game, it only took 11/12 stages for it to auto end at 9m. Decreased AoE would make the skill hit more stages before 9m. I also am not sure on where to get the secondary radius for the aoe on enemies. I set it to 1m for now.

- Vaal Flameblast wasn't applying decreased AoE per stage, it was looking for regular flame blast.
- Vaal Flameblast base radius increased to 45, from update 3.14.

Current Issues:
Vaal Blade Flurry applies 50% less damage to player at all times, regardless if it's the active skill. This is in the current release, not from this PR.

### Link to a build that showcases this PR:
https://pobb.in/6MwWYCMzXy3M
### Before screenshot:

### After screenshot:
![image](https://github.com/user-attachments/assets/660527c7-dfb9-4199-b967-c5b8de956dee)
![image](https://github.com/user-attachments/assets/fca499a1-4f89-4f46-b8f6-34d398837268)
![image](https://github.com/user-attachments/assets/583874a5-2dcc-4024-8401-e2e1e83e9928)
