### PR TITLE
Fix Storm Cascade Trigger being affected by accuracy

### DIFF
--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -905,6 +905,7 @@ local configTable = {
 	["the surging thoughts"] = function(env)
 		if env.player.mainSkill.activeEffect.grantedEffect.name == "Storm Cascade" then
 			return {
+				triggerOnUse = true,
 				triggerSkillCond = function(env, skill)
 					return (skill.skillTypes[SkillType.Melee] or skill.skillTypes[SkillType.Attack])
 				end


### PR DESCRIPTION
Closes #9224

### Description of the problem being solved:
According to this linked issue the Storm Cascade Trigger is triggered on attack rather than hit which means it should not be affected by hit chance.

This pr simply adds the missing flag to the trigger config.

### Steps taken to verify a working solution:
- Using the build from the linked issue test whether hit cache affects trigger rate

### Link to a build that showcases this PR:
See linked issue

