### PR TITLE
Add Support for Nuanced Kinetic Fusillade

### DIFF
--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -2267,10 +2267,10 @@ local skills, mod, flag, skill = ...
 #flags attack projectile area duration
 	parts = {
 		{
-			name = "1 Projectile"
+			name = "All Projectiles",
 		},
 		{
-			name = "All Projectiles",
+			name = "1 Projectile"
 		},
 	},
 	preDamageFunc = function(activeSkill, output, breakdown)
@@ -2278,7 +2278,7 @@ local skills, mod, flag, skill = ...
 		local t_insert = table.insert
 		local s_format = string.format
 
-		if activeSkill.skillPart == 2 then
+		if activeSkill.skillPart == 1 then
 			-- Set base dpsMultiplier for projectile count
 			activeSkill.skillData.dpsMultiplier = output.ProjectileCount
 
@@ -2313,13 +2313,22 @@ local skills, mod, flag, skill = ...
 		local t_insert = table.insert
 		local s_format = string.format
 
+		local baseDelayBetweenProjectiles = 0.05
+		local projectileCount = 1
+
+		if activeSkill.skillPart == 1 then
+			projectileCount = output.ProjectileCount
+		end
+
 		-- Calculate effective attack rate accounting for delayed projectile firing
 		-- Projectiles orbit for base_skill_effect_duration before firing
 		-- Recasting resets the timer, so attacking too fast wastes potential damage
 		local baseDuration = skillData.duration
 		local actualDuration = output.Duration or baseDuration
-		local ticksNeeded = math.ceil(actualDuration / data.misc.ServerTickTime)
-		local effectiveDelay = ticksNeeded * data.misc.ServerTickTime
+		local ticksNeededForInitialDelay = math.ceil(actualDuration / data.misc.ServerTickTime)
+		local timePerProjectile = baseDelayBetweenProjectiles * output.DurationMod
+		local timeForAllProjectiles = timePerProjectile * projectileCount
+		local effectiveDelay = ticksNeededForInitialDelay * data.misc.ServerTickTime + math.ceil(timeForAllProjectiles / data.misc.ServerTickTime) * data.misc.ServerTickTime
 		local maxEffectiveAPS = 1 / effectiveDelay
 		local currentAPS = output.Speed
 
@@ -2327,9 +2336,11 @@ local skills, mod, flag, skill = ...
 
 		if breakdown then
 			local breakdownAPS = {}
-			t_insert(breakdownAPS, s_format("^8Projectiles orbit for %.3fs before firing", actualDuration))
+			t_insert(breakdownAPS, s_format("^1(These calculations are speculative and best-effort)", actualDuration))
+			t_insert(breakdownAPS, s_format("^8Delay of^7 %.3fs ^8before projectiles start firing", actualDuration))
+			t_insert(breakdownAPS, s_format("^8Each projectile fires sequentially with a^7 %.3fs ^8delay between each projectile", timePerProjectile))
 			t_insert(breakdownAPS, s_format("^8Server tick time:^7 %.3fs", data.misc.ServerTickTime))
-			t_insert(breakdownAPS, s_format("^8Ticks needed:^7 %d ^8(rounded up)", ticksNeeded))
+			t_insert(breakdownAPS, s_format("^8Ticks needed:^7 %d ^8(rounded up)", ticksNeededForInitialDelay + math.ceil(timeForAllProjectiles / data.misc.ServerTickTime)))
 			t_insert(breakdownAPS, s_format("^8Effective delay:^7 %.3fs", effectiveDelay))
 			t_insert(breakdownAPS, s_format("^8Max effective attack rate:^7 1 / %.3f = %.2f", effectiveDelay, maxEffectiveAPS))
 			if currentAPS and currentAPS > maxEffectiveAPS then
@@ -2344,7 +2355,7 @@ local skills, mod, flag, skill = ...
 		end
 
 		-- Adjust dpsMultiplier if attacking too fast (only for "All Projectiles" mode)
-		if activeSkill.skillPart == 2 then
+		if activeSkill.skillPart == 1 then
 			if currentAPS and currentAPS > maxEffectiveAPS then
 				local efficiencyRatio = maxEffectiveAPS / currentAPS
 				local originalMultiplier = skillData.dpsMultiplier or output.ProjectileCount

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -2265,6 +2265,100 @@ local skills, mod, flag, skill = ...
 
 #skill KineticFusillade
 #flags attack projectile area duration
