### PR TITLE
Add tooltip warning to flavour text config

### DIFF
--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -968,6 +968,7 @@ function main:OpenOptionsPopup()
 	controls.showFlavourText = new("CheckBoxControl", { "TOPLEFT", nil, "TOPLEFT" }, { defaultLabelPlacementX, currentY, 20 }, "^7Styled Tooltips with Flavour Text:", function(state)
 		self.showFlavourText = state
 	end)
+	controls.showFlavourText.tooltipText = "If updating while inside a build, please re-load the build after saving."
 
 	nextRow()
 	drawSectionHeader("build", "Build-related options")


### PR DESCRIPTION
### Description of the problem being solved:
Just copied the text from the hex configs. Some tooltips are cached and this is simpler than making a bunch of changes to tooltip stuff.

### After screenshot:
<img width="659" height="36" alt="image" src="https://github.com/user-attachments/assets/a67d1c13-b4f0-4d83-bbd2-559c09bf1f5a" />
