### PR TITLE
Use four digits of precision for damage modification values.

### DIFF
--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -459,6 +459,9 @@ data.highPrecisionMods = {
 	["SupportManaMultiplier"] = {
 		["MORE"] = 4,
 	},
+	["Damage"] = {
+		["MORE"] = 4,
+	},
 }
 
 data.weaponTypeInfo = {


### PR DESCRIPTION
Closes #8998

### Description of the problem being solved:
Currently we do not use enough digits for MORE Damage mods to handle cases like the linked issue. This pr adds MORE Damage mods to high precision mods list to make the calculations use four digits. Though as I'm unsure how many digits the game uses this could cause rounding issues elsewhere.

Leaving as draft for now.