### PR TITLE
Fix Pyroclast Mine Exposure being inverted and unscalable

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -14468,8 +14468,7 @@ skills["PyroclastMine"] = {
 	castTime = 0.18,
 	statMap = {
 		["pyroclast_mine_aura_fire_exposure_%_to_apply"] = {
-			mod("FireExposure", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "AuraDebuff", unscalable = true, effectName = "Pyroclast Mine Fire Exposure" }),
-			mult = -1,
+			mod("FireExposure", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "AuraDebuff", effectName = "Pyroclast Mine Fire Exposure" }),
 		},
 	},
 	baseFlags = {
@@ -14569,8 +14568,7 @@ skills["PyroclastMineAltX"] = {
 	castTime = 0.18,
 	statMap = {
 		["pyroclast_mine_aura_fire_exposure_%_to_apply"] = {
-			mod("FireExposure", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "AuraDebuff", unscalable = true, effectName = "Pyroclast Mine Fire Exposure" }),
-			mult = -1,
+			mod("FireExposure", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "AuraDebuff", effectName = "Pyroclast Mine Fire Exposure" }),
 		},
 	},
 	baseFlags = {

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -3123,8 +3123,7 @@ local skills, mod, flag, skill = ...
 #flags spell area projectile mine
 	statMap = {
 		["pyroclast_mine_aura_fire_exposure_%_to_apply"] = {
-			mod("FireExposure", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "AuraDebuff", unscalable = true, effectName = "Pyroclast Mine Fire Exposure" }),
-			mult = -1,
+			mod("FireExposure", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "AuraDebuff", effectName = "Pyroclast Mine Fire Exposure" }),
 		},
 	},
 #baseMod skill("radius", 20)
@@ -3139,8 +3138,7 @@ local skills, mod, flag, skill = ...
 #flags spell area projectile mine
 	statMap = {
 		["pyroclast_mine_aura_fire_exposure_%_to_apply"] = {
-			mod("FireExposure", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "AuraDebuff", unscalable = true, effectName = "Pyroclast Mine Fire Exposure" }),
-			mult = -1,
+			mod("FireExposure", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "AuraDebuff", effectName = "Pyroclast Mine Fire Exposure" }),
 		},
 	},
 #baseMod skill("radius", 20)


### PR DESCRIPTION
Fixes #9159

### Description of the problem being solved:
For some reason I was inverting the value of the exposure and also forgot to remove the unscaleable tag from the mod

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/kl6j10a8

### Before screenshot:
<img width="417" height="145" alt="image" src="https://github.com/user-attachments/assets/1249b169-2b02-4ff5-9f44-6ac0dfcbed5d" />

### After screenshot:
<img width="418" height="146" alt="image" src="https://github.com/user-attachments/assets/ee5c08f7-194f-4f0e-8f7e-6910d52fcf7b" />
