### PR TITLE
Fix Maven Memory Game skill breaking Vile Bastion from working

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -699,11 +699,11 @@ function calcs.defence(env, actor)
 			"Total: "..output.SpellBlockChance+output.SpellBlockChanceOverCap.."%",
 		}
 	end
-	if modDB:Flag(nil, "CannotBlockAttacks") or enemyDB:Flag(nil, "CannotBeBlocked") then
+	if modDB:Flag(nil, "CannotBlockAttacks") then
 		output.BlockChance = 0
 		output.ProjectileBlockChance = 0
 	end
-	if modDB:Flag(nil, "CannotBlockSpells") or enemyDB:Flag(nil, "CannotBeBlocked") then
+	if modDB:Flag(nil, "CannotBlockSpells") then
 		output.SpellBlockChance = 0
 		output.SpellProjectileBlockChance = 0
 	end
@@ -2623,12 +2623,14 @@ function calcs.buildDefenceEstimations(env, actor)
 			output["NumberOfDamagingHits"] = numberOfHitsToDie(DamageIn)
 		end
 
-	
 		do
 			local DamageIn = { }
 			local BlockChance = output.EffectiveBlockChance / 100
 			if damageCategoryConfig ~= "Melee" and damageCategoryConfig ~= "Untyped" then
 				BlockChance = output["Effective"..damageCategoryConfig.."BlockChance"] / 100
+			end
+			if enemyDB:Flag(nil, "CannotBeBlocked") then
+				BlockChance = 0
 			end
 			local blockEffect = (1 - BlockChance * output.BlockEffect / 100)
 			local suppressChance = 0


### PR DESCRIPTION
Fixes # 
![image](https://github.com/user-attachments/assets/fd1273f5-35d6-4c02-b5a7-2c14a8c89580)

### Description of the problem being solved:
Maven Memory Game and other boss skills in the Config menu would break Vile Bastion. We were setting the actual Block Chance to 0, so Vile Bastion and any other nodes/skills that use block chance like Mystic Bulwark.
### Steps taken to verify a working solution:
- Skills with CannotBeBlocked do not override output.BlockChance, they do so farther down in the calcs.
- output.BlockChance is still set to 0 from CannotBlockAttacks or CannotBlockSpells, so things like The Eternal Apple still function.
- Calcs page still shows block chance on the left, and Unmitigated % shows 100% as expected.

### Link to a build that showcases this PR:
https://pobb.in/I6azipBrk7sI
### Before Screenshot
![image](https://github.com/user-attachments/assets/62303218-f069-4919-91c2-edadfb9b3a8f)
![image](https://github.com/user-attachments/assets/4a7201bc-8a22-4447-a001-b5f26f13a0ca)
### After screenshot:
![image](https://github.com/user-attachments/assets/9d40d2f2-b0e4-4be1-9f15-2a2a372f8ebf)
![image](https://github.com/user-attachments/assets/09556989-d4b7-4fbc-b827-dc950fd4c38e)
![image](https://github.com/user-attachments/assets/e586ef6d-0446-44cc-a605-a2797c5aa3c0)