### PR TITLE
Fix incorrect tooltip when crafting some flask mods

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -852,6 +852,7 @@ holding Shift will put it in the second.]])
 				tooltip:Clear()
 			elseif tooltip:CheckForUpdate(val, modList) then
 				local index, range = slider:GetDivVal(val)
+				range = verifyRange(range, index, drop)
 				local modId = modList[index]
 				local mod = self.displayItem.affixes[modId]
 				for _, line in ipairs(mod) do


### PR DESCRIPTION
Fixes #8423

### Description of the problem being solved:
When crafting mods on items that used a `less x` mod, we flipped the order of the values so they would smoothly transition between tiers instead of jumping
e.g. (45-49)% less Duration, (40-44)% less Duration, (35-39)% less Duration
We didn't update the range slider tooltip though so it was still jumping and was not representing the value on the item

### Steps taken to verify a working solution:
- Test on flask mods
- Test on mods from many other items

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/zz6xt0yc

### Before screenshot:
<img width="559" height="348" alt="image" src="https://github.com/user-attachments/assets/ebc7e9f4-01f8-45e5-b5f8-e25a8b8797f5" />

### After screenshot:
<img width="568" height="343" alt="image" src="https://github.com/user-attachments/assets/98a9aa7d-353a-4f2b-8ad7-593068dc38a8" />
