### PR TITLE
Add support for importing loadouts from build XML

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -314,6 +314,24 @@ You can get this from your web browser's cookies while logged into the Path of E
 				self.build:Init(self.build.dbFileName, self.build.buildName, self.importCodeXML, false, self.importCodeSite and self.controls.importCodeIn.buf or nil)
 				self.build.viewMode = "TREE"
 			end)
+		elseif self.controls.importCodeMode.selIndex == 3 then
+			local controls = { }
+			t_insert(controls, new("LabelControl", nil, {0, 20, 0, 16}, colorCodes.WARNING.."Warning:^7 Importing many loadouts into the same build"))
+			t_insert(controls, new("LabelControl", nil, {0, 36, 0, 16}, "may cause performance issues. Use with caution."))
+			t_insert(controls, new("LabelControl", nil, {0, 64, 0, 16}, "^7Prefix for imported loadouts:"))
+			controls.prefix = new("EditControl", nil, {0, 84, 350, 20}, "Imported - ", nil, nil, 50)
+			controls.import = new("ButtonControl", nil, {-45, 114, 80, 20}, "Import", function()
+				local prefix = controls.prefix.buf
+				if prefix == "" then
+					prefix = "Imported - "
+				end
+				main:ClosePopup()
+				self.build:ImportLoadouts(self.importCodeXML, prefix)
+			end)
+			t_insert(controls, new("ButtonControl", nil, {45, 114, 80, 20}, "Cancel", function()
+				main:ClosePopup()
+			end))
+			main:OpenPopup(380, 144, "Import Loadouts", controls, "import")
 		else
 			self.build:Shutdown()
 			self.build:Init(false, "Imported build", self.importCodeXML, false, self.importCodeSite and self.controls.importCodeIn.buf or nil)
@@ -331,7 +349,7 @@ You can get this from your web browser's cookies while logged into the Path of E
 	self.controls.importCodeState.label = function()
 		return self.importCodeDetail or ""
 	end
