### PR TITLE
Add "file nil" error message

### DIFF
--- a/runtime/lua/xml.lua
+++ b/runtime/lua/xml.lua
@@ -102,9 +102,9 @@ function xml.LoadXMLFile(fileName)
 	local fileText = fileHnd:read("*a")
 	fileHnd:close()
 	if not fileText then
-		return nil, "file returns nil.  OneDrive?"
+		return nil, fileName.." file returns nil.  OneDrive?"
 	elseif fileText == "" then
-		return nil, "file is empty"
+		return nil, fileName.." file is empty"
 	end
 	return xml.ParseXML(fileText)
 end

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -507,10 +507,12 @@ end
 
 function main:LoadSettings(ignoreBuild)
 	local setXML, errMsg = common.xml.LoadXMLFile(self.userPath.."Settings.xml")
-	if errMsg then
-		launch:ShowErrMsg("^1Error parsing 'Settings.xml': "..errMsg)
+	if errMsg and not errMsg:match(".*No such file or directory") then
+		ConPrintf("Error: '%s'", errMsg)
+		launch:ShowErrMsg("^1"..errMsg)
 		return true
-	elseif not setXML then
+	end
+	if not setXML then
 		return true
 	elseif setXML[1].elem ~= "PathOfBuilding" then
 		launch:ShowErrMsg("^1Error parsing 'Settings.xml': 'PathOfBuilding' root element missing")
@@ -638,10 +640,12 @@ end
 
 function main:LoadSharedItems()
 	local setXML, errMsg = common.xml.LoadXMLFile(self.userPath.."Settings.xml")
-	if errMsg then
-		launch:ShowErrMsg("^1Error parsing 'Settings.xml': "..errMsg)
+	if errMsg and not errMsg:match(".*No such file or directory") then
+		ConPrintf("Error: '%s'", errMsg)
+		launch:ShowErrMsg("^1"..errMsg)
 		return true
-	elseif not setXML then
+	end
+	if not setXML then
 		return true
 	elseif setXML[1].elem ~= "PathOfBuilding" then
 		launch:ShowErrMsg("^1Error parsing 'Settings.xml': 'PathOfBuilding' root element missing")


### PR DESCRIPTION
Should improve reporting of errors caused by **OneDrive** moving `settings.xml` to the cloud.  

Was a PITA to reproduce the error.  If anyone can easily and reliably reproduce it let me know on Discord please!  
  
<img width="522" height="126" alt="image" src="https://github.com/user-attachments/assets/b38b0b5d-2a14-4b3b-ab94-6ef85742d78d" />

  