### PR TITLE
Fix trader price overlapping slots

### DIFF
--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -487,7 +487,7 @@ Highest Weight - Displays the order retrieved from trade]]
 
 	local effective_row_count = row_count - ((scrollBarShown and #slotTables >= 19) and #slotTables-19 or 0) + 2 + 2 -- Two top menu rows, two bottom rows, slots after #19 overlap the other controls at the bottom of the pane
 	self.effective_rows_height = row_height * (effective_row_count - #slotTables + (18 - (#slotTables > 37 and 3 or 0))) -- scrollBar height, "18 - slotTables > 37" logic is fine tuning whitespace after last row
-	self.pane_height = (row_height + row_vertical_padding) * effective_row_count + 2 * pane_margins_vertical + row_height / 2
+	self.pane_height = (row_height + row_vertical_padding) * effective_row_count + 3 * pane_margins_vertical + row_height / 2
 	local pane_width = 850 + (scrollBarShown and 25 or 0)
 
 	self.controls.scrollBar = new("ScrollBarControl", {"TOPRIGHT", self.controls["StatWeightMultipliersButton"],"TOPRIGHT"}, {0, 25, 18, 0}, 50, "VERTICAL", false)


### PR DESCRIPTION
### Description of the problem being solved:
Sometimes the text is above, sometimes its behind the drop downs when a build has many jewel sockets.
### Before screenshot:
<img width="882" height="646" alt="image" src="https://github.com/user-attachments/assets/7cb2e15d-365b-4a13-adc1-a0b79b254431" />

### After screenshot:
<img width="896" height="666" alt="image" src="https://github.com/user-attachments/assets/c974ee33-c1d5-4f0c-aed9-64331b365d9c" />
