### PR TITLE
Fix "Ngamahu, Flame's Advance" applying to Foiled Unique Jewels

### DIFF
--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2435,14 +2435,14 @@ local specialModList = {
 			if node and not node.conqueredBy then 
 				getSimpleConv({ "PhysicalDamage","FireDamage","ColdDamage","LightningDamage","ChaosDamage","ElementalDamage" }, (dmgType:gsub("^%l", string.upper)).."Damage", "INC", true)(node, out, data)
 			end
-		end}, {type = "ItemCondition", itemSlot = "{SlotName}", rarityCond = "UNIQUE", neg = true}),
+		end}, {type = "ItemCondition", itemSlot = "{SlotName}", rarityCond = "UNIQUE", neg = true}, {type = "ItemCondition", itemSlot = "{SlotName}", rarityCond = "RELIC", neg = true}),
 	} end,
 	["non%-unique jewels cause small and notable passive skills in a (%a+) radius to also grant %+(%d+) to (%a+)"] = function(_, radius, val, attr) return {
 		mod("ExtraJewelFunc", "LIST", {radius = (radius:gsub("^%l", string.upper)), type = "Other", func = function(node, out, data)
 		if node and not node.conqueredBy and (node.type == "Notable" or node.type == "Normal") then
 			out:NewMod(firstToUpper(attr):match("^%a%l%l"), "BASE", tonumber(val), data.modSource)
 		end
-	end}, {type = "ItemCondition", itemSlot = "{SlotName}", rarityCond = "UNIQUE", neg = true}),
+	end}, {type = "ItemCondition", itemSlot = "{SlotName}", rarityCond = "UNIQUE", neg = true}, {type = "ItemCondition", itemSlot = "{SlotName}", rarityCond = "RELIC", neg = true}),
 	} end,
 	-- Deadeye
 	["projectiles pierce all nearby targets"] = { flag("PierceAllTargets") },


### PR DESCRIPTION
Fixes #9261 

### Description of the problem being solved:
Ngamahu's mod was only accounting for unique jewels and not also foiled unique. Adding the RELIC rarity to the mod.

### Steps taken to verify a working solution:
- Verify strength is 3315 with foiled Emperor's Mastery

### Link to a build that showcases this PR:
<pre>https://pobb.in/3NS6SffXK8Bm</pre>

### Before screenshot:
<img width="1012" height="809" alt="image" src="https://github.com/user-attachments/assets/91639212-03b0-4849-bc0d-e3b9461c040d" />

### After screenshot:
<img width="1054" height="821" alt="image" src="https://github.com/user-attachments/assets/dd5c460b-29f0-4142-aa4d-a0554ebd920c" />
