### PR TITLE
Fix Reduced Effect of Curses on Self not clamping

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1517,7 +1517,7 @@ function calcs.defence(env, actor)
 	if breakdown then
 		breakdown.LightRadiusMod = breakdown.mod(modDB, nil, "LightRadius")
 	end
-	output.CurseEffectOnSelf = modDB:More(nil, "CurseEffectOnSelf") * (100 + modDB:Sum("INC", nil, "CurseEffectOnSelf"))
+	output.CurseEffectOnSelf = m_max(modDB:More(nil, "CurseEffectOnSelf") * (100 + modDB:Sum("INC", nil, "CurseEffectOnSelf")), 0)
 	output.ExposureEffectOnSelf = modDB:More(nil, "ExposureEffectOnSelf") * (100 + modDB:Sum("INC", nil, "ExposureEffectOnSelf"))
 	output.WitherEffectOnSelf = modDB:More(nil, "WitherEffectOnSelf") * (100 + modDB:Sum("INC", nil, "WitherEffectOnSelf"))
 

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2775,7 +2775,7 @@ function calcs.perform(env, skipEHP)
 						local cfg = { skillName = grantedEffect.name }
 						local inc = modDB:Sum("INC", cfg, "CurseEffectOnSelf") + gemModList:Sum("INC", nil, "CurseEffectAgainstPlayer")
 						local more = modDB:More(cfg, "CurseEffectOnSelf") * gemModList:More(nil, "CurseEffectAgainstPlayer")
-						modDB:ScaleAddList(curseModList, (1 + inc / 100) * more)
+						modDB:ScaleAddList(curseModList, m_max((1 + inc / 100) * more, 0))
 					end
 				elseif not enemyDB:Flag(nil, "Hexproof") or modDB:Flag(nil, "CursesIgnoreHexproof") then
 					local curse = {


### PR DESCRIPTION
Fixes #
![image](https://github.com/user-attachments/assets/9f032ae1-918b-45f0-bada-7f23ab4c7e81)
### Description of the problem being solved:
As explained in image, ``reduced effect of curses on you`` was not clamped. So stacking reduced effect would provide positive results after 100. In the case of a Level 15 Elemental Weakness (-26 resists), 150% reduced effect would result in +13 resistance. This also applied to less effect of curses but I am not sure if there are any of those.
### Steps taken to verify a working solution:
- Empty build, -60 resistances.
- Enable level 15 elemental weakness in config
- Add to custom config box ``150% reduced effect of curses on you`` or ``150% less effect of curses on you``
- Observe that resistance now goes back to -60% as expected, and not reversing to provide positive effects.
- Increased and more effect is still uncapped, and will

### Link to a build that showcases this PR:
https://pobb.in/I6azipBrk7sI
### Before screenshot:
![image](https://github.com/user-attachments/assets/c5d3f5d2-ad96-489a-a813-db49935abb0a)
![image](https://github.com/user-attachments/assets/90ebeef5-8bf9-4285-9c2b-819e1a2eb6c8)

### After screenshot:
![image](https://github.com/user-attachments/assets/4788d391-aa56-48fa-bcd1-c975a0385cdf)
![image](https://github.com/user-attachments/assets/d787ac49-dc51-4866-9ca8-d270ee4f2bd7)