### PR TITLE
FIX: fixes toggle requiring reload, minor optimalizations

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -719,7 +719,9 @@ function GemSelectClass:AddCommonGemInfo(gemInstance, grantedEffect, addReq, mer
 				if launch.devModeAlt then
 					line = line .. " ^1" .. lineMap[line]
 				end
-				self.tooltip:AddLine(16, colorCodes.UNSUPPORTED .. line..main.notSupportedTooltipText)
+				local line = colorCodes.UNSUPPORTED .. line
+				line = main.notSupportedModTooltips and (line .. main.notSupportedTooltipText) or line
+				self.tooltip:AddLine(line)
 			end
 		end
 	end

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -763,7 +763,9 @@ holding Shift will put it in the second.]])
 						tooltip:AddLine(16, "")
 						for i, line in ipairs(node.sd) do
 							if line ~= " " and (node.mods[i].extra or not node.mods[i].list) then
-								tooltip:AddLine(16, colorCodes.UNSUPPORTED..line..main.notSupportedTooltipText)
+								local line = colorCodes.UNSUPPORTED .. line
+								line = main.notSupportedModTooltips and (line .. main.notSupportedTooltipText) or line
+								tooltip:AddLine(16, line)
 							else
 								tooltip:AddLine(16, colorCodes.MAGIC..line)
 							end
@@ -3343,7 +3345,9 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 		))
 		for _, modLine in pairs(item.buffModLines) do
 			if modLine.extra then
-				tooltip:AddLine(16, colorCodes.UNSUPPORTED..modLine.line..main.notSupportedTooltipText)
+				local line = colorCodes.UNSUPPORTED..modLine.line
+				line = main.notSupportedModTooltips and (line .. main.notSupportedTooltipText) or line
+				tooltip:AddLine(16, line)
 			else
 				tooltip:AddLine(16, colorCodes.MAGIC..modLine.line)
 			end
@@ -3360,7 +3364,9 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 		tooltip:AddLine(16, s_format("^x7F7F7F%s%.2f ^x7F7F7FSecond Cooldown When Deactivated", main:StatColor(tinctureData.cooldown, base.tincture.cooldown), tinctureData.cooldown))
 		for _, modLine in pairs(item.buffModLines) do
 			if modLine.extra then
-				tooltip:AddLine(16, colorCodes.UNSUPPORTED..modLine.line..main.notSupportedTooltipText)
+				local line = colorCodes.UNSUPPORTED..modLine.line
+				line = main.notSupportedModTooltips and (line .. main.notSupportedTooltipText) or line
+				tooltip:AddLine(16, line)
 			else
 				tooltip:AddLine(16, colorCodes.MAGIC..modLine.line)
 			end

--- a/src/Classes/NotableDBControl.lua
+++ b/src/Classes/NotableDBControl.lua
@@ -255,7 +255,9 @@ function NotableDBClass:AddValueTooltip(tooltip, index, node)
 			tooltip:AddLine(16, "")
 			for i, line in ipairs(node.sd) do
 				if line ~= " " and (node.mods[i].extra or not node.mods[i].list) then
-					tooltip:AddLine(16, colorCodes.UNSUPPORTED..line..main.notSupportedTooltipText)
+					local line = colorCodes.UNSUPPORTED..modLine.line
+					line = main.notSupportedModTooltips and (line .. main.notSupportedTooltipText) or line
+					tooltip:AddLine(16, line)
 				else
 					tooltip:AddLine(16, colorCodes.MAGIC..line)
 				end

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -1029,7 +1029,9 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build)
 				end
 			end
 			if line ~= " " and (node.mods[i].extra or not node.mods[i].list) then 