-	self.controls.importCodeMode = new("DropDownControl", {"TOPLEFT",self.controls.importCodeIn,"BOTTOMLEFT"}, {0, 4, 160, 20}, { "Import to this build", "Import to a new build" })
+	self.controls.importCodeMode = new("DropDownControl", {"TOPLEFT",self.controls.importCodeIn,"BOTTOMLEFT"}, {0, 4, 160, 20}, { "Import to this build", "Import to a new build", "Import loadouts only" })
 	self.controls.importCodeMode.enabled = function()
 		return self.build.dbFileName and self.importCodeValid
 	end

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -958,15 +958,24 @@ holding Shift will put it in the second.]])
 	self.lastSlot = self.slots[baseSlots[#baseSlots]]
 end)
 
-function ItemsTabClass:Load(xml, dbFileName)
-	self.activeItemSetId = 0
-	self.itemSets = { }
-	self.itemSetOrderList = { }
-	self.tradeQuery.statSortSelectionList = { }
+function ItemsTabClass:Load(xml, dbFileName, appendItems)
+	if not appendItems then
+		self.activeItemSetId = 0
+		self.itemSets = { }
+		self.itemSetOrderList = { }
+		self.tradeQuery.statSortSelectionList = { }
+	end
+
+	local itemIdMap = { }
+	local itemSetIdMap = { }
 	for _, node in ipairs(xml) do
 		if node.elem == "Item" then
 			local item = new("Item", "")
-			item.id = tonumber(node.attrib.id)
+			local itemId = tonumber(node.attrib.id)
+			if not appendItems then
+				item.id = itemId
+			end
+
 			item.variant = tonumber(node.attrib.variant)
 			if node.attrib.variantAlt then
 				item.hasAltVariant = true
@@ -1009,8 +1018,13 @@ function ItemsTabClass:Load(xml, dbFileName)
 			end
 			if item.base then
 				item:BuildModList()
-				self.items[item.id] = item
-				t_insert(self.itemOrderList, item.id)
+				if appendItems then
+					self:AddItem(item, true)
+					itemIdMap[itemId] = item.id
+				else
+					self.items[item.id] = item
+					t_insert(self.itemOrderList, item.id)
+				end
 			end
 		-- Below is OBE and left for legacy compatibility (all Slots are part of ItemSets now)
 		elseif node.elem == "Slot" then
@@ -1023,14 +1037,22 @@ function ItemsTabClass:Load(xml, dbFileName)
 				end
 			end
 		elseif node.elem == "ItemSet" then
-			local itemSet = self:NewItemSet(tonumber(node.attrib.id))
+			local oldItemSetId = tonumber(node.attrib.id)
+			local itemSet = self:NewItemSet(not appendItems and oldItemSetId or nil)
+			if appendItems then
+				itemSetIdMap[oldItemSetId] = itemSet.id
+			end
 			itemSet.title = node.attrib.title
 			itemSet.useSecondWeaponSet = node.attrib.useSecondWeaponSet == "true"
 			for _, child in ipairs(node) do
 				if child.elem == "Slot" then
 					local slotName = child.attrib.name or ""
 					if itemSet[slotName] then
-						itemSet[slotName].selItemId = tonumber(child.attrib.itemId)
+						local itemId = tonumber(child.attrib.itemId)
+						if appendItems and itemIdMap[itemId] then
+							itemId = itemIdMap[itemId]
+						end
+						itemSet[slotName].selItemId = itemId
 						itemSet[slotName].active = child.attrib.active == "true"
 						itemSet[slotName].pbURL = child.attrib.itemPbURL or ""
 					end
@@ -1051,16 +1073,20 @@ function ItemsTabClass:Load(xml, dbFileName)
 			end
 		end
 	end
-	if not self.itemSetOrderList[1] then
-		self.activeItemSet = self:NewItemSet(1)
-		self.activeItemSet.useSecondWeaponSet = xml.attrib.useSecondWeaponSet == "true"
-		self.itemSetOrderList[1] = 1
+	if not appendItems then
+		if not self.itemSetOrderList[1] then
+			self.activeItemSet = self:NewItemSet(1)
+			self.activeItemSet.useSecondWeaponSet = xml.attrib.useSecondWeaponSet == "true"
+			self.itemSetOrderList[1] = 1
+		end
+		self:SetActiveItemSet(tonumber(xml.attrib.activeItemSet) or 1)
+		if xml.attrib.showStatDifferences then
+			self.showStatDifferences = xml.attrib.showStatDifferences == "true"
+		end
+		self:ResetUndo()
+	else
+		return itemIdMap, itemSetIdMap
 	end
-	self:SetActiveItemSet(tonumber(xml.attrib.activeItemSet) or 1)
-	if xml.attrib.showStatDifferences then
-		self.showStatDifferences = xml.attrib.showStatDifferences == "true"
-	end
-	self:ResetUndo()
 end
 
 function ItemsTabClass:Save(xml)

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -456,8 +456,11 @@ function TreeTabClass:GetSpecList()
 	return newSpecList
 end
 
-function TreeTabClass:Load(xml, dbFileName)
-	self.specList = { }
+function TreeTabClass:Load(xml, dbFileName, appendSpecs)
+	if not appendSpecs then
+		self.specList = { }
+	end
+
 	if xml.elem == "Spec" then
 		-- Import single spec from old build
 		self.specList[1] = new("PassiveSpec", self.build, defaultTreeVersion)
@@ -473,16 +476,19 @@ function TreeTabClass:Load(xml, dbFileName)
 					main:OpenMessagePopup("Unknown Passive Tree Version", "The build you are trying to load uses an unrecognised version of the passive skill tree.\nYou may need to update the program before loading this build.")
 					return true
 				end
+
 				local newSpec = new("PassiveSpec", self.build, node.attrib.treeVersion or defaultTreeVersion)
 				newSpec:Load(node, dbFileName)
 				t_insert(self.specList, newSpec)
 			end
 		end
 	end
-	if not self.specList[1] then
-		self.specList[1] = new("PassiveSpec", self.build, latestTreeVersion)
+	if not appendSpecs then
+		if not self.specList[1] then
+			self.specList[1] = new("PassiveSpec", self.build, latestTreeVersion)
+		end
+		self:SetActiveSpec(tonumber(xml.attrib.activeSpec) or 1)
 	end
-	self:SetActiveSpec(tonumber(xml.attrib.activeSpec) or 1)
 end
 
 function TreeTabClass:PostLoad()


### PR DESCRIPTION
(I totally did not made this PR just because I was too lazy to merge my 2 pobs together manually :d)

Adds support for importing only loadouts (item sets, skill sets, tree specs, config sets) from a build XML to current build without overwriting anything else.

Closes #7843 

Example pob 1:
https://pobb.in/4E0oETFkyZi0
<img width="410" height="189" alt="image" src="https://github.com/user-attachments/assets/1c86da4f-8d00-4e44-b3c7-0dacb6765ca8" />

Example pob 2:
https://pobb.in/xGLaSDnPOuKw
<img width="469" height="154" alt="image" src="https://github.com/user-attachments/assets/c1ad765f-cb74-4c77-bb96-988f350942e0" />

Example merged pob:
https://pobb.in/wb54Pkh83oR9
<img width="528" height="258" alt="image" src="https://github.com/user-attachments/assets/2ead3688-68fd-4b07-bbd9-b48f117342b7" />

Merging process:

Open pob, go to import, add xml or link, select import loadouts only:
<img width="768" height="290" alt="image" src="https://github.com/user-attachments/assets/1b0eb3b1-3dec-4dcb-959b-f6ca82c66c96" />

<img width="1336" height="558" alt="image" src="https://github.com/user-attachments/assets/d6c96da9-5459-4b55-b9d0-92384578f219" />

After import press:
<img width="1146" height="510" alt="image" src="https://github.com/user-attachments/assets/1b196e5b-4343-4a3c-b370-ab399c9078b2" />

