### PR TITLE
Fix EO incorrectly setting ailment chance to 0% for critical strikes

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3866,10 +3866,12 @@ function calcs.offence(env, actor, activeSkill)
 			end
 		end
 
-		-- Note: "Elemental Overload" only affects `Chance`, if "Perfect Agony" (or similar) is also in effect. Otherwise only `DotMulti` is affected, which is handled later
-		if modDB:Flag(nil, "AilmentsAreNeverFromCrit") and modDB:Flag(nil, "AilmentsOnlyFromCrit") then 
+		-- Note: "Elemental Overload" and "Perfect Agony" interactions as per wiki: https://www.poewiki.net/wiki/Elemental_Overload#Mechanics
+		-- As of 3.25 EO also disables chance-based modifiers exclusive to critical strikes like "Adder's Touch"
+		-- Perfect Agony + Elemental Overload completely disables ailment application
+		if modDB:Flag(nil, "AilmentsAreNeverFromCrit") then
 			for _, ailment in ipairs(ailmentTypeList) do
-				output[ailment.."ChanceOnCrit"] = 0
+				output[ailment.."ChanceOnCrit"] = modDB:Flag(nil, "AilmentsOnlyFromCrit") and 0 or output[ailment.."ChanceOnHit"] 
 			end
 		end
 


### PR DESCRIPTION
Fixes #8827 .

Allocating Elemental Overload falsely set ailment chance to `0%` for critical strikes. However, it should only make ailments from crit be treated as if they were from non-critical strikes.

So the chance should only be `0%` if Perfect Agony is also allocated.

