### PR TITLE
Fix inc effect on Cluster Jewel causing rounding issues

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -109,7 +109,17 @@ function calcs.buildModListForNode(env, node)
 	if node.type == "Keystone" then
 		modList:AddMod(node.keystoneMod)
 	else
-		modList:AddList(node.modList)
+		-- Apply effect scaling
+		local scale = calcLib.mod(node.modList, nil, "PassiveSkillEffect")
+		if scale ~= 1 then
+			local combinedList = new("ModList")
+			for _, mod in ipairs(node.modList) do
+				combinedList:MergeMod(mod)
+			end
+			modList:ScaleAddList(combinedList, scale)
+		else
+			modList:AddList(node.modList)
+		end
 	end
 
 	-- Run first pass radius jewels
@@ -121,14 +131,6 @@ function calcs.buildModListForNode(env, node)
 
 	if modList:Flag(nil, "PassiveSkillHasNoEffect") or (env.allocNodes[node.id] and modList:Flag(nil, "AllocatedPassiveSkillHasNoEffect")) then
 		wipeTable(modList)
-	end
-
-	-- Apply effect scaling
-	local scale = calcLib.mod(modList, nil, "PassiveSkillEffect")
-	if scale ~= 1 then
-		local scaledList = new("ModList")
-		scaledList:ScaleAddList(modList, scale)
-		modList = scaledList
 	end
 
 	-- Run second pass radius jewels


### PR DESCRIPTION
Fixes #1149  .

### Description of the problem being solved:
Different mods affecting the same stat on a cluster jewel were being scaled independently and rounded, causing some small errors compared to the game, which combines the mods first then scales them.
### Steps taken to verify a working solution:
- Create the cluster jewel in the issue
- Observe 27% chaos res instead of 26%
