### PR TITLE
Add support for average Lightning Tendrils DPS

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -12177,6 +12177,16 @@ skills["LightningTendrilsAltX"] = {
 	skillTypes = { [SkillType.Spell] = true, [SkillType.Damage] = true, [SkillType.Area] = true, [SkillType.Totemable] = true, [SkillType.Lightning] = true, [SkillType.Channel] = true, [SkillType.AreaSpell] = true, },
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 0.23,
+	postCritFunc = function(activeSkill, output, breakdown)
+		-- Formula to find a effective damage multiplier to take into account the 500% more damage on every 5th hit
+		if activeSkill.skillPart == 1 then
+			local critChance = output.PreEffectiveCritChance / 100
+			local effectiveCritChance = output.CritChance / 100
+			local critMulti = output.CritMultiplier
+			local averageMore = 100 * ((4 * (1 + critChance * (critMulti - 1)) + 6 * critMulti) / (5 * ((1 - effectiveCritChance) + critMulti * effectiveCritChance)) - 1)
+			activeSkill.skillModList:NewMod("Damage", "MORE", averageMore, "Average Pulse Damage", nil, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "SkillPart", skillPart = 1 })
+		end
+	end,
 	parts = {
 		{
 			name = "Average DPS",
@@ -12190,13 +12200,7 @@ skills["LightningTendrilsAltX"] = {
 	},
 	statMap = {
 		["lightning_tendrils_channelled_larger_pulse_damage_+%_final"] = {
-			{
-				mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "SkillPart", skillPart = 1 }),
-				div = 5,
-			},
-			{
-				mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "SkillPart", skillPart = 3 }),
-			},
+			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "SkillPart", skillPart = 3 }),
 		},
 		["lightning_tendrils_channelled_larger_pulse_area_of_effect_+%_final"] = {
 			mod("AreaOfEffect", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 3 }),

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -2796,6 +2796,16 @@ local skills, mod, flag, skill = ...
 
 #skill LightningTendrilsAltX
 #flags spell area channelling
+	postCritFunc = function(activeSkill, output, breakdown)
+		-- Formula to find a effective damage multiplier to take into account the 500% more damage on every 5th hit
+		if activeSkill.skillPart == 1 then
+			local critChance = output.PreEffectiveCritChance / 100
+			local effectiveCritChance = output.CritChance / 100
+			local critMulti = output.CritMultiplier
+			local averageMore = 100 * ((4 * (1 + critChance * (critMulti - 1)) + 6 * critMulti) / (5 * ((1 - effectiveCritChance) + critMulti * effectiveCritChance)) - 1)
+			activeSkill.skillModList:NewMod("Damage", "MORE", averageMore, "Average Pulse Damage", nil, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "SkillPart", skillPart = 1 })
+		end
+	end,
 	parts = {
 		{
 			name = "Average DPS",
@@ -2809,13 +2819,7 @@ local skills, mod, flag, skill = ...
 	},
 	statMap = {
 		["lightning_tendrils_channelled_larger_pulse_damage_+%_final"] = {
-			{
-				mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "SkillPart", skillPart = 1 }),
-				div = 5,
-			},
-			{
-				mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "SkillPart", skillPart = 3 }),
-			},
+			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "SkillPart", skillPart = 3 }),
 		},
 		["lightning_tendrils_channelled_larger_pulse_area_of_effect_+%_final"] = {
 			mod("AreaOfEffect", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 3 }),

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2974,6 +2974,8 @@ function calcs.offence(env, actor, activeSkill)
 
 		--Calculate reservation DPS
 		globalOutput.ReservationDpsMultiplier = 100 / (100 - enemyDB:Sum("BASE", nil, "LifeReservationPercent"))
+		
+		runSkillFunc("postCritFunc")
 
 		-- Calculate base hit damage
 		for _, damageType in ipairs(dmgTypeList) do


### PR DESCRIPTION
Lightning Tendrils has a mechanic where it critically strikes every 3rd / 5th use but we were did not have a averaged calc for this
There is now a new skill part for the averaged DPS
I also applied DPS multipliers to the other 2 skill parts to show accurate DPS for just those parts when they hit as people may use the stronger pulse one to see DPS for Ignite
Fixes #7214, Fixes #6049, Fixes #4111

Before:
<img width="711" height="454" alt="image" src="https://github.com/user-attachments/assets/d0b86bc1-e2fd-41ec-aabd-089e48ea22cb" />

After:
<img width="712" height="453" alt="image" src="https://github.com/user-attachments/assets/2060f905-4cdd-47f1-b3b8-422490330179" />
<img width="711" height="455" alt="image" src="https://github.com/user-attachments/assets/0eb430fd-aace-4886-bdc1-694859815890" />


