### PR TITLE
Add Undo support to Tattoo/Runegraft overrides

### DIFF
--- a/src/Classes/PassiveSpec.lua
+++ b/src/Classes/PassiveSpec.lua
@@ -1913,12 +1913,16 @@ function PassiveSpecClass:CreateUndoState()
 	for mastery, effect in pairs(self.masterySelections) do
 		selections[mastery] = effect
 	end
+	local hashOverridesCopy = { }
+	for node, override in pairs(self.hashOverrides) do
+		hashOverridesCopy[node] = override
+	end
 	return {
 		classId = self.curClassId,
 		ascendClassId = self.curAscendClassId,
 		secondaryAscendClassId = self.secondaryAscendClassId,
 		hashList = allocNodeIdList,
-		hashOverrides = self.hashOverrides,
+		hashOverrides = hashOverridesCopy,
 		masteryEffects = selections,
 		treeVersion = self.treeVersion
 	}

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -877,6 +877,7 @@ function TreeTabClass:ModifyNodePopup(selectedNode)
 	end
 	controls.save = new("ButtonControl", nil, {-90, 75, 80, 20}, "Add", function()
 		addModifier(selectedNode)
+		self.build.spec:AddUndoState()
 		self.modFlag = true
 		self.build.buildFlag = true
 		self.defaultTattoo[nodeName] = controls.modSelect.selIndex
@@ -884,6 +885,7 @@ function TreeTabClass:ModifyNodePopup(selectedNode)
 	end)
 	controls.reset = new("ButtonControl", nil, {0, 75, 80, 20}, "Reset Node", function()
 		self:RemoveTattooFromNode(selectedNode)
+		self.build.spec:AddUndoState()
 		self.modFlag = true
 		self.build.buildFlag = true
 		self.defaultTattoo[nodeName] = nil


### PR DESCRIPTION
### Description of the problem being solved:
Overrides from Tattoos/Runegrafts were not able to be undone with CTRL+Z as we weren't keeping track of the overrides when saving undo states.

### Link to a build that showcases this PR:
https://pobb.in/8ZvKgaG0CDNi