### PR TITLE
Show Flask Slot for Unique Items Comparisons

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1262,6 +1262,8 @@ function ItemClass:GetPrimarySlot()
 		return "Ring 1"
 	elseif self.type == "Flask" then
 		return "Flask 1"
+	elseif self.type == "Tincture" then
+		return "Flask 1"
 	else
 		return self.type
 	end

--- a/src/Classes/ItemDBControl.lua
+++ b/src/Classes/ItemDBControl.lua
@@ -26,7 +26,7 @@ local ItemDBClass = newClass("ItemDBControl", "ListControl", function(self, anch
 	self.leaguesAndTypesLoaded = false
 	self.leagueList = { "Any league", "No league" }
 	self.typeList = { "Any type", "Armour", "Jewellery", "One Handed Melee", "Two Handed Melee" }
-	self.slotList = { "Any slot", "Weapon 1", "Weapon 2", "Helmet", "Body Armour", "Gloves", "Boots", "Amulet", "Ring", "Belt", "Jewel" }
+	self.slotList = { "Any slot", "Weapon 1", "Weapon 2", "Helmet", "Body Armour", "Gloves", "Boots", "Amulet", "Ring", "Belt", "Jewel", "Flask" }
 	local baseY = dbType == "RARE" and -22 or -62
 	self.controls.slot = new("DropDownControl", {"BOTTOMLEFT",self,"TOPLEFT"}, {0, baseY, 179, 18}, self.slotList, function(index, value)
 		self.listBuildFlag = true


### PR DESCRIPTION
### Description of the problem being solved:
Flask was not available in the Slot drop down for the Uniques. With this, we can search for Unique Flasks/Tinctures the same as we do armour for EHP, DPS, etc.

We were already able to search for Flasks and Tinctures separately using the Type drop down, but I think having the Slot available is good too.

### Link to a build that showcases this PR:
https://pobb.in/kmHHdXJKZgLa
### Before screenshot:

### After screenshot:
<img width="794" height="557" alt="image" src="https://github.com/user-attachments/assets/600390b5-1093-4ce3-b6e0-40121d0649c4" />
<img width="689" height="338" alt="image" src="https://github.com/user-attachments/assets/a4436555-7eae-4e1a-84f4-5456931dca5f" />