### PR TITLE
Fix Rune Daggers not counting as different weapon type for Mastery

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1438,6 +1438,7 @@ function ItemClass:BuildModListForSlotNum(baseList, slotNum)
 		local weaponData = { }
 		self.weaponData[slotNum] = weaponData
 		weaponData.type = self.base.type
+		weaponData.subType = self.base.subType
 		weaponData.name = self.name
 		weaponData.AttackSpeedInc = calcLocal(modList, "Speed", "INC", ModFlag.Attack) + m_floor(self.quality / 8 * calcLocal(modList, "AlternateQualityLocalAttackSpeedPer8Quality", "INC", 0))
 		weaponData.AttackRate = round(self.base.weapon.AttackRateBase * (1 + weaponData.AttackSpeedInc / 100), 2)

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -3344,7 +3344,7 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 	if base.weapon then
 		-- Weapon-specific info
 		local weaponData = item.weaponData[slotNum]
-		tooltip:AddLine(fontSizeBig, s_format("^x7F7F7F%s", self.build.data.weaponTypeInfo[base.type].label or base.type), "FONTIN SC")
+		tooltip:AddLine(fontSizeBig, s_format("^x7F7F7F%s", self.build.data.weaponTypeInfo[base.type].label or base.subType or base.type), "FONTIN SC")
 		if item.quality > 0 then
 			tooltip:AddLine(fontSizeBig, s_format("^x7F7F7FQuality: "..colorCodes.MAGIC.."+%d%%", item.quality), "FONTIN SC")
 		end

