### PR TITLE
Add support for Sunblast's additional trap mod

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -11086,8 +11086,7 @@ c["Skills used by Traps have 20% increased Area of Effect"]={{[1]={flags=0,keywo
 c["Skills used by Traps have 50% increased Area of Effect"]={{[1]={flags=0,keywordFlags=4096,name="AreaOfEffect",type="INC",value=50}},nil}
 c["Skills which Exert an Attack have 40% chance to not count that Attack"]={nil,"Skills which Exert an Attack have 40% chance to not count that Attack "}
 c["Skills which Throw Traps have +1 Cooldown Use"]={nil,"Skills which Throw Traps have +1 Cooldown Use "}
-c["Skills which Throw Traps throw up to 2 additional Traps"]={nil,"Skills which Throw Traps throw up to 2 additional Traps "}
-c["Skills which Throw Traps throw up to 2 additional Traps Traps cannot be triggered by Enemies"]={nil,"Skills which Throw Traps throw up to 2 additional Traps Traps cannot be triggered by Enemies "}
+c["Skills which Throw Traps throw up to 2 additional Traps"]={{[1]={flags=0,keywordFlags=0,name="TrapThrowCount",type="BASE",value=2}},nil}
 c["Skills which create Brands have 35% chance to create an additional Brand"]={nil,"Skills which create Brands have 35% chance to create an additional Brand "}
 c["Skills which throw Mines throw up to 1 additional Mine if you have at least 800 Dexterity"]={nil,"Skills which throw Mines throw up to 1 additional Mine if you have at least 800 Dexterity "}
 c["Skills which throw Mines throw up to 1 additional Mine if you have at least 800 Dexterity Skills which throw Mines throw up to 1 additional Mine if you have at least 800 Intelligence"]={nil,"Skills which throw Mines throw up to 1 additional Mine if you have at least 800 Dexterity Skills which throw Mines throw up to 1 additional Mine if you have at least 800 Intelligence "}

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -4003,6 +4003,7 @@ local specialModList = {
 		mod("TrapThrowCount", "BASE", tonumber(num) * tonumber(chance) / 100.0),
 		mod("MineThrowCount", "BASE", tonumber(num) * tonumber(chance) / 100.0),
 	} end,
+	["skills which throw traps throw up to (%d+) additional traps?"] = function(num) return { mod("TrapThrowCount", "BASE", tonumber(num)) } end,
 	-- Totems
 	["can have up to (%d+) additional totems? summoned at a time"] = function(num) return { mod("ActiveTotemLimit", "BASE", num) } end,
 	["attack skills can have (%d+) additional totems? summoned at a time"] = function(num) return { mod("ActiveTotemLimit", "BASE", num, nil, 0, KeywordFlag.Attack) } end,


### PR DESCRIPTION
Adds support for parsing the 'skills which throw traps throw up to X additional traps' mod

### Description of the problem being solved:
Sunblast's unique mod "Skills which Throw Traps throw up to 2 additional Traps" was not being parsed correctly.

### Steps taken to verify a working solution:
- Equipped a trap that benefits from additional traps thrown (e.g. Lightning Trap)
- Equipped Sunblast
- Verified Avg. traps per throw increases by 2 (i.e. 1 -> 3).
- Verified other sources of additional traps still increase the avg correctly (e.g. Cluster Traps, 3 -> 5)

### Link to a build that showcases this PR:
https://pobb.in/LiBgCVh7UIem

### Before screenshot:
<img width="1764" height="806" alt="Screenshot 2025-11-11 184630" src="https://github.com/user-attachments/assets/f02debf6-5b17-47d0-9e1b-384f2337931d" />

### After screenshot:
<img width="1755" height="858" alt="Screenshot 2025-11-11 184816" src="https://github.com/user-attachments/assets/061c84d6-0390-489f-b12a-3d0f1c5705df" />
