### PR TITLE
Add QoL when comparing Anointed Amulets

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1545,7 +1545,7 @@ function ItemsTabClass:CreateDisplayItemFromRaw(itemRaw, normalise)
 		-- if the new item is an amulet and does not have an anoint and your current amulet does, apply that anoint to the new item
 		if newItem.base.type == "Amulet" and #newItem.enchantModLines == 0 and self.activeItemSet["Amulet"].selItemId > 0 then
 			local currentAnoint = self.items[self.activeItemSet["Amulet"].selItemId].enchantModLines
-			if currentAnoint and #currentAnoint == 1 then -- skip if amulet has more than one anoint e.g. Stranglegrasp
+			if currentAnoint and #currentAnoint == 1 then -- skip if amulet has more than one anoint e.g. Stranglegasp
 				newItem.enchantModLines = currentAnoint
 				newItem:BuildAndParseRaw()
 			end

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1545,7 +1545,7 @@ function ItemsTabClass:CreateDisplayItemFromRaw(itemRaw, normalise)
 		-- if the new item is an amulet and does not have an anoint and your current amulet does, apply that anoint to the new item
 		if newItem.base.type == "Amulet" and #newItem.enchantModLines == 0 and self.activeItemSet["Amulet"].selItemId > 0 then
 			local currentAnoint = self.items[self.activeItemSet["Amulet"].selItemId].enchantModLines
-			if #currentAnoint == 1 then -- skip if amulet has more than one anoint e.g. Stranglegrasp
+			if currentAnoint and #currentAnoint == 1 then -- skip if amulet has more than one anoint e.g. Stranglegrasp
 				newItem.enchantModLines = currentAnoint
 				newItem:BuildAndParseRaw()
 			end

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1542,6 +1542,14 @@ end
 function ItemsTabClass:CreateDisplayItemFromRaw(itemRaw, normalise)
 	local newItem = new("Item", itemRaw)
 	if newItem.base then
+		-- if the new item is an amulet and does not have an anoint and your current amulet does, apply that anoint to the new item
+		if newItem.base.type == "Amulet" and #newItem.enchantModLines == 0 and self.activeItemSet["Amulet"].selItemId > 0 then
+			local currentAnoint = self.items[self.activeItemSet["Amulet"].selItemId].enchantModLines
+			if #currentAnoint == 1 then -- skip if amulet has more than one anoint e.g. Stranglegrasp
+				newItem.enchantModLines = currentAnoint
+				newItem:BuildAndParseRaw()
+			end
+		end
 		if normalise then
 			newItem:NormaliseQuality()
 			newItem:BuildModList()


### PR DESCRIPTION
### Description of the problem being solved:
An idea I've had for some quality of life when comparing a new amulet when your current amulet has an anoint. This will automatically apply the same anoint to the displayItem given...
1) the new ammy does not have an anoint 
2) the current amulet has to exist, have an anoint, and have only one anoint

It saves a few clicks when comparing, with having to go to Anoint, find yours, Anoint it and then close out. For me it's a pain because the anoint on my main maxes my spell suppression so my EHP/Max Hit is heavily affected if a new amulet doesn't have the same anoint. I'd really like this, but I also understand this might be a bit too much magic in the background or too much to be automated. Whatever the case, here it is.

EDIT: Open to adding a toggle in options and maybe expand this/another PR to work with eldritch implicits on gear as well

### Steps taken to verify a working solution:
- Test new item has same anoint as current
- Test new item does not get anoints if current is Stranglegrasp for example with 2+ anoints
- Test new item does not get anoints if there is no current amulet equipped
- Test new item does not get a different anoint if it already has one
- Lastly this only works on a new displayItem that isn't already in the items list

### Link to a build that showcases this PR:
<pre>eNrNXFtv27gSfm5-hWBggV3sJrbkSy5IduHm0gRIGq-dtuc8FYxE29zSpFekkniL_vczQ10s-UpZXuD0oZWpmY_Dj-TMkCJ7_sfbhDsvNFRMiouae9SoOVT4MmBidFH79HRzeFL74_eD8x7R48fh-4hxfPP7wbtz8-z4YxISX9Pwnr5Q3o20fJABvajpMKI154XR1_j33UPvsf9UcyaEiYH0v1H9IZTRFGqsOT4nSn0kExAb-GBGzXkmImD6ovZRCkDRJBxR_Tm1sfkVbORYndEmyqciuJxjxEpTIvSYSvFA_pLhBxkslTORL4cWvTvvcTKj4UAT7Sj466LWBWLIiF6RCfwNzSE8ggoaRw2vVt-o8T4KlS6hNphSGmSS7tFawV5Ir4dD6mv2Qi9Dpi_HRPi5OtbplZV9iLhmU85omLOqvU7jdgl8reiT1IRf9QYFWlqbpaXebvQXpsfvObBojY0adyPBNC2l0pNMSVG6BQWFtcxHnMP0spLtU0XDF6LZgjFrseXkmYkS_DwQQS6lsuAeJXs0hHmoSykMqC9h6pato6TmPRtSe8lS7UgUylqzWzuuB7ZypYF3M6gP3s1OciAjbimp5w7HWyt1Rd8spO6EtsJ6kdpEnW22mal8fdvLJJsnR5536nrHjeNjb63H641nivmEP5A3Nokm4CufyDc6r6-zYayMxlqAQ1in2jxep3rDQlpe61LyYAetMZFqrdrJ-hnNxC0E-q7vR5BDzDKV1sbJY8EbRFP_DGXvhG83Iz-J0LjTXBDubFTowzzBUP_MqaXGvIpkts0Da2NLVSMqkvpmds25p9QffwB--0RTO986j9ybaUVZK1pRcAWtbUuFEiSh4hqSjk43KZWk6VrQcDQbjBnlQTnp1LBLMrVwgUhzXtuK7mJ1pUZMXrUkJV9IGNgFirI2vRCVd8puZzNdsbjdwKSQJoJCQG0T4l4o_8KUm5dT64YTGYWWHR4LWzUgDSjx-qJPg8i3C2DZyuE9hyWYbTMyLbCT81KqXa2J_-1KBiNr0kwlpTSK9g2i6RR8CI4GWwCMlZBNs1x-ctixkH6EoWw1ozGs2lcwl7auIEsU7GtZULFvCwb7Eo2Zi1tXkXXoAziLCQQBszp-kLkF8trOgQWU1WrICFquynryFSwf4y6EKicNSdE8EVprSkjFPzNr_IK4VQXXIoAEC6aCdR2LGquqeWITcKRKXRFNnCBJoj-TkBGhXbMzs1DomUJFSeiP72E8XNTyv24I58_gLKAU8c_rZn8Jnz5KTRVWiaXpj_OnkFKHpPPeR2xjFv5wJkRpCDPxQFJYUW6X6C7AljsaAHJ7St5xshGVvFZmIUTCWbeoKRivOUIGFGDbJyfNpqn23fmn_r15eDfWeqrO6vXX19ejKdFjOaRvEDmOfDmpTwEEDD5U3xjnh2hBvQt_3o-65o8BqqdI5_E-marHv3D6hAzqjemvY0MNUcgEPlxKMWSjhJP4x4DqjJisxGFBWmi63qdj8Dg0dEQ0eaYh9rAjzE4aFXQyQ3_Xg4S-vl7hGHKzvEq8m7VBoV2UX3RfGzQ9r-UWdIvBcJOq204VJ9nmFm7o0JAGA4xTlzICX0P5cBNKxz09OS1YkIT5Tc0tyOe24jZZ23BbxY5IU6Iy7GAs2c7Mkhr2uQWhqc7AlzCLDYdqk0Jzda9vGV0LgyUXTDconbSKdeF28UbTGkt9tJ2Ak9NOUQuD3Q50Z0yUGsSYxl4BDVtHUqqh2Ijxx6EJUNBZGAk2qLUyRqZZ-mtT3XGRySRJlZz3idjctsU-yGUa9sMjl8xZDd0xONmyIxeHYDZoz-uZZzXuOP6FjwP08spRMtQf6ES9n0G2kX4ZUWP52uX6z4hwpmf4-qI2JFzBqySooXLivyGSDgn4LBC7j797CBlOsh2lWrGKG1zHLez3YnWYGcdyT7Mphq_u_X0eOrEFo18cSRMLkngRR-W4Tfh4N0E0h77hPz0SombcAiN5p8EeJ1I03lH8QslUCtMeE0HjRqJQ2kZjImQfVwyiNuQ4PppoyDLWoGhiCWQiJqGAMRpHsT781rMz59PHuz8_XR88janTFS-MH3Sx95wu-HuqD5I05MzphdRxj5pHjWKRd9RZLGoeuaf5sssoBMv0AQQJmBA0cLI3rQPTM336Nzy3D4Acznym1ZnjHXz3QzIE6R9dDosnWFcrp-uHbCLF7OA7zEN19hd9haULZCxfidYhe440_fE9xPly1jhq__j1Z69x2Gz84mjpDCBrECM9PviesHDm_nAbPzlxREEJs0Jz4qWXE0-_ubD3W_PHibV0K2_Fz27j0G3_slXZtIiYst8UZgLGvhCXqcBYImxShETWN9naCtlLeFGQnPMEw5YKtcBSq9E4bDdinuKonOhxNgTROWH5VjUbhy1QwW0zZ0RwxjivYyqcmYzi9q3EAB5_K7LTbB22TixwJkSQdbYAwx7YgntTJTCWbUGclgVOTHnOGC_Hfrr6KvTAgoZX6K8FjV-bP2FPTGIvZTVspkk29zUwpXnT-nSIk045XqOBIF674aTJXwJi-t2gQl7vSFFo61romL45fMvANxu28BgzYHFqwlvqoUxf4P5jO40qBQlvq0Rzq0Rrq0R7q0Rnq8TxVomTrRKnWyXcxnaR7ay622l1t_PqbifWXcHseR0jVDFUeSvDE3hw0OV0RNT04FHM3tIANY8gbS8fQZqbI8iqdxFUaBtb0K13jM-EJTgO8FhIHVwS4YzJC4RBhwQBw6U8zIVr4cNE1maeAytsCMso9X80CRY6Yp7ArE1GktU2lyAJGr1nWIHjnkGc8d1SPgGM7vNMKWh-vCh3wDSUjTcL6psR3lO-pN8qoR-b63jO4JVM9wK0gNEugXHDifrmuCU0VhPolUD4wCGwqCpWr2u5W9kKb18d2SkzomQwSzKcfwmm1PiWUlfi5QN6sFJ9kTDpGiYr96G7H87a-4FpVXQtO4_IXfmvMnYyoH8Bo7MHjFZp19jcF42dfXmW9r6Aqnv91h66xN0Xwe2KE20XQ0qoxFlhacr3EBV3jCGl_XDZGFNCvs_EqBTbRsGrGvXcfU21Zmm_0yodcL19TaTWvoCqJ4V7M6W6r-tURmjvwVu2K1NadanTqahftv6qc7i5nzTOq9z9e3Mmu2SEpf1P1Wjartpv5Vexld39PhbflY3o7MGIZtlIuadJ4u7B9lZlD7ePhcJyN8YbUelnQfM9DJ_MpzInoEozYW5vQKbHec0Z4BfB4AX3yJ-k5LnvgdMpFUHh49ol4b6Kt7jENNIrPvXiZ7qvcXFiTSypdGhudl3f3FxfPt19vs4-JzPlf32OhkO8r5WoDKg5WGj2z5KvgbhHXnNU9Kzidxe1z4y-mpdXVBPGIUnzJedkqmjB5iLabfZ5vYBlcHLvLJC-kNAPGeaSeaDrNxoCv6P5Wwsoc89oyZzYFjy2iieerICS21x5qPi7AX7Qig_WWqDgGYQiCJbYNeVuMiV8gdy0zKYB2HD8SowfZNUKUjR-QZ5Snw2Zn8jY9Xp6JrPATXYBwALD3PEq6idFFsrx3a2idlpmw6q5LbbAalJmM76oT2ZF7aTIQjk7mF0EyIqluMXhYoF0zWmXcdy_X-jZj1KYwQ7zZi5gAfgAriM5alcEfMTDVdkbC6T5x4el2ZOV23BlrokUaDIlNm0xVyHyqnGJDa-F6wEFb1R4Y-fUFiDiEgvV9GhuXjkus-yCZClfoD8psyEhPbdfaH9aaDNJjLvtvkgWLHuKpZdVAc0X3D3YhefVq8MsHmC3QjSp7MJ8Sct2VP-kGZ4EWoFizuPYgeCUq4aAM68awhMTvo5CagXQX0pH-otJyBrN7Fx1IVinhTvqZ2ewd0aIT4rvrG7OCdpoo_-_wvM4Pl0VAOavLGPJaqyBjsQVMKJtJ8YWs1Z7kd2amITLlS1dgxg7guSu5LKPS15Ye5R1QBDLb22TxrVI2YWMW0o43oCXvBrg0mXRKmB4qSyaEhGkcI-rcvXS3QArbcA0txCu8O5aVQ7NYdhloMyu83q6qjN3G3BZ5fwj5eQ_5joCPiVnP5vptYmBDs0dirUHJ43Wf5MF6Xl98f_w-B_bBa0J</pre>

### After screenshot:

![anointAmmyQoL](https://github.com/user-attachments/assets/a59b8df7-983e-4c16-9682-6d579983e576)
