### PR TITLE
Update the debugger instructions for pycharm so they actually work

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,7 +190,7 @@ Files in `/Data` `/Export` and `/TreeData` can be massive and cause the EmmyLua 
 ### PyCharm Community / IntelliJ Idea Community
 
 1. Create a new "Debug Configuration" of type "Emmy Debugger(NEW)".
-2. Select "x86" version.
+2. Select "x64" version.
 3. Select if you want the program to block (checkbox) until you attached the debugger (useful if you have to debug the startup process).
 4. Copy the generated code snippet directly below `function launch:OnInit()` in `./src/Launch.lua`.
 5. Start Path of Building Community


### PR DESCRIPTION

### Description of the problem being solved:

I was re-setting up my dev env, and the current debugger setup instructions for Pycharm say to use "x86", while the Visual Studio instructions mention "x64". 

x86 causes PoB to hang forever, while x64 seems to work fine, so I want to update the instructions so other people don't run into the same issue

If there is some reason it needs to be x86 for pycharm and I'm just dumb, feel free to say so 👍 