+	parts = {
+		{
+			name = "1 Projectile"
+		},
+		{
+			name = "All Projectiles",
+		},
+	},
+	preDamageFunc = function(activeSkill, output, breakdown)
+		local skillData = activeSkill.skillData
+		local t_insert = table.insert
+		local s_format = string.format
+
+		if activeSkill.skillPart == 2 then
+			-- Set base dpsMultiplier for projectile count
+			activeSkill.skillData.dpsMultiplier = output.ProjectileCount
+
+			-- Calculate average damage scaling for sequential projectiles
+			-- Each projectile does more damage based on how many came before it
+			local moreDamagePerProj = skillData.KineticFusilladeSequentialDamage or 0
+			if moreDamagePerProj ~= 0 and output.ProjectileCount > 1 then
+				-- Average multiplier: sum of (0, X, 2X, 3X, ..., (n-1)X) / n
+				-- This equals: X * (0 + 1 + 2 + ... + (n-1)) / n = X * n(n-1)/2 / n = X * (n-1)/2
+				local avgMoreMult = moreDamagePerProj * (output.ProjectileCount - 1) / 2
+				activeSkill.skillModList:NewMod("Damage", "MORE", avgMoreMult, "Skill:KineticFusillade", ModFlag.Hit)
+
+				-- Store the average multiplier for display
+				output.KineticFusilladeAvgMoreMult = avgMoreMult
+
+				if breakdown then
+					local breakdownSequential = {}
+					t_insert(breakdownSequential, s_format("^8Each projectile deals^7 %d%%^8 more damage per previous projectile", moreDamagePerProj))
+					t_insert(breakdownSequential, s_format("^8With^7 %d^8 projectiles, damage progression is:^7", output.ProjectileCount))
+					for i = 1, output.ProjectileCount do
+						local projMult = moreDamagePerProj * (i - 1)
+						t_insert(breakdownSequential, s_format("  ^8Projectile %d:^7 %d%%^8 more damage", i, projMult))
+					end
+					t_insert(breakdownSequential, s_format("^8Average more multiplier:^7 %.1f%%", avgMoreMult))
+					breakdown.KineticFusilladeSequentialBreakdown = breakdownSequential
+				end
+			end
+		end
+	end,
+	postCritFunc = function(activeSkill, output, breakdown)
+		if activeSkill.skillPart == 2 then
+			local skillData = activeSkill.skillData
+			local t_insert = table.insert
+			local s_format = string.format
+
+			-- Calculate effective attack rate accounting for delayed projectile firing
+			-- Projectiles orbit for base_skill_effect_duration before firing
+			-- Recasting resets the timer, so attacking too fast wastes potential damage
+			local baseDuration = skillData.duration
+			local actualDuration = output.Duration or baseDuration
+			local ticksNeeded = math.ceil(actualDuration / data.misc.ServerTickTime)
+			local effectiveDelay = ticksNeeded * data.misc.ServerTickTime
+			local maxEffectiveAPS = 1 / effectiveDelay
+			local currentAPS = output.Speed
+
+			output.KineticFusilladeMaxEffectiveAPS = maxEffectiveAPS
+
+			if breakdown then
+				local breakdownAPS = {}
+				t_insert(breakdownAPS, s_format("^8Projectiles orbit for %.3fs before firing", actualDuration))
+				t_insert(breakdownAPS, s_format("^8Server tick time:^7 %.3fs", data.misc.ServerTickTime))
+				t_insert(breakdownAPS, s_format("^8Ticks needed:^7 %d ^8(rounded up)", ticksNeeded))
+				t_insert(breakdownAPS, s_format("^8Effective delay:^7 %.3fs", effectiveDelay))
+				t_insert(breakdownAPS, s_format("^8Max effective attack rate:^7 1 / %.3f = %.2f", effectiveDelay, maxEffectiveAPS))
+				if currentAPS and currentAPS > maxEffectiveAPS then
+					t_insert(breakdownAPS, "")
+					t_insert(breakdownAPS, s_format("^1Current attack rate (%.2f) exceeds max effective rate!", currentAPS))
+					t_insert(breakdownAPS, s_format("^1DPS is reduced by %.1f%%", (1 - maxEffectiveAPS / currentAPS) * 100))
+				elseif currentAPS then
+					t_insert(breakdownAPS, "")
+					t_insert(breakdownAPS, s_format("^2Current attack rate (%.2f) is within effective limits", currentAPS))
+				end
+				breakdown.KineticFusilladeMaxEffectiveAPS = breakdownAPS
+			end
+
+			-- Adjust dpsMultiplier if attacking too fast
+			if currentAPS and currentAPS > maxEffectiveAPS then
+				local efficiencyRatio = maxEffectiveAPS / currentAPS
+				local originalMultiplier = skillData.dpsMultiplier or output.ProjectileCount
+				skillData.dpsMultiplier = originalMultiplier * efficiencyRatio
+			end
+		end
+	end,
+	statMap = {
+		["kinetic_fusillade_damage_+%_final_per_projectile_fired"] = {
+			skill("KineticFusilladeSequentialDamage", nil),
+		},
+		["quality_display_kinetic_fusillade_is_gem"] = {
+		},
+	},
 #mods
 
 #skill KineticRain

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -2309,42 +2309,42 @@ local skills, mod, flag, skill = ...
 		end
 	end,
 	postCritFunc = function(activeSkill, output, breakdown)
