### PR TITLE
Fix various node scaling issues

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -110,17 +110,7 @@ function calcs.buildModListForNode(env, node)
 	if node.type == "Keystone" then
 		modList:AddMod(node.keystoneMod)
 	else
-		-- Apply effect scaling
-		local scale = calcLib.mod(node.modList, nil, "PassiveSkillEffect")
-		if scale ~= 1 then
-			local combinedList = new("ModList")
-			for _, mod in ipairs(node.modList) do
-				combinedList:MergeMod(mod)
-			end
-			modList:ScaleAddList(combinedList, scale)
-		else
-			modList:AddList(node.modList)
-		end
+		modList:AddList(node.modList)
 	end
 
 	-- Run first pass radius jewels
@@ -132,6 +122,14 @@ function calcs.buildModListForNode(env, node)
 
 	if modList:Flag(nil, "PassiveSkillHasNoEffect") or (env.allocNodes[node.id] and modList:Flag(nil, "AllocatedPassiveSkillHasNoEffect")) then
 		wipeTable(modList)
+	end
+
+	-- Apply effect scaling
+	local scale = calcLib.mod(modList, nil, "PassiveSkillEffect")
+	if scale ~= 1 then
+		local scaledList = new("ModList")
+		scaledList:ScaleAddList(modList, scale)
+		modList = scaledList
 	end
 
 	-- Run second pass radius jewels


### PR DESCRIPTION
This reverts commit e5230c5c23af9db8c96bf2262ef402470ea53cbc.

Fixes #8853, #8848, #8839, #8835 .

### Description of the problem being solved:
Seemingly tattoos and nodes created by the timeless jewel finder are implemented oddly.  These may be fixable (see #8840), but the "All Attributes" nodes are a harder problem to fix and affect a lot more builds than the initial PR addressed.