### PR TITLE
Fix Wiki hotkey (F1) not working correctly on Relic Items

### DIFF
--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -152,7 +152,7 @@ itemLib.wiki = {
 		itemLib.wiki.open(name)
 	end,
 	openItem = function(item)
-		local name = item.rarity == "UNIQUE" and item.title or item.baseName
+		local name = (item.rarity == "UNIQUE" or item.rarity == "RELIC") and item.title or item.baseName
 
 		itemLib.wiki.open(name)
 	end,


### PR DESCRIPTION
The Unique item check wasn't being made for relic uniques so it would bring you to the item base page instead of the unique item page