-		if activeSkill.skillPart == 2 then
-			local skillData = activeSkill.skillData
-			local t_insert = table.insert
-			local s_format = string.format
+		local skillData = activeSkill.skillData
+		local t_insert = table.insert
+		local s_format = string.format
 
-			-- Calculate effective attack rate accounting for delayed projectile firing
-			-- Projectiles orbit for base_skill_effect_duration before firing
-			-- Recasting resets the timer, so attacking too fast wastes potential damage
-			local baseDuration = skillData.duration
-			local actualDuration = output.Duration or baseDuration
-			local ticksNeeded = math.ceil(actualDuration / data.misc.ServerTickTime)
-			local effectiveDelay = ticksNeeded * data.misc.ServerTickTime
-			local maxEffectiveAPS = 1 / effectiveDelay
-			local currentAPS = output.Speed
+		-- Calculate effective attack rate accounting for delayed projectile firing
+		-- Projectiles orbit for base_skill_effect_duration before firing
+		-- Recasting resets the timer, so attacking too fast wastes potential damage
+		local baseDuration = skillData.duration
+		local actualDuration = output.Duration or baseDuration
+		local ticksNeeded = math.ceil(actualDuration / data.misc.ServerTickTime)
+		local effectiveDelay = ticksNeeded * data.misc.ServerTickTime
+		local maxEffectiveAPS = 1 / effectiveDelay
+		local currentAPS = output.Speed
 
-			output.KineticFusilladeMaxEffectiveAPS = maxEffectiveAPS
+		output.KineticFusilladeMaxEffectiveAPS = maxEffectiveAPS
 
-			if breakdown then
-				local breakdownAPS = {}
-				t_insert(breakdownAPS, s_format("^8Projectiles orbit for %.3fs before firing", actualDuration))
-				t_insert(breakdownAPS, s_format("^8Server tick time:^7 %.3fs", data.misc.ServerTickTime))
-				t_insert(breakdownAPS, s_format("^8Ticks needed:^7 %d ^8(rounded up)", ticksNeeded))
-				t_insert(breakdownAPS, s_format("^8Effective delay:^7 %.3fs", effectiveDelay))
-				t_insert(breakdownAPS, s_format("^8Max effective attack rate:^7 1 / %.3f = %.2f", effectiveDelay, maxEffectiveAPS))
-				if currentAPS and currentAPS > maxEffectiveAPS then
-					t_insert(breakdownAPS, "")
-					t_insert(breakdownAPS, s_format("^1Current attack rate (%.2f) exceeds max effective rate!", currentAPS))
-					t_insert(breakdownAPS, s_format("^1DPS is reduced by %.1f%%", (1 - maxEffectiveAPS / currentAPS) * 100))
-				elseif currentAPS then
-					t_insert(breakdownAPS, "")
-					t_insert(breakdownAPS, s_format("^2Current attack rate (%.2f) is within effective limits", currentAPS))
-				end
-				breakdown.KineticFusilladeMaxEffectiveAPS = breakdownAPS
+		if breakdown then
+			local breakdownAPS = {}
+			t_insert(breakdownAPS, s_format("^8Projectiles orbit for %.3fs before firing", actualDuration))
+			t_insert(breakdownAPS, s_format("^8Server tick time:^7 %.3fs", data.misc.ServerTickTime))
+			t_insert(breakdownAPS, s_format("^8Ticks needed:^7 %d ^8(rounded up)", ticksNeeded))
+			t_insert(breakdownAPS, s_format("^8Effective delay:^7 %.3fs", effectiveDelay))
+			t_insert(breakdownAPS, s_format("^8Max effective attack rate:^7 1 / %.3f = %.2f", effectiveDelay, maxEffectiveAPS))
+			if currentAPS and currentAPS > maxEffectiveAPS then
+				t_insert(breakdownAPS, "")
+				t_insert(breakdownAPS, s_format("^1Current attack rate (%.2f) exceeds max effective rate!", currentAPS))
+				t_insert(breakdownAPS, s_format("^1DPS is reduced by %.1f%%", (1 - maxEffectiveAPS / currentAPS) * 100))
+			elseif currentAPS then
+				t_insert(breakdownAPS, "")
+				t_insert(breakdownAPS, s_format("^2Current attack rate (%.2f) is within effective limits", currentAPS))
 			end
+			breakdown.KineticFusilladeMaxEffectiveAPS = breakdownAPS
+		end
 