[Link to relevant section on Wiki](https://www.poewiki.net/wiki/Elemental_Overload#Mechanics)

### Steps taken to verify a working solution:
- Ailment *chance* is now unaffected by EO (except for chance modifiers specifically affecting critical strikes)
- Ailment *multipliers* are correctly affected by EO (assumes non-crit)
- Ailment chance is correctly set to 0% if both EO and Perfect Agony are allocated
- EO disables inherent ability to inflict elemental ailments likes Freeze, Shock, Ignite, Brittle, Scorch, Sap
- EO disables `chance` modifiers that only apply to critical strikes like "Adder's Touch" passive notable

### Limitations:
- The breakdowns are still somewhat misleading / lack information. I originally also wanted to change that in the same PR, but it turned out to be a deeper rabbit hole than expected, so I am postponing it
- There is still something else wrong with the displayed bleed chance, if chance to bleed differs between crit and non-crit (see 19% chance to bleed in *before* screenshot), but that will also have to go in a different PR and is not directly related to the EO interaction
- There are some lingering problems with the way "portion of critical" strikes is (not) handled during ailment calculation. E.g. if you have "x% increased duration of ailments from critical strikes" it will apply to non-critical strikes as well because the duration is simply overwritten rather than being tracked separately like chance and multi. This is not a problem for now because no such mod exists, but it might be in the future.

### Link to a build that showcases this PR:
[Ailment Test Build](eNqtHG1z2jjzc_kVHmbumXumhPjdkCe5GwJJk2vSpJA21_vSEbYANcamtpyE3vS_PyvJgE2RsYG2k9rSvmlXu1pJ65z--Tr1lWccxSQMzupaU60rOHBDjwTjs_qnh8ujVv3PP2qn94hO7kbnCfFZzx-1N6f8WXF9FMcf0BSf1QcukKgrPn7G_lndaNUViqIxpp8XxI2vQHyGAjrBYXCLvoXRu9A7q38IA1xXngl-uQ09oHN9e3_Xf6gr7gRFyKU4umEUOwkNRT-NEoBHsYsDr7tiL8gMUeARunibIhIMQvcJ03dRmMxgfBkBSJAVAIb05vTeR3McDSiiSgw_zuod0Awa4x6awk8QEvkJsNIczWiaZqvdbqum7dSPC5HPkyimu1EYzDD2VkhN1bBbMtj7CF-MRtil5Bl3I0K7ExS4K46G2myblgx5J4TbxKdk5hMcrUSUwV_9Ql9TVRnwQ0iR37sfZNTl2E1LNdq6rmuaXYwX0iWelMO5D4rNcQA7NG2nrbU1zdKkw3gkdPILLhhFa2otQ9MMw9alxrweB4TiLKJpOEbT1m3DMnXLNIuY_opsa5ba1AxVd2zTlqrkPiRxGOTw2nrT3AK-NllNy2yqheL9ykYHfTSdltNu63YJk2VRHcMwmlarDSNsqZaUbzfxfYhFWUypvfs4xtEzoiQvpBS-G06HJMibGWaG2lTbhmW0VPBfqddHGN2NhCv2kUeS-BbTCMcrzTSl2rhFAeqGMc04SRHoPY4gCNIcxjaEAXZDiJt5Js2CuJJhtBldyvGGjHB5yEqDSRGqSrPbOC4GZeEqE95NoD54ZznIQZj4JSFplAn9Mqgefs2EhQJ3-56FbEsn13VAS9LLQ7blAj6HlOch2wbMI8_F1f0S0oKow2KOpuuOpevSEDmZx8RF_i16JdNkCgvbA3rCQYaMKZ-C4wkNIGbJcA057iWJ8A5o3dD3dkGboDDeAe8WEq4rSME6rptA8jZf4VhmkWOW0R4kQ-4JA74O3BV8EdVPQcTjfiaHKrTOCPfBC1nWNvRxWZQVk9SZy2Q4gtcYBynDlaKsplGEdIOxO3kHWu4jissF_VW6oemFumXAWd3qZhHZDcotYJDHqKAphrhZU5pRhFNRURcBjsbzwYRg36sGvZCri2YloizTcxY7q2-tJL9NyiiFWlEnjyjyyi1GVWV6RnE2RmvtYn0J8Kyq5NMFQ3YOCB5e226o8n1T-I3tmvxqaJ1oGiZRSYsL4FIDWCwvIgfvYy9xy61ny83fuQ873rLDWGKBnL5fCbVDKXKfeqE3Lq00zqQSRl6-QTKbQQxhs2GNQKto3YTsn2RyoCNb3Q59B1O5lEuzFbY8gxV0aQbLrKE8lzWU8mNhy36FwazAS7NYGvQWgsUUFgF-xnEbZo85pHurS9jyldq_ccD8rlLuceELyD5hZ1VxNWhIkFYJjlSUCAc_5qXp58BLMbgIPMi1wBlK81jH2MTmgUwhlMZxD1GkeGlW_RlFBAVU5wdpMT9YuyQ-xVEPpgAjyJgqMUaRO7mBprN69u0S-f4QQgZrXaOoLY6OTo_5uSJ7eogwVtDC-V0GwSVjL8oUxcB2LmZTzCjCHhtnjhp1m7FmeyoUzTurw8Jr76weED93gMjaQO4g9HDMjh9arYap2qbZMNttB551u2U3LN1S9YYFuwS9YTqGDc9tW7UbttF2bGhRocXU2q02wDu22tDVdstp6KbZtht6S9X0hgPwDcO2gWTbsKyG5thOw3DsNrS2bKNhtVqGAZR0S2sY7ZYNPw3TAXotU4d2y7SAj22qLaBnOSb0QhNIoVsgi-aAjJoJSDpsYYCvaqkAbZhqo9U2Wg1NNYGPratmQ9dVGKGhwz6nYcGGx2jYpqW2G7YKXBuaZrdadXGwKxTDtP7m9FP_hj-8mVA6i0-Oj19eXpozRCfhCL_C6tl0w-nxDJDAXkfxE_H9I2aS4w78OR93OjfnP9wgfujdfUdHP_rDL3_dPHXtD0PLvhk9zjqPQffyyvnbOafD89aXb-qXJ_IyDJ5-hPeXDnmYOo_dV0cN4n-62uDdER6_BIF3O3t_Pvx0_Y9mzOnHj8Qm3-x3vdfHwZXxTdcC5yt-Tm4QMO6cnfEBHC9GcCqOhGMxnPRNIRRP2Xh1MRHYIzOYcAfAziKdsnAXEZguwlmO2Zzks5dNWvYwYAqIYZqPUOLTd3j6MUE-oXPhIGHEmuLzOQSoS5aZrZ04xZPwpePTFIeBntVHyI9xPUPxRhy0B2E0Xe5G6wuHYewHmApHBWps5RRcH-YzNss7NzdrgqQn68LHUnyFeAu_Sxv5mXpnxaSLfDfmbHw0ZPKw-wO2f_IWJ_VrCByWBK6fgJKDNKILn0wNAhJBNOJxgVmhj9EzkHHDJBDjSW8YdNDkWNjsFlPkQaA6vgYjxsdsSMecGTyl6AGapmEkbViTUry-88Mh8rVF43dhAMaiJ_S-bBOGZDwyMmaJ6CmR5fxhsOlsSbXLZ4yYKYuA95ngF-VHGC6sa6Xmg7jdIxDsYHVwmfmEfCK2DmjE1M6w_gYF2U4TAoljqvyfaP8ClMxW0zRNXW_b8E-E-VOuLyWJsTh-esRoFgZ83qTTrYC5mGmMQjrR-ODYezprFkaEjaEwbR_e6fxE-fTh-uOni9otip6UcKTQCVZ6YTKkkLAo7wOWu9RgzYLXZKq8j0hcS1eJE-U-woreVJvqepO93mQ09VxbN4lAfFobwKrmUuwpyx6zlvrZiaKrtdTNT5TzI_hb42bo4-8nim3Wrqczn7iE9Wo1S_2NTeMIoxioCZsr7FqEZe8K2IQ8YUVkqbW31m_po0JDhWfZikifFZHnKy8TCKFKDwRRHllAAFXU_k31d6L9_BeW6zE-UZvWz9-1lnqka-p_s-wXu4aU3ApVz6EC2hGsDOVQYYHJI1uA7JREhhUI0DXQUcS2MACajpenexkmP_WtMIJWRpS3v9tHXAGgTMgplAufZ5IghkhGmaLjHP5Pvi9cN0-sTMBtFR2s4y6t4yJwB4Vf8uSMwNTBbL6C7OYglTBYp7-rCOI2hfsFbN-n8-1CpBhFIph5Y6pHRt6Ukqm7Gf_t74Z6ZKYmkMz91fUgD4CQ4vcZvsKpQPhsQmwTgSINkVIIfSuEsRXC3AphbYWwt0I4WyFaWyHaWyE0dTvIdq1q29Wqbdertjgk5GtvfgnQN4b9B5jW1wFk71E45jdytcGUeXHXT1hOr_yFX7APgReNE3yi9LBPIpJMs8FXrXU8L1ZgzYogVLMlZJCw5Yn5a5mptibrKs8pWAnTFMgPRaZ4P4Rskq26i7RRFSnGWf089OaKOPBROsN5HDOPECnmcv6UICMEULR1GlYFGuCYzxBh1ihoFShcwi7gSTF2kXvwgmb7sD4PQ_qL7Hpl2a3qsusbZdf3Vrx9KDVWscc5hqT1QHytSuZbusGu7A9lOW0XQocZ-sEdwDrAWPR9hTAPEMeqzuEdnElbl6ECy8408XEVx7nC_hTv4Gn7hxWzMoWq9q8A32eZsFYVYe8ZqR0qxB0sRpv7Dsk-TMQx955fVmUv2CvqbfD1_X3EONRaYu6tDP0wdj3EQmAfgMb-CrH2nB3V81n9ULPBOIACq4uv7e0O-t5GW42cv197gJ4_N8-TFbT41k7JHqvvkUGYh3EkY29dmIeaTofYH9q7CrOnF-7rxcYBxr53GrFvUnqIxPhgqcyBFpqDBctDrFj7O6tdOdzmDrjErQ27q0EeHvDrl0fMbixicXvNL1TYE78XE0dMwSxhN-8R_6Tm4vLyovtw_fliwWRKYvfrMBmN2NctKSuBEiTTIY4y-xh-3fRVNKeQA8zLg5Q4Gcbi8azO7pD4rVIPU0T8mN2d-T6axey2K73XYedd6TUUuw8poMahrsjyC5bNtFYAckoXrzhidzyPoLWIYKlcy_4tQgmGrOaMFSvIqLHvQeSExI1DF8VU1MRJNMW_w5FTYUff0uGwzgLc6-kM-VLOae8WTVB2pzvDLhkRl93WFZuc3QALqAK9LAt4pfZOK7DkNPjNiIyA6JQjixsNGXbaW6BV_r2MVKuiV47ewy6Sjl10ypGXZZZhAGqSUVlCFVD6kH6LA07TIT6745Ja9sLHSxA5wTs6wVFaNCOjdAsBaQFS6DgRGSZU7sYZiAJd8eJviYZYnxxV1DZLxsD6CiJRrtpXotAsjJyUKJKVBrIiVHFZKdVfWodXYIK0BFWi_szZ62YlLKpwJeNPuwuchMffznNIPFGLKXGXNbCigAFr9P5keIHp_mTWK073p8jzCam90145-idKWJnCBiqiIKMUEeZU-1FgvrUfhQcSuDSJ8M4E-uuZyAq3X5yDLGskNyIveosiR1o6uTMFUeC5MzqvP90Zm8f_Hh7xQp6iBWAJU-AfNAl6oAxa4BslSXGxNgeS1egq0RJL4caRVqYoHDz9BqooBgiQLYRgLb8qyBbLUVpWUV9h5LPPb0N_P4K_fOu1DzH2JUgyQ4G3IHe3KUdf2aGk9mDDDjR5fXCPfXCyrw5Zac0GQnK5To8Xu7rTexTRueLhGDY0KF2OfbDBgFVues9sGj-AUVZ1m2g2w8FSTFF8N2UlmQp-Zf9xgrnubhiMyDgtsxMv2UK7ZYtCCfVxpkIxW7OZ33w6udKhIUvBa_m2GU-s1xoJT5drtbesnstdlPnEosxHgNW-sKODCUxsxUXBf2D3Hv-PKkOsYPZRjVdjBR6eKHWD_gXFtdZ4Auv_euMowvgHrmk5idLG-ZIp8l_QPE4pWGquNg9zZ2FlIpCRH3mpEyooTZeBWDhdH1a82HO7SUzDKezNl7dgeZWKXzQhYDGbUdfxeRgvge995OJJ6Hs4Wu3nreXef1kixT6ixxH2Bnw7ykpdYWM-KqLiqGqOb2aPKkPIwacfGMG857UyhQIvEAduyOtNQca4HAKzRwl4084Ll0s-t_CIyZj4dyO-MAKrMS5kZeQZsc159uBCwkszclj5j7SKMK1fuGW3zRJuqpYXMpfKHy8dX0Qk_sYeP4Sw1WIgrDl9OT1e_8Ut_wc5GBnx)

### Before screenshot:
With EO:
<img width="1022" height="819" alt="image" src="https://github.com/user-attachments/assets/e84a7412-770d-463c-ab67-ece2beed00cc" />
<img width="505" height="257" alt="image" src="https://github.com/user-attachments/assets/7a2f0817-0f29-4975-bfd4-03074a4d9148" />
<img width="502" height="203" alt="image" src="https://github.com/user-attachments/assets/da40f6f5-9b8a-4144-a94f-272dd09978ae" />

### After screenshot:
With EO:
<img width="1025" height="823" alt="image" src="https://github.com/user-attachments/assets/a10ec5c0-00fb-4150-9473-0e166df4b539" />
<img width="400" height="229" alt="image" src="https://github.com/user-attachments/assets/8dcc9215-a497-4e55-9abe-a7ffa4139dc4" />
<img width="405" height="140" alt="image" src="https://github.com/user-attachments/assets/843c8f76-568b-4a86-943f-ab3ed687ea86" />

With PA and EO: (No more ailments)
<img width="1020" height="532" alt="image" src="https://github.com/user-attachments/assets/ae55a9b5-21a8-42c4-a83e-2bb5b192533e" />

With just PA (Bleed chance is still wrong, as mentioned in "Limitations":
<img width="1679" height="822" alt="image" src="https://github.com/user-attachments/assets/8f1bcc35-e198-490f-aa1d-7829c35780ae" />