--- a/src/Data/Bases/dagger.lua
+++ b/src/Data/Bases/dagger.lua
@@ -144,7 +144,7 @@ itemBases["Ethereal Blade"] = {
 
 itemBases["Carving Knife"] = {
 	type = "Dagger",
-	subType = "Rune",
+	subType = "Rune Dagger",
 	socketLimit = 3,
 	tags = { dagger = true, default = true, one_hand_weapon = true, onehand = true, weapon = true, },
 	influenceTags = { shaper = "rune_dagger_shaper", elder = "rune_dagger_elder", adjudicator = "rune_dagger_adjudicator", basilisk = "rune_dagger_basilisk", crusader = "rune_dagger_crusader", eyrie = "rune_dagger_eyrie", cleansing = "rune_dagger_cleansing", tangle = "rune_dagger_tangle" },
@@ -155,7 +155,7 @@ itemBases["Carving Knife"] = {
 }
 itemBases["Boot Knife"] = {
 	type = "Dagger",
-	subType = "Rune",
+	subType = "Rune Dagger",
 	socketLimit = 3,
 	tags = { dagger = true, default = true, one_hand_weapon = true, onehand = true, weapon = true, },
 	influenceTags = { shaper = "rune_dagger_shaper", elder = "rune_dagger_elder", adjudicator = "rune_dagger_adjudicator", basilisk = "rune_dagger_basilisk", crusader = "rune_dagger_crusader", eyrie = "rune_dagger_eyrie", cleansing = "rune_dagger_cleansing", tangle = "rune_dagger_tangle" },
@@ -166,7 +166,7 @@ itemBases["Boot Knife"] = {
 }
 itemBases["Copper Kris"] = {
 	type = "Dagger",
-	subType = "Rune",
+	subType = "Rune Dagger",
 	socketLimit = 3,
 	tags = { dagger = true, default = true, one_hand_weapon = true, onehand = true, weapon = true, },
 	influenceTags = { shaper = "rune_dagger_shaper", elder = "rune_dagger_elder", adjudicator = "rune_dagger_adjudicator", basilisk = "rune_dagger_basilisk", crusader = "rune_dagger_crusader", eyrie = "rune_dagger_eyrie", cleansing = "rune_dagger_cleansing", tangle = "rune_dagger_tangle" },
@@ -177,7 +177,7 @@ itemBases["Copper Kris"] = {
 }
 itemBases["Skean"] = {
 	type = "Dagger",
-	subType = "Rune",
+	subType = "Rune Dagger",
 	socketLimit = 3,
 	tags = { dagger = true, default = true, one_hand_weapon = true, onehand = true, weapon = true, },
 	influenceTags = { shaper = "rune_dagger_shaper", elder = "rune_dagger_elder", adjudicator = "rune_dagger_adjudicator", basilisk = "rune_dagger_basilisk", crusader = "rune_dagger_crusader", eyrie = "rune_dagger_eyrie", cleansing = "rune_dagger_cleansing", tangle = "rune_dagger_tangle" },
@@ -188,7 +188,7 @@ itemBases["Skean"] = {
 }
 itemBases["Imp Dagger"] = {
 	type = "Dagger",
-	subType = "Rune",
+	subType = "Rune Dagger",
 	socketLimit = 3,
 	tags = { dagger = true, default = true, one_hand_weapon = true, onehand = true, weapon = true, },
 	influenceTags = { shaper = "rune_dagger_shaper", elder = "rune_dagger_elder", adjudicator = "rune_dagger_adjudicator", basilisk = "rune_dagger_basilisk", crusader = "rune_dagger_crusader", eyrie = "rune_dagger_eyrie", cleansing = "rune_dagger_cleansing", tangle = "rune_dagger_tangle" },
@@ -199,7 +199,7 @@ itemBases["Imp Dagger"] = {
 }
 itemBases["Butcher Knife"] = {
 	type = "Dagger",
-	subType = "Rune",
+	subType = "Rune Dagger",
 	socketLimit = 3,
 	tags = { dagger = true, default = true, one_hand_weapon = true, onehand = true, weapon = true, },
 	influenceTags = { shaper = "rune_dagger_shaper", elder = "rune_dagger_elder", adjudicator = "rune_dagger_adjudicator", basilisk = "rune_dagger_basilisk", crusader = "rune_dagger_crusader", eyrie = "rune_dagger_eyrie", cleansing = "rune_dagger_cleansing", tangle = "rune_dagger_tangle" },
@@ -210,7 +210,7 @@ itemBases["Butcher Knife"] = {
 }
 itemBases["Boot Blade"] = {
 	type = "Dagger",
-	subType = "Rune",
+	subType = "Rune Dagger",
 	socketLimit = 3,
 	tags = { dagger = true, default = true, one_hand_weapon = true, onehand = true, weapon = true, },
 	influenceTags = { shaper = "rune_dagger_shaper", elder = "rune_dagger_elder", adjudicator = "rune_dagger_adjudicator", basilisk = "rune_dagger_basilisk", crusader = "rune_dagger_crusader", eyrie = "rune_dagger_eyrie", cleansing = "rune_dagger_cleansing", tangle = "rune_dagger_tangle" },
@@ -221,7 +221,7 @@ itemBases["Boot Blade"] = {
 }
 itemBases["Golden Kris"] = {
 	type = "Dagger",
-	subType = "Rune",
+	subType = "Rune Dagger",
 	socketLimit = 3,
 	tags = { dagger = true, default = true, one_hand_weapon = true, onehand = true, weapon = true, },
 	influenceTags = { shaper = "rune_dagger_shaper", elder = "rune_dagger_elder", adjudicator = "rune_dagger_adjudicator", basilisk = "rune_dagger_basilisk", crusader = "rune_dagger_crusader", eyrie = "rune_dagger_eyrie", cleansing = "rune_dagger_cleansing", tangle = "rune_dagger_tangle" },
@@ -232,7 +232,7 @@ itemBases["Golden Kris"] = {
 }
 itemBases["Royal Skean"] = {
 	type = "Dagger",
-	subType = "Rune",
+	subType = "Rune Dagger",
 	socketLimit = 3,
 	tags = { dagger = true, default = true, one_hand_weapon = true, onehand = true, weapon = true, },
 	influenceTags = { shaper = "rune_dagger_shaper", elder = "rune_dagger_elder", adjudicator = "rune_dagger_adjudicator", basilisk = "rune_dagger_basilisk", crusader = "rune_dagger_crusader", eyrie = "rune_dagger_eyrie", cleansing = "rune_dagger_cleansing", tangle = "rune_dagger_tangle" },
@@ -243,7 +243,7 @@ itemBases["Royal Skean"] = {
 }
 itemBases["Fiend Dagger"] = {
 	type = "Dagger",
-	subType = "Rune",
+	subType = "Rune Dagger",
 	socketLimit = 3,
 	tags = { dagger = true, default = true, one_hand_weapon = true, onehand = true, weapon = true, },
 	influenceTags = { shaper = "rune_dagger_shaper", elder = "rune_dagger_elder", adjudicator = "rune_dagger_adjudicator", basilisk = "rune_dagger_basilisk", crusader = "rune_dagger_crusader", eyrie = "rune_dagger_eyrie", cleansing = "rune_dagger_cleansing", tangle = "rune_dagger_tangle" },
@@ -254,7 +254,7 @@ itemBases["Fiend Dagger"] = {
 }
 itemBases["Slaughter Knife"] = {
 	type = "Dagger",
-	subType = "Rune",
+	subType = "Rune Dagger",
 	socketLimit = 3,
 	tags = { dagger = true, default = true, one_hand_weapon = true, onehand = true, weapon = true, },
 	influenceTags = { shaper = "rune_dagger_shaper", elder = "rune_dagger_elder", adjudicator = "rune_dagger_adjudicator", basilisk = "rune_dagger_basilisk", crusader = "rune_dagger_crusader", eyrie = "rune_dagger_eyrie", cleansing = "rune_dagger_cleansing", tangle = "rune_dagger_tangle" },
@@ -265,7 +265,7 @@ itemBases["Slaughter Knife"] = {
 }
 itemBases["Ezomyte Dagger"] = {
 	type = "Dagger",
-	subType = "Rune",
+	subType = "Rune Dagger",
 	socketLimit = 3,
 	tags = { dagger = true, default = true, one_hand_weapon = true, onehand = true, top_tier_base_item_type = true, weapon = true, },
 	influenceTags = { shaper = "rune_dagger_shaper", elder = "rune_dagger_elder", adjudicator = "rune_dagger_adjudicator", basilisk = "rune_dagger_basilisk", crusader = "rune_dagger_crusader", eyrie = "rune_dagger_eyrie", cleansing = "rune_dagger_cleansing", tangle = "rune_dagger_tangle" },
@@ -276,7 +276,7 @@ itemBases["Ezomyte Dagger"] = {
 }
 itemBases["Platinum Kris"] = {
 	type = "Dagger",
-	subType = "Rune",
+	subType = "Rune Dagger",
 	socketLimit = 3,
 	tags = { dagger = true, default = true, one_hand_weapon = true, onehand = true, top_tier_base_item_type = true, weapon = true, },
 	influenceTags = { shaper = "rune_dagger_shaper", elder = "rune_dagger_elder", adjudicator = "rune_dagger_adjudicator", basilisk = "rune_dagger_basilisk", crusader = "rune_dagger_crusader", eyrie = "rune_dagger_eyrie", cleansing = "rune_dagger_cleansing", tangle = "rune_dagger_tangle" },
@@ -287,7 +287,7 @@ itemBases["Platinum Kris"] = {
 }
 itemBases["Imperial Skean"] = {
 	type = "Dagger",
-	subType = "Rune",
+	subType = "Rune Dagger",
 	socketLimit = 3,
 	tags = { dagger = true, default = true, one_hand_weapon = true, onehand = true, top_tier_base_item_type = true, weapon = true, },
 	influenceTags = { shaper = "rune_dagger_shaper", elder = "rune_dagger_elder", adjudicator = "rune_dagger_adjudicator", basilisk = "rune_dagger_basilisk", crusader = "rune_dagger_crusader", eyrie = "rune_dagger_eyrie", cleansing = "rune_dagger_cleansing", tangle = "rune_dagger_tangle" },
@@ -298,7 +298,7 @@ itemBases["Imperial Skean"] = {
 }
 itemBases["Demon Dagger"] = {
 	type = "Dagger",
-	subType = "Rune",
+	subType = "Rune Dagger",
 	socketLimit = 3,
 	tags = { dagger = true, default = true, one_hand_weapon = true, onehand = true, top_tier_base_item_type = true, weapon = true, },
 	influenceTags = { shaper = "rune_dagger_shaper", elder = "rune_dagger_elder", adjudicator = "rune_dagger_adjudicator", basilisk = "rune_dagger_basilisk", crusader = "rune_dagger_crusader", eyrie = "rune_dagger_eyrie", cleansing = "rune_dagger_cleansing", tangle = "rune_dagger_tangle" },
@@ -309,7 +309,7 @@ itemBases["Demon Dagger"] = {
 }
 itemBases["Flickerflame Blade"] = {
 	type = "Dagger",
-	subType = "Rune",
+	subType = "Rune Dagger",
 	socketLimit = 3,
 	tags = { dagger = true, default = true, experimental_base = true, not_for_sale = true, one_hand_weapon = true, onehand = true, weapon = true, },
 	influenceTags = { shaper = "rune_dagger_shaper", elder = "rune_dagger_elder", adjudicator = "rune_dagger_adjudicator", basilisk = "rune_dagger_basilisk", crusader = "rune_dagger_crusader", eyrie = "rune_dagger_eyrie", cleansing = "rune_dagger_cleansing", tangle = "rune_dagger_tangle" },
@@ -320,7 +320,7 @@ itemBases["Flickerflame Blade"] = {
 }
 itemBases["Flashfire Blade"] = {
 	type = "Dagger",
-	subType = "Rune",
+	subType = "Rune Dagger",
 	socketLimit = 3,
 	tags = { dagger = true, default = true, experimental_base = true, not_for_sale = true, one_hand_weapon = true, onehand = true, weapon = true, },
 	influenceTags = { shaper = "rune_dagger_shaper", elder = "rune_dagger_elder", adjudicator = "rune_dagger_adjudicator", basilisk = "rune_dagger_basilisk", crusader = "rune_dagger_crusader", eyrie = "rune_dagger_eyrie", cleansing = "rune_dagger_cleansing", tangle = "rune_dagger_tangle" },
@@ -331,7 +331,7 @@ itemBases["Flashfire Blade"] = {
 }
 itemBases["Infernal Blade"] = {
 	type = "Dagger",
-	subType = "Rune",
+	subType = "Rune Dagger",
 	socketLimit = 3,
 	tags = { dagger = true, default = true, experimental_base = true, not_for_sale = true, one_hand_weapon = true, onehand = true, weapon = true, },
 	influenceTags = { shaper = "rune_dagger_shaper", elder = "rune_dagger_elder", adjudicator = "rune_dagger_adjudicator", basilisk = "rune_dagger_basilisk", crusader = "rune_dagger_crusader", eyrie = "rune_dagger_eyrie", cleansing = "rune_dagger_cleansing", tangle = "rune_dagger_tangle" },

--- a/src/Export/Bases/dagger.txt
+++ b/src/Export/Bases/dagger.txt
@@ -7,7 +7,7 @@ local itemBases = ...
 #baseMatch BaseType Metadata/Items/Weapons/OneHandWeapons/Daggers/AbstractDagger
 
 #type Dagger
-#subType Rune
+#subType Rune Dagger
 #influenceBaseTag rune_dagger
 #socketLimit 3
 #baseMatch BaseType Metadata/Items/Weapons/OneHandWeapons/Daggers/AbstractRuneDagger

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -214,7 +214,7 @@ local function doActorAttribsConditions(env, actor)
 		if (actor.weaponData1.type == "Dagger" or actor.weaponData1.countsAsAll1H) and (actor.weaponData2.type == "Dagger" or actor.weaponData2.countsAsAll1H) then
 			condList["DualWieldingDaggers"] = true
 		end
-		if (env.data.weaponTypeInfo[actor.weaponData1.type].label or actor.weaponData1.type) ~= (env.data.weaponTypeInfo[actor.weaponData2.type].label or actor.weaponData2.type) then
+		if (env.data.weaponTypeInfo[actor.weaponData1.type].label or actor.weaponData1.subType or actor.weaponData1.type) ~= (env.data.weaponTypeInfo[actor.weaponData2.type].label or actor.weaponData2.subType or actor.weaponData2.type) then
 			local info1 = env.data.weaponTypeInfo[actor.weaponData1.type]
 			local info2 = env.data.weaponTypeInfo[actor.weaponData2.type]
 			if info1.oneHand and info2.oneHand then


### PR DESCRIPTION
Rune Daggers were not counting as different weapon types for the purpose of the Mastery that increases your damage when using 2 different weapon types
Also fixes the item tooltip to show the subtype name instead of the base type as the game shows Rune Dagger and Warstaff for those bases
