### PR TITLE
Fix insufficient skill cost warning applying to other skills

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1625,7 +1625,7 @@ function buildMode:AddDisplayStatList(statList, actor)
 			end
 		end
 	end
-	for pool, warningFlag in pairs({["Life"] = "LifeCostWarning", ["Mana"] = "ManaCostWarning", ["Rage"] = "RageCostWarning", ["Energy Shield"] = "ESCostWarning"}) do
+	for pool, warningFlag in pairs({["Life"] = "LifeCostWarningList", ["Mana"] = "ManaCostWarningList", ["Rage"] = "RageCostWarningList", ["Energy Shield"] = "ESCostWarningList"}) do
 		if actor.output[warningFlag] then
 			local line = "You do not have enough "..(actor.output.EnergyShieldProtectsMana and pool == "Mana" and "Energy Shield and Mana" or pool).." to use: "
 			for _, skill in ipairs(actor.output[warningFlag]) do
@@ -1635,7 +1635,7 @@ function buildMode:AddDisplayStatList(statList, actor)
 			InsertIfNew(self.controls.warnings.lines, line)
 		end
 	end
-	for pool, warningFlag in pairs({["Unreserved life"] = "LifePercentCostPercentCostWarning", ["Unreserved Mana"] = "ManaPercentCostPercentCostWarning"}) do
+	for pool, warningFlag in pairs({["Unreserved life"] = "LifePercentCostPercentCostWarningList", ["Unreserved Mana"] = "ManaPercentCostPercentCostWarningList"}) do
 		if actor.output[warningFlag] then
 			local line = "You do not have enough ".. pool .."% to use: "
 			for _, skill in ipairs(actor.output[warningFlag]) do

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -445,8 +445,11 @@ function calcs.buildOutput(build, mode)
 							local reservation = GlobalCache.cachedData[mode][uuid].Env.player.mainSkill and GlobalCache.cachedData[mode][uuid].Env.player.mainSkill.skillData[rawPool .. "ReservedPercent"]
 							-- Skill has both cost and reservation check if there's available pool for raw cost before reservation
 							if not reservation or (reservation and (totalPool + m_ceil((output[rawPool] or 0) * reservation / 100)) < cachedCost) then
-								output[costResource.."Warning"] = output[costResource.."Warning"] or {}
-								t_insert(output[costResource.."Warning"], skill.activeEffect.grantedEffect.name)
+								if env.player.mainSkill and env.player.mainSkill.activeEffect.grantedEffect.name == skill.activeEffect.grantedEffect.name then
+									output[costResource.."Warning"] = true
+								end
+								output[costResource.."WarningList"] = output[costResource.."WarningList"] or {}
+								t_insert(output[costResource.."WarningList"], skill.activeEffect.grantedEffect.name)
 							end
 						end
 					end
@@ -455,8 +458,8 @@ function calcs.buildOutput(build, mode)
 					local cachedCost = GlobalCache.cachedData[mode][uuid].Env.player.output[costResource]
 					if cachedCost then
 						if (output[pool] or 0) < cachedCost then
-							output[costResource.."PercentCostWarning"] = output[costResource.."PercentCostWarning"] or {}
-							t_insert(output[costResource.."PercentCostWarning"], skill.activeEffect.grantedEffect.name)
+							output[costResource.."PercentCostWarningList"] = output[costResource.."PercentCostWarningList"] or {}
+							t_insert(output[costResource.."PercentCostWarningList"], skill.activeEffect.grantedEffect.name)
 						end
 					end
 				end


### PR DESCRIPTION
Fixes #9169

### Description of the problem being solved:
When checking to see if we should apply the red text to a skills resource cost value we were checking the list of all skills that had a warning for that cost type instead of just the active skill in the sidebar
Decided to change the variable name for the list so that we can still use other `statData.stat.."Warning"` for other stats if we want 

### Steps taken to verify a working solution:
- Test build with mana cost above and below threshold
- Test existing builds for the List variable name change

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/j072y0ad

### Before screenshot:
<img width="309" height="215" alt="image" src="https://github.com/user-attachments/assets/36a1cd51-a510-421d-a2f9-c11fe577f570" />


### After screenshot:
<img width="310" height="215" alt="image" src="https://github.com/user-attachments/assets/97aba6c0-b729-42e3-aad5-a53374982057" />
