### PR TITLE
Fix Breakdown of Crit Damage when using Dance with Death

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3102,6 +3102,9 @@ function calcs.offence(env, actor, activeSkill)
 						rolls = 0
 					end
 					output.DamageRolls = rolls
+					if pass == 1 then
+						output.CritDamageRolls = rolls
+					end
 					rolls = m_abs(rolls) + 2
 					damageTypeHitAvgNotLucky = (damageTypeHitMin / rolls + damageTypeHitMax / rolls)
 					damageTypeHitAvgLucky = (damageTypeHitMin / rolls + (rolls - 1) * damageTypeHitMax / rolls)
@@ -3408,15 +3411,17 @@ function calcs.offence(env, actor, activeSkill)
 			if output.CritEffect ~= 1 then
 				breakdown.AverageHit = { }
 				local damageRolls = output.DamageRolls or 0
+				local critRolls = output.CritDamageRolls or 0
 				local rolls = m_abs(damageRolls) + 2
+				local rollsCrit = m_abs(critRolls) + 2
 				if damageRolls > 0 then
 					t_insert(breakdown.AverageHit, s_format("(1/%d) x %d + (%d/%d) x %d = %.1f ^8(average from non-crits)", rolls, totalHitMin, rolls - 1, rolls, totalHitMax, totalHitAvg))
 				end
 				if damageRolls < 0 then
 					t_insert(breakdown.AverageHit, s_format("(%d/%d) x %d + (1/%d) x %d = %.1f ^8(average from non-crits)", rolls - 1, rolls, totalHitMin, rolls, totalHitMax, totalHitAvg))
 				end
-				if damageRolls > 0 or skillModList:Flag(skillCfg, "CritLucky") then
-					t_insert(breakdown.AverageHit, s_format("(1/%d) x %d + (%d/%d) x %d = %.1f ^8(average from crits)", rolls, totalCritMin, rolls - 1, rolls, totalCritMax, totalCritAvg))
+				if damageRolls > 0 or critRolls > 0 or skillModList:Flag(skillCfg, "CritLucky") then
+					t_insert(breakdown.AverageHit, s_format("(1/%d) x %d + (%d/%d) x %d = %.1f ^8(average from crits)", rollsCrit, totalCritMin, rollsCrit - 1, rollsCrit, totalCritMax, totalCritAvg))
 					t_insert(breakdown.AverageHit, "")
 				end
 				if damageRolls < 0 and not skillModList:Flag(skillCfg, "CritLucky") then


### PR DESCRIPTION
Fixes #9011 

### Description of the problem being solved:
When using the Dance with Death keystone to have Critical Damage be lucky, it was not correctly showing the correct formula for Crit Damage
Crit Damage is handled in pass 1 so output.DamageRolls was being overwritten to 0 after pass 2 was done for non-crit damage calcs
So now we have a new variable just for Crit Damage rolls that cannot be overwritten and we use that for the breakdown


### Steps taken to verify a working solution:
- Test with and without Azadi's Crest
- Test with unlucky hit damage

### Link to a build that showcases this PR:
https://pobb.in/hGvQM_hqvpJE

### Before screenshot:
<img width="639" height="90" alt="image" src="https://github.com/user-attachments/assets/baac4cbc-8d5e-4c68-a6b7-a4c18726224a" />

### After screenshot:
<img width="670" height="91" alt="image" src="https://github.com/user-attachments/assets/7a245519-fc83-4a03-adaa-d21fa283370a" />
