### PR TITLE
Fix Incorrect tooltip in dropdowns

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -87,6 +87,7 @@ function GemSelectClass:CalcOutputWithThisGem(calcFunc, gemData, qualityId, useF
 	if gemInstance.qualityId == nil or gemInstance.qualityId == "" then
 		gemInstance.qualityId = "Default"
 	end
+	self:AddGemTooltip(gemInstance)
 	-- Calculate the impact of using this gem
 	local output = calcFunc(nil, useFullDPS)
 	-- Put the original gem back into the list


### PR DESCRIPTION
Fixes #9100 .

### Description of the problem being solved:

When I hover over a list item in a dropdown, it should display the correct tooltip.
If I have anything typed into the textbox, the tooltip is always for the topmost element.

### Steps taken to verify a working solution:
- Enter text to textbox
- Hover any gem

### Before screenshot:
<img width="600" height="445" alt="image" src="https://github.com/user-attachments/assets/e161bad5-9697-4b5e-b9eb-e0ee655d2986" />

### After screenshot:
<img width="600" height="457" alt="image" src="https://github.com/user-attachments/assets/3df6e79b-45c7-4d85-b44f-49c7244a2314" />
