### PR TITLE
Fix Heraldry not granting Exposure to enemies

### DIFF
--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -553,4 +553,21 @@ describe("TetsItemMods", function()
 		assert.are_not.equals(64, build.calcsTab.mainOutput.Armour)
 		runCallback("OnFrame")
 	end)
+	
+	it("Heralds apply exposure with Heraldry", function()
+		build.skillsTab:PasteSocketGroup("Arc 20/0 Default  1\nHerald of Thunder 20/0 Default  1\n")
+		runCallback("OnFrame")
+		
+		assert.are.equals(0.5, build.calcsTab.mainOutput.LightningEffMult)
+				
+		build.configTab.input.customMods = [[
+		Nearby Enemies have Cold Exposure while you are affected by Herald of Ice
+		Nearby Enemies have Fire Exposure while you are affected by Herald of Ash
+		Nearby Enemies have Lightning Exposure while you are affected by Herald of Thunder
+		]]
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(0.6, build.calcsTab.mainOutput.LightningEffMult)
+	end)
 end)

--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -570,4 +570,19 @@ describe("TetsItemMods", function()
 
 		assert.are.equals(0.6, build.calcsTab.calcsOutput.LightningEffMult)
 	end)
+	
+	it("Enemy self curse effect", function()
+		build.skillsTab:PasteSocketGroup("Arc 20/0 Default  1\nConductivity 14/0 Default  1\n")
+		runCallback("OnFrame")
+		
+		assert.are.equals(0.8, build.calcsTab.calcsOutput.LightningEffMult)
+				
+		build.configTab.input.customMods = [[
+		Nearby Enemies have 20% increased Effect of Curses on them
+		]]
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(0.86, build.calcsTab.calcsOutput.LightningEffMult)
+	end)
 end)

--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -558,7 +558,7 @@ describe("TetsItemMods", function()
 		build.skillsTab:PasteSocketGroup("Arc 20/0 Default  1\nHerald of Thunder 20/0 Default  1\n")
 		runCallback("OnFrame")
 		
-		assert.are.equals(0.5, build.calcsTab.mainOutput.LightningEffMult)
+		assert.are.equals(0.5, build.calcsTab.calcsOutput.LightningEffMult)
 				
 		build.configTab.input.customMods = [[
 		Nearby Enemies have Cold Exposure while you are affected by Herald of Ice
@@ -568,6 +568,6 @@ describe("TetsItemMods", function()
 		build.configTab:BuildModList()
 		runCallback("OnFrame")
 
-		assert.are.equals(0.6, build.calcsTab.mainOutput.LightningEffMult)
+		assert.are.equals(0.6, build.calcsTab.calcsOutput.LightningEffMult)
 	end)
 end)


### PR DESCRIPTION
Fixes #9178, Fixes #9182

With my change in #9173, I moved the place in the file where EnemyModifiers were calculated but didn't realise that they also need to be recalculated later so that mods that rely on "AffectedBy" x still work

Changed it to use a cache so it doesn't duplicate earlier added mods