### PR TITLE
Fix importing characters with names that contain foreign letters

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -597,7 +597,7 @@ function ImportTabClass:DownloadPassiveTree()
 	local sessionID = #self.controls.sessionInput.buf == 32 and self.controls.sessionInput.buf or (main.gameAccounts[accountName] and main.gameAccounts[accountName].sessionID)
 	local charSelect = self.controls.charSelect
 	local charData = charSelect.list[charSelect.selIndex].char
-	launch:DownloadPage(realm.hostName.."character-window/get-passive-skills?accountName="..accountName:gsub("#", "%%23").."&character="..charData.name.."&realm="..realm.realmCode, function(response, errMsg)
+	launch:DownloadPage(realm.hostName.."character-window/get-passive-skills?accountName="..accountName:gsub("#", "%%23").."&character="..urlEncode(charData.name).."&realm="..realm.realmCode, function(response, errMsg)
 		self.charImportMode = "SELECTCHAR"
 		if errMsg then
 			self.charImportStatus = colorCodes.NEGATIVE.."Error importing character data, try again ("..errMsg:gsub("\n"," ")..")"
@@ -619,7 +619,7 @@ function ImportTabClass:DownloadItems()
 	local sessionID = #self.controls.sessionInput.buf == 32 and self.controls.sessionInput.buf or (main.gameAccounts[accountName] and main.gameAccounts[accountName].sessionID)
 	local charSelect = self.controls.charSelect
 	local charData = charSelect.list[charSelect.selIndex].char
-	launch:DownloadPage(realm.hostName.."character-window/get-items?accountName="..accountName:gsub("#", "%%23").."&character="..charData.name.."&realm="..realm.realmCode, function(response, errMsg)
+	launch:DownloadPage(realm.hostName.."character-window/get-items?accountName="..accountName:gsub("#", "%%23").."&character="..urlEncode(charData.name).."&realm="..realm.realmCode, function(response, errMsg)
 		self.charImportMode = "SELECTCHAR"
 		if errMsg then
 			self.charImportStatus = colorCodes.NEGATIVE.."Error importing character data, try again ("..errMsg:gsub("\n"," ")..")"


### PR DESCRIPTION
Fixes #8933 

Ideally, we would want to display the non-ASCII chars properly. It seems to be a problem of fonts, which I'm uncertain how to fix now. This would at least allow characters with name containing non-ASCII characters to be imported to PoB.

### Description of the problem being solved:
When importing data from POE with a character name containing non-ASCII characters, we will get a 400 error. This is due to the utf-8 encoding of those characters not being compatible with URL encoding.

### Steps taken to verify a working solution:
- Find an account with non-ASCII character names on poe.ninja
- Try importing passives & items with a name containing non-ASCII characters

### Link to a build that showcases this PR:
N/A

### Before screenshot:
<img width="1688" height="1087" alt="image" src="https://github.com/user-attachments/assets/2fe063d0-1697-41dc-bdaa-fe7cd0cbe4b6" />
<img width="1684" height="1083" alt="image" src="https://github.com/user-attachments/assets/d51fc5cf-117f-4cdb-b9a7-d6b88a2a97ef" />

### After screenshot:
<img width="1683" height="1086" alt="image" src="https://github.com/user-attachments/assets/fa73f179-dd93-4b10-ac91-4765df5b093e" />
<img width="1683" height="1085" alt="image" src="https://github.com/user-attachments/assets/b1aac3b1-6817-46be-9e46-821c30723417" />

