### PR TITLE
Fix mod order when crafting Grafts

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1752,7 +1752,10 @@ function ItemsTabClass:UpdateAffixControl(control, item, type, outputTable, outp
 				return modA.statOrder[i] < modB.statOrder[i]
 			end
 		end
-		return modA.level > modB.level
+		if modA.level ~= modB.level then
+			return modA.level < modB.level
+		end
+		return a < b
 	end)
 	control.selIndex = 1
 	control.list = { "None" }
@@ -1796,7 +1799,7 @@ function ItemsTabClass:UpdateAffixControl(control, item, type, outputTable, outp
 			if selAffix == modId then
 				control.selIndex = #control.list
 			end
-			t_insert(lastSeries.modList, 1, modId)
+			t_insert(lastSeries.modList, modId)
 			if #lastSeries.modList == 2 then
 				lastSeries.label = lastSeries.label:gsub("%(%-?[%d%.]+%-%-?[%d%.]+%)","#"):gsub("%-?%d+%.?%d*","#")
 				lastSeries.haveRange = true


### PR DESCRIPTION
Fixes #9161 .

### Description of the problem being solved:
Some graft mods had identical statOrder values and the same level requirement so it would then fall back to the random order the pairs list added the mods in
Instead now we sort based on Id if the statOrder and level values are the same
Making the change also requires change the lastSeries list to no longer prepend the values

### Steps taken to verify a working solution:
- Test graft mods with same statOrder and levels
- Test mods with different levels and stat orders
- Test many different rares to make sure the order was the same as before

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/7e6qc0ac

### Before screenshot:
<img width="767" height="303" alt="image" src="https://github.com/user-attachments/assets/d3192714-2ec7-48c6-890d-41c0753b6eb9" />

### After screenshot:
<img width="761" height="326" alt="image" src="https://github.com/user-attachments/assets/1b659866-ec67-4cf8-9c1b-3fe544c81167" />
