### PR TITLE
Fix Poion Conc of Bouncing not counting Chains towards DPS

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -17504,6 +17504,9 @@ skills["PoisonousConcoctionAltX"] = {
 			mod("ChaosPerLifeFlaskPercent", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
 		},
 	},
+	baseMods = {
+		mod("DPS", "MORE", 100, 0, 0, { type = "PerStat", stat = "ChainMax" }),
+	},
 	baseFlags = {
 		attack = true,
 		area = true,

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -3393,6 +3393,7 @@ local skills, mod, flag, skill = ...
 			mod("ChaosPerLifeFlaskPercent", "BASE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
 		},
 	},
+#baseMod mod("DPS", "MORE", 100, 0, 0, { type = "PerStat", stat = "ChainMax" })
 #mods
 
 #skill Snipe


### PR DESCRIPTION
Poisonous Concoction of Bouncing gains DPS from extra chains as the projectiles keep chaining to the same target
Fixes #8851