### PR TITLE
Fix grafts being considered as equipped items for Utula's Hunger

### DIFF
--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -631,7 +631,7 @@ function ModStoreClass:EvalMod(mod, cfg, globalLimits)
 			end
 			if tag.searchCond then
 				for slot, item in pairs(items) do
-					if (not tag.allSlots or tag.allSlots and item.type ~= "Jewel") and slot ~= itemSlot or not tag.excludeSelf then
+					if (not tag.allSlots or tag.allSlots and (item.type ~= "Jewel" and item.type ~= "Graft")) and slot ~= itemSlot or not tag.excludeSelf then
 						t_insert(matches, item:FindModifierSubstring(tag.searchCond:lower(), slot:lower()))
 					end
 				end


### PR DESCRIPTION
Fixes #9228 .

### Description of the problem being solved:

When calculating whether to apply the life bonus from Utula's Hunger, graft mods are included for consideration. However, in-game grafts with '#% increased maximum life' do not disable the Utula's mod.

I've changed the logic from #6556 to also exclude grafts.

### Steps taken to verify a working solution:
- Checked that Utula's life is applied when a graft with a life mod is equipped
- Validated that the previous jewel-excluding logic still works
- Test suite passed

### Link to a build that showcases this PR:

https://pobb.in/pCw4lcCfCNVt

### Before screenshot:
<img width="728" height="659" alt="7LEDChB" src="https://github.com/user-attachments/assets/219702e8-dd98-43ee-b522-e5fce5b7561d" />

### After screenshot:
<img width="732" height="664" alt="dxxqtfo" src="https://github.com/user-attachments/assets/48ed593f-9c85-4c7b-8c11-90e8209888ce" />
