### PR TITLE
fix spelling: consistant -> consistent 

### DIFF
--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -1210,7 +1210,7 @@ local configTable = {
 		else -- Needed to get the cooldown form the active part
 			-- Autoexertion has cooldown as part of its support part
 			-- Not really sure which one should apply here
-			-- Applying the one form the active part to be consistant
+			-- Applying the one form the active part to be consistent
 			-- with skills like Automation and Spellslinger
 			for _, skill in ipairs(env.player.activeSkillList) do
 				if skill.activeEffect.grantedEffect.name == "Autoexertion" then


### PR DESCRIPTION
[skip ci]