-				tooltip:AddLine(16, colorCodes.UNSUPPORTED..line..main.notSupportedTooltipText)
+				local line = colorCodes.UNSUPPORTED..line
+				line = main.notSupportedModTooltips and (line .. main.notSupportedTooltipText) or line
+				tooltip:AddLine(16, line)
 			else
 				tooltip:AddLine(16, colorCodes.MAGIC..line)
 			end

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -769,7 +769,9 @@ function SkillsTabClass:CreateGemSlot(index)
 						if grantedEffect.statMap[qual[1]] or self.build.data.skillStatMap[qual[1]] then
 							tooltip:AddLine(16, colorCodes.MAGIC..line)
 						else
-							tooltip:AddLine(16, colorCodes.UNSUPPORTED..line..main.notSupportedTooltipText)
+							local line = colorCodes.UNSUPPORTED..line
+							line = main.notSupportedModTooltips and (line .. main.notSupportedTooltipText) or line
+							tooltip:AddLine(16, line)
 						end
 					end
 				end

--- a/src/Classes/Tooltip.lua
+++ b/src/Classes/Tooltip.lua
@@ -49,9 +49,6 @@ end)
 function TooltipClass:Clear()
 	wipeTable(self.lines)
 	wipeTable(self.blocks)
-	if self.updateParams then
-		wipeTable(self.updateParams)
-	end
 	self.recipe = nil
 	self.center = false
 	self.color = { 0.5, 0.3, 0 }
@@ -63,17 +60,17 @@ function TooltipClass:CheckForUpdate(...)
 	if not self.updateParams then
 		self.updateParams = { }
 	end
+
 	for i = 1, select('#', ...) do
-		if self.updateParams[i] ~= select(i, ...) then
+		local temp = select(i, ...)
+		if self.updateParams[i] ~= temp then
+			self.updateParams[i] = temp
 			doUpdate = true
-			break
 		end
 	end
-	if doUpdate then
+	if doUpdate or self.updateParams.notSupportedModTooltips ~= main.notSupportedModTooltips then
+		self.updateParams.notSupportedModTooltips = main.notSupportedModTooltips
 		self:Clear()
-		for i = 1, select('#', ...) do
-			self.updateParams[i] = select(i, ...)
-		end
 		return true
 	end
 end

--- a/src/Modules/ItemTools.lua
+++ b/src/Modules/ItemTools.lua
@@ -127,7 +127,7 @@ function itemLib.formatModLine(modLine, dbMode)
 	local colorCode
 	if modLine.extra then
 		colorCode = colorCodes.UNSUPPORTED
-		line = line..main.notSupportedTooltipText
+		line = main.notSupportedModTooltips and (line .. main.notSupportedTooltipText) or line
 		if launch.devModeAlt then
 			line = line .. "   ^1'" .. modLine.extra .. "'"
 		end

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -102,7 +102,7 @@ function main:Init()
 	self.showWarnings = true
 	self.slotOnlyTooltips = true
 	self.notSupportedModTooltips = true
-	self.notSupportedTooltipText = ""
+	self.notSupportedTooltipText = " ^8(Not supported in PoB yet)"
 	self.POESESSID = ""
 	self.showPublicBuilds = true
 
@@ -610,7 +610,6 @@ function main:LoadSettings(ignoreBuild)
 				end
 				if node.attrib.notSupportedModTooltips then
 					self.notSupportedModTooltips = node.attrib.notSupportedModTooltips == "true"
-					self.notSupportedTooltipText = self.notSupportedModTooltips and " ^8(Not supported in PoB yet)" or ""
 				end
 				if node.attrib.POESESSID then
 					self.POESESSID = node.attrib.POESESSID or ""


### PR DESCRIPTION
Fixes issues with #8925 mentioned on Discord.

This pr is against the branch for #8925

### Description of the problem being solved:

The TooltipClass:CheckForUpdate had to be updated so that the tooltip updates correctly after changing the option. I kinda obsessed over optimizing this. Removed the secondary loop as the first one without the break statement will update all the records. Though this has the cost of doing more comparisons which could end up being more expensive if strings end up being compared often. Looking through current calls to this function it seems like it's all just addresses and booleans.

### Steps taken to verify a working solution:
- Test saving saving the messing with the options
- Test tooltip caching since i messed with that too

