### PR TITLE
Fix Beacon of Madness explode mod disabling life from Utula's Hunger

### DIFF
--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -664,6 +664,7 @@ data.itemTagSpecialExclusionPattern = {
 		["boots"] = {
 			"Enemy's Life", -- Legacy of Fury
 			"^Enemies Cannot Leech Life", -- Sin Trek
+			'their Life as Chaos Damage', -- Beacon of Madness
 			"when on Full Life",
 			"when on Low Life",
 			"^Allocates",


### PR DESCRIPTION
Fixes #9229 .

### Description of the problem being solved:

The explode mod from the EV/ES variant of Beacon of Madness is incorrectly being parsed as a life mod for the purposes of the Utula's Hunger life mod.

The full mod from Beacon is:
 - Enemies you Kill while affected by Glorious Madness have a 40% chance to Explode, dealing a quarter of their Life as Chaos Damage

This fix uses the same approach as  #7341 .

### Steps taken to verify a working solution:
- Tested equipping Utula's Hunger with and without EV/ES Beacon of Madness Equipped
- Verified no other boot slot mods match the new pattern
- Test suite passed

### Link to a build that showcases this PR:
https://pobb.in/_7jTMFd2Wqb4


### Before screenshot:

<img width="731" height="680" alt="AAL48ED" src="https://github.com/user-attachments/assets/f6ca6b99-34db-470d-a623-89e237145607" />


### After screenshot:

<img width="731" height="680" alt="4rzYwHO" src="https://github.com/user-attachments/assets/72e0050d-2e02-4e80-b66e-2d349d87af64" />

