### PR TITLE
Add support for Chieftain's Ramako, Sun's Light notable (Ruthless version)

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -9644,7 +9644,6 @@ c["Nearby Enemy Monsters have at least 8% of Life Reserved"]={{[1]={flags=0,keyw
 c["Nearby Enemy Monsters' Action Speed is at most 92% of base value"]={{[1]={flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="MaximumActionSpeedReduction",type="MAX",value=8}}}},nil}
 c["Nearby Enemy Monsters' Fire Resistance against"]={nil,"Fire Resistance against "}
 c["Nearby Enemy Monsters' Fire Resistance against Damage over Time is -20% while you are Stationary"]={{[1]={flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={[1]={actor="player",type="ActorCondition",var="Stationary"},flags=8,keywordFlags=0,name="FireResist",type="OVERRIDE",value=-20}}}},nil}
-c["Nearby Enemy Monsters have no Fire Resistance against Damage over Time while you are Stationary"]={{[1]={flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={[1]={actor="player",type="ActorCondition",var="Stationary"},flags=8,keywordFlags=0,name="FireResist",type="OVERRIDE",value=0}}}},nil}
 c["Nearby Hindered Enemies deal 15% reduced Damage over Time"]={{[1]={[1]={actor="enemy",type="ActorCondition",var="Hindered"},flags=0,keywordFlags=0,name="EnemyModifier",type="LIST",value={mod={flags=0,keywordFlags=0,name="DamageOverTime",type="INC",value=-15}}}},nil}
 c["Nearby allies Recover 1% of your Maximum Life when you Die"]={nil,"Nearby allies Recover 1% of your Maximum Life when you Die "}
 c["Nearby allies Recover 2% of your Maximum Life when you Die"]={nil,"Nearby allies Recover 2% of your Maximum Life when you Die "}

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2406,6 +2406,9 @@ local specialModList = {
 	["(%d+)%% more damage for each endurance charge lost recently, up to (%d+)%%"] = function(num, _, limit) return {
 		mod("Damage", "MORE", num, { type = "Multiplier", var = "EnduranceChargesLostRecently", limit = tonumber(limit), limitTotal = true }),
 	} end,
+	["nearby enemy monsters have no fire resistance against damage over time while you are stationary"] = {
+		mod("EnemyModifier", "LIST", { mod = mod("FireResist", "OVERRIDE", 0, nil, ModFlag.Dot, { type = "ActorCondition", actor = "player", var = "Stationary" }) }),
+	},
 	["(%d+)%% more damage if you've lost an endurance charge in the past 8 seconds"] = function(num) return { mod("Damage", "MORE", num, { type = "Condition", var = "LostEnduranceChargeInPast8Sec" })	} end,
 	["trigger level (%d+) (.+) when you attack with a non%-vaal slam or strike skill near an enemy"] = function(num, _, skill) return triggerExtraSkill(skill, num) end,
 	["non%-unique jewels cause increases and reductions to other damage types in a (%a+) radius to be transformed to apply to (%a+) damage"] = function(_, radius, dmgType) return {


### PR DESCRIPTION
### Description of the problem being solved:
For PoE Ruthless version, the Chieftain's Ramako, Sun's Light notable was not working

### Steps taken to verify a working solution:
- Open PoB, set "Is the enemy a Boss?" to "Guardian / Pinnacle Boss"
- set character to be Marauder / Chieftain
- allocate Ramako, Sun's Light notable 
- set "TIme spent stationary" in Calcs tab to 1
- check in calcs that enemy resistance is overriden and is 0 
- check that flammability and exposure have no effect for "Ignite" and "Skill Damage over Time" sections

### Before screenshot:
![image](https://github.com/user-attachments/assets/5de275a5-9c95-4e30-b5c8-82dc4b153061)

### After screenshot:
![image](https://github.com/user-attachments/assets/536b3e2c-2c18-41b0-8642-d01cf9f46bb7)
![image](https://github.com/user-attachments/assets/ad4b2e0a-1d2e-4178-a6d7-3e43749c8598)