-			-- Adjust dpsMultiplier if attacking too fast
+		-- Adjust dpsMultiplier if attacking too fast (only for "All Projectiles" mode)
+		if activeSkill.skillPart == 2 then
 			if currentAPS and currentAPS > maxEffectiveAPS then
 				local efficiencyRatio = maxEffectiveAPS / currentAPS
 				local originalMultiplier = skillData.dpsMultiplier or output.ProjectileCount

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -737,6 +737,8 @@ return {
 	{ label = "Normal Hits/Cast", haveOutput = "NormalHitsPerCast", { format = "{3:output:NormalHitsPerCast}", { breakdown = "NormalHitsPerCast" }, }, },
 	{ label = "Super Hits/Cast", haveOutput = "SuperchargedHitsPerCast", { format = "{3:output:SuperchargedHitsPerCast}", { breakdown = "SuperchargedHitsPerCast" }, }, },
 	{ label = "DPS Multiplier", haveOutput = "SkillDPSMultiplier", { format = "{3:output:SkillDPSMultiplier}", { breakdown = "SkillDPSMultiplier" }, }, },
+	{ label = "Average Seq More", haveOutput = "KineticFusilladeAvgMoreMult", { format = "{1:output:KineticFusilladeAvgMoreMult}%", { breakdown = "KineticFusilladeSequentialBreakdown" }, }, },
+	{ label = "Max Effective APS", haveOutput = "KineticFusilladeMaxEffectiveAPS", { format = "{2:output:KineticFusilladeMaxEffectiveAPS}", { breakdown = "KineticFusilladeMaxEffectiveAPS" }, }, },
 	-- Traps
 	{ label = "Avg. Active Traps", haveOutput = "AverageActiveTraps", { format = "{2:output:AverageActiveTraps}", { breakdown = "AverageActiveTraps" }, }, },
 	{ label = "Active Trap Limit", flag = "trap", { format = "{0:output:ActiveTrapLimit}", { modName = "ActiveTrapLimit", cfg = "skill" }, }, },


### PR DESCRIPTION
### Description of the problem being solved:

Kinetic Fusillade is not well supported by PoB at the moment yet it is becoming a more popular skill. Better support for this particular skill should increase user satisfaction.

For reference [Neversink](https://www.youtube.com/watch?v=7Y-rGKMoV4c) and [Mathil](https://www.youtube.com/watch?v=-4QbSVG8f_0) are playing this skill and `0.4%` of poe.ninja players are using this skill.

So, I've added support for the `Projectiles deal (3-8)% more Damage per previous Projectile fired in sequence` mod as well as support for "Effective DPS" calculations which take into account skill duration (rounded to server tick) and attack rate. This is visible within the `Calcs` tab.

The modes are currently: `1 Projectile` and `All Projectiles`.

We want `1 Projectile` mode because this skill is not guaranteed to layer all projectiles onto a single enemy. In fact, it specifically states it will _try_ to not target a single enemy (although the inherent chain might eventually mean the boss does get hit by all projectiles with other enemies nearby). Without a single projectile breakdown it would be very difficult for the average user to reverse engineer the actual damage of a single projectile as you would have to "undo" the sequential damage multiplier.

The `All Projectiles` mode is special because it needs to consider the `Projectiles deal (3-8)% more Damage per previous Projectile fired in sequence` mod.

### Steps taken to verify a working solution:
- Start with a blank build
- Add a wand
- Add Kinetic Fusillade
- Visit Calc tab
- Check `1 Projectile` mode has sane and correct calculations
- Add GMP or Greater Volley or some other source of +proj
- Check `All Projectiles` mode to see it properly considers projectile count and duration modifiers.

### Link to a build that showcases this PR:

- No Duration stuff: https://pobb.in/iXM1GEjz962N
- Medium amounts of duration investment: https://pobb.in/LAXNIm3oLXaq
- Enough duration to exceed effective attack rate (dps isn't limited by skill's duration anymore): https://pobb.in/K9AOdebJ8IAD

For any of those PoBs, check out `All Projectiles` mode which does some linear algebra to calculate DPS considering the `Projectiles deal (3-8)% more Damage per previous Projectile fired in sequence` mod (which is now fully supported).

### Before screenshot:

<img width="234" height="228" alt="image" src="https://github.com/user-attachments/assets/4615918f-c701-4281-b744-6ba52880a002" />

### After screenshot:

Using `All Projectiles` mode:

<img width="584" height="381" alt="image" src="https://github.com/user-attachments/assets/5f9880a9-0eed-4c2e-ac1e-55e9eb7feffb" />

Now, allocating less duration stuff on the tree or gear can properly showcase in-game dps increases or decreases:

<img width="813" height="360" alt="image" src="https://github.com/user-attachments/assets/324d6346-86b9-421f-8cd5-9455c48f5948" />

