### PR TITLE
Slighty better nil checks for missing API function

### DIFF
--- a/src/HeadlessWrapper.lua
+++ b/src/HeadlessWrapper.lua
@@ -51,6 +51,10 @@ end
 function GetScreenScale()
 	return 1
 end
+function GetDPIScaleOverridePercent()
+	return 1
+end
+function SetDPIScaleOverridePercent(scale) end
 function SetClearColor(r, g, b, a) end
 function SetDrawLayer(layer, subLayer) end
 function SetViewport(x, y, width, height) end

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -113,6 +113,8 @@ function main:Init()
 	self.showPublicBuilds = true
 	self.showFlavourText = true
 
+	if not SetDPIScaleOverridePercent then SetDPIScaleOverridePercent = function(scale) end end
+
 	if self.userPath then
 		self:ChangeUserPath(self.userPath, ignoreBuild)
 	end
@@ -645,7 +647,7 @@ function main:LoadSettings(ignoreBuild)
 				end
 				if node.attrib.dpiScaleOverridePercent then
 					self.dpiScaleOverridePercent = tonumber(node.attrib.dpiScaleOverridePercent) or 0
-					if SetDPIScaleOverridePercent then SetDPIScaleOverridePercent(self.dpiScaleOverridePercent) end
+					SetDPIScaleOverridePercent(self.dpiScaleOverridePercent)
 				end
 			end
 		end
@@ -884,7 +886,7 @@ function main:OpenOptionsPopup()
 		{ label = "250%", percent = 250 },
 	}, function(index, value)
 		self.dpiScaleOverridePercent = value.percent
-		if SetDPIScaleOverridePercent then SetDPIScaleOverridePercent(value.percent) end
+		SetDPIScaleOverridePercent(value.percent)
 	end)
 	controls.dpiScaleOverrideLabel = new("LabelControl", { "RIGHT", controls.dpiScaleOverride, "LEFT" }, { defaultLabelSpacingPx, 0, 0, 16 }, "^7UI scaling override:")
 	controls.dpiScaleOverride.tooltipText = "Overrides Windows DPI scaling inside Path of Building.\nChoose a percentage between 100% and 250% or revert to the system default."
@@ -1102,7 +1104,7 @@ function main:OpenOptionsPopup()
 		if not launch.devMode then
 			main:SetManifestBranch(self.betaTest and "beta" or "master")
 		end
-		if SetDPIScaleOverridePercent then SetDPIScaleOverridePercent(self.dpiScaleOverridePercent) end
+		SetDPIScaleOverridePercent(self.dpiScaleOverridePercent)
 		main:ClosePopup()
 		main:SaveSettings()
 	end)
@@ -1131,7 +1133,7 @@ function main:OpenOptionsPopup()
 		self.showPublicBuilds = initialShowPublicBuilds
 		self.showFlavourText = initialShowFlavourText
 		self.dpiScaleOverridePercent = initialDpiScaleOverridePercent
-		if SetDPIScaleOverridePercent then SetDPIScaleOverridePercent(self.dpiScaleOverridePercent) end
+		SetDPIScaleOverridePercent(self.dpiScaleOverridePercent)
 		main:ClosePopup()
 	end)
 	nextRow(1.5)


### PR DESCRIPTION
Combines several `if` statements into one that defines a "nop" function if the API call is missing.  There might be an even nicer way of doing it, I'm not sure.

I'm thinking that, ideally, 3rd party front-end providers should view these types of measures as temporary.

(Bonus function declarations in `HeadlessWrapper.lua`)
