### PR TITLE
Fix missing Malevolence Aura Effect on String of Servitude

### DIFF
--- a/src/Data/Uniques/belt.lua
+++ b/src/Data/Uniques/belt.lua
@@ -826,6 +826,7 @@ Variant: Hatred Aura Effect
 Variant: Determination Aura Effect
 Variant: Discipline Aura Effect
 Variant: Grace Aura Effect
+Variant: Malevolence Aura Effect
 Variant: Intelligence/Dexterity
 Variant: Dexterity/Strength
 Variant: Strength/Intelligence
@@ -848,13 +849,14 @@ Implicits: 24
 {variant:15}Determination has (45-60)% increased Aura Effect
 {variant:16}Discipline has (45-60)% increased Aura Effect
 {variant:17}Grace has (45-60)% increased Aura Effect
-{variant:18}(12-18)% increased Intelligence
-{variant:18}(12-18)% increased Dexterity
+{variant:18}Malevolence has (45-60)% increased Aura Effect
+{variant:19}(12-18)% increased Intelligence
 {variant:19}(12-18)% increased Dexterity
-{variant:19}(12-18)% increased Strength
+{variant:20}(12-18)% increased Dexterity
 {variant:20}(12-18)% increased Strength
-{variant:20}(12-18)% increased Intelligence
-{variant:21}{tags:jewellery_resistance}+(42-48)% to all Elemental Resistances
+{variant:21}(12-18)% increased Strength
+{variant:21}(12-18)% increased Intelligence
+{variant:22}{tags:jewellery_resistance}+(42-48)% to all Elemental Resistances
 Implicit Modifier magnitudes are tripled
 Corrupted
 ]],[[


### PR DESCRIPTION
Fixes #8994 

### Description of the problem being solved:
- The String of Servitude was missing the Malevolence Aura Effect modifier.

### Steps taken to verify a working solution:
- Added Malevolence Aura Effect to the String of Servitude
-  Verified that it appears correctly in the droptable and applies to the item.

### After screenshot:

<img width="384" height="442" alt="Screenshot 2025-10-01 003424" src="https://github.com/user-attachments/assets/e0a88b19-5d29-46df-bae3-3e2d914828a6" />

**Malevolence option in droptable**

<img width="577" height="301" alt="Screenshot 2025-10-01 003437" src="https://github.com/user-attachments/assets/40a3ffa2-bb53-4348-ae3c-5994ff9e8ff8" />

**Belt with added modifier**