### PR TITLE
fix: remove cast speed on The Queen's Hunger, Vaal Regalia

### DIFF
--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -173,7 +173,6 @@ end
 table.insert(queensHunger, "Requires Level 68, 194 Int")
 table.insert(queensHunger, "Trigger Level 20 Bone Offering, Flesh Offering or Spirit Offering every 5 seconds")
 table.insert(queensHunger, "Offering Skills Triggered this way also affect you")
-table.insert(queensHunger, "(5-10)% increased Cast Speed")
 table.insert(queensHunger, "(100-130)% increased Energy Shield")
 table.insert(queensHunger, "(6-10)% increased maximum Life")
 
@@ -778,14 +777,14 @@ function buildKeystoneItems(keystoneMap)
 
 	local skinOfTheLordsKeystones = {}
 	local seen = {}
-	for _, node in pairs(keystoneMap) do		
+	for _, node in pairs(keystoneMap) do
 		if isKeystoneNative(node) and not isValueInArray(excludedPassiveKeystones, node.name) and not seen[node] then
 			table.insert(skinOfTheLordsKeystones, node.name)
 			seen[node] = true
 		end
 	end
 	table.sort(skinOfTheLordsKeystones)
-	
+
 	for _, name in ipairs(skinOfTheLordsKeystones) do
 		table.insert(skinOfTheLords, "Variant: "..name)
 	end
@@ -800,7 +799,7 @@ function buildKeystoneItems(keystoneMap)
 	end
 	table.insert(skinOfTheLords, "Corrupted")
 	table.insert(data.uniques.generated, table.concat(skinOfTheLords, "\n"))
-	
+
 	local impossibleEscapeKeystones = {}
 	seen = {}
 	for _, node in pairs(keystoneMap) do


### PR DESCRIPTION
Fixes #8897 

### Description of the problem being solved:
-  In the current build, the Queen’s Hunger, Vaal Regalia still includes a cast speed modifier, which should not be present.

### Steps taken to verify a working solution:
- Remove the cast speed option
- Verifying in the calculation that cast speed is no longer applied

### After screenshot:
<img width="648" height="357" alt="Screenshot 2025-10-01 001957" src="https://github.com/user-attachments/assets/436c2f7b-0061-40e6-9cec-390bde4bfeb5" />

**The Queen's Hunger, Vaal Regalia**

<img width="754" height="91" alt="Screenshot 2025-10-01 002019" src="https://github.com/user-attachments/assets/70aaece1-32ae-49e2-b657-1709039e4a63" />

**Item tooltip (cast speed removed)**