### PR TITLE
Fix comparison showing for Ring 3 when Ascendancy was not allocated

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -3899,7 +3899,7 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 		-- Build sorted list of slots to compare with
 		local compareSlots = { }
 		for slotName, slot in pairs(self.slots) do
-			if self:IsItemValidForSlot(item, slotName) and not slot.inactive and (not slot.weaponSet or slot.weaponSet == (self.activeItemSet.useSecondWeaponSet and 2 or 1)) then
+			if self:IsItemValidForSlot(item, slotName) and not slot.inactive and (not slot.weaponSet or slot.weaponSet == (self.activeItemSet.useSecondWeaponSet and 2 or 1)) and slot.shown() then
 				t_insert(compareSlots, slot)
 			end
 		end


### PR DESCRIPTION
Fixes #9199 

### Description of the problem being solved:
I missed a change from PoB for PoE2 regarding Ring 3 and only comparing shown items. Adding that line in here.


### Before screenshot:
<img width="1198" height="975" alt="image" src="https://github.com/user-attachments/assets/5003b136-2ec8-4742-88b8-352ca7503358" />

### After screenshot:
<img width="1193" height="765" alt="image" src="https://github.com/user-attachments/assets/1cdea9f9-901d-44d6-881a-ff0e704624ab" />

Comparison shown with Nameless Ascendancy
<img width="1197" height="955" alt="image" src="https://github.com/user-attachments/assets/d74ca557-3d53-4178-bfe5-10d2e189908f" />
