### PR TITLE
Added SSL bypass to launch:DownloadPage function

### DIFF
--- a/src/Launch.lua
+++ b/src/Launch.lua
@@ -254,7 +254,7 @@ end
 function launch:DownloadPage(url, callback, params)
 	params = params or {}
 	local script = [[
-		local url, requestHeader, requestBody, connectionProtocol, proxyURL = ...
+		local url, requestHeader, requestBody, connectionProtocol, proxyURL, noSSL = ...
 		local responseHeader = ""
 		local responseBody = ""
 		ConPrintf("Downloading page at: %s", url)
@@ -281,6 +281,10 @@ function launch:DownloadPage(url, callback, params)
 		if proxyURL then
 			easy:setopt(curl.OPT_PROXY, proxyURL)
 		end
+		if noSSL then
+			easy:setopt(curl.OPT_SSL_VERIFYPEER, 0)
+			easy:setopt(curl.OPT_SSL_VERIFYHOST, 0)
+		end
 		easy:setopt_headerfunction(function(data)
 			responseHeader = responseHeader .. data
 			return true
@@ -303,7 +307,7 @@ function launch:DownloadPage(url, callback, params)
 		ConPrintf("Download complete. Status: %s", errMsg or "OK")
 		return responseBody, errMsg, responseHeader
 	]]
-	local id = LaunchSubScript(script, "", "ConPrintf", url, params.header, params.body, self.connectionProtocol, self.proxyURL)
+	local id = LaunchSubScript(script, "", "ConPrintf", url, params.header, params.body, self.connectionProtocol, self.proxyURL, self.noSSL or false)
 	if id then
 		self.subScripts[id] = {
 			type = "DOWNLOAD",


### PR DESCRIPTION
### Description of the problem being solved:
Now build links from pobb.in can successfully import.
### Steps taken to verify a working solution:
- POB shortcut add --no-ssl
- Now the DownloadPage function can complete without throwing SSL connect error
