### PR TITLE
Use correct stat to set "Every3UseCrit" flag for Glacial Hammer of Shattering

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -4995,7 +4995,7 @@ skills["GlacialHammerAltX"] = {
 	statDescriptionScope = "skill_stat_descriptions",
 	castTime = 1,
 	statMap = {
-		["additional_main_hand_hits_per_combo_average"] = {
+		["glacial_hammer_third_hit_always_crits"] = {
 			flag("Every3UseCrit"),
 		},
 	},

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -898,7 +898,7 @@ local skills, mod, flag, skill = ...
 #skill GlacialHammerAltX
 #flags attack melee
 	statMap = {
-		["additional_main_hand_hits_per_combo_average"] = {
+		["glacial_hammer_third_hit_always_crits"] = {
 			flag("Every3UseCrit"),
 		},
 	},


### PR DESCRIPTION
Glacial Hammer of Shattering was implemented in #8931 but used the wrong stat.

### Description of the problem being solved:

- "Every third successive strike is a Critical Strike" stat was marked as "Not supported in PoB yet"
- Effective Crit Chance was not displayed + DPS was unaffected by the stat

### Steps taken to verify a working solution:

- Effective Crit Chance now shows up
- roughly validated DPS
