### PR TITLE
Fix buggy tooltip for Equipped Items

### DIFF
--- a/src/Classes/ItemSlotControl.lua
+++ b/src/Classes/ItemSlotControl.lua
@@ -46,7 +46,8 @@ local ItemSlotClass = newClass("ItemSlotControl", "DropDownControl", function(se
 	self.abyssalSocketList = { }
 	self.tooltipFunc = function(tooltip, mode, index, itemId)
 		local item = itemsTab.items[self.items[index]]
-		if main.popups[1] or mode == "OUT" or not item or (not self.dropped and itemsTab.selControl and itemsTab.selControl ~= self.controls.activate) then
+		-- not selControl.ListControl allows hover when All Items or Unique/Rare DB Sections are in focus
+		if main.popups[1] or mode == "OUT" or not item or (not self.dropped and itemsTab.selControl and itemsTab.selControl ~= self.controls.activate and not itemsTab.selControl.ListControl) then
 			tooltip:Clear(true)
 		elseif tooltip:CheckForUpdate(item, launch.devModeAlt, itemsTab.build.outputRevision) then
 			itemsTab:AddItemTooltip(tooltip, item, self)

--- a/src/Classes/Tooltip.lua
+++ b/src/Classes/Tooltip.lua
@@ -43,7 +43,6 @@ end
 local TooltipClass = newClass("Tooltip", function(self)
 	self.lines = { }
 	self.blocks = { }
-	self.iterate = 0
 	self:Clear()
 end)
 
@@ -78,8 +77,6 @@ function TooltipClass:CheckForUpdate(...)
 	if doUpdate or self.updateParams.notSupportedModTooltips ~= main.notSupportedModTooltips then
 		self.updateParams.notSupportedModTooltips = main.notSupportedModTooltips
 		self:Clear()
-		self.iterate = self.iterate + 1
-		ConPrintf("Iteration count: "..self.iterate)
 		return true
 	end
 end


### PR DESCRIPTION
Fixes #9036 

### Description of the problem being solved:
Equipped items don't always show tooltips, and it's possible if you've clicked on other sections of the tab, might not ever show on hover unless you interact with the dropdown and hover over possible items for the slot, if any. 

Essentially it's really buggy.

This PR smooths out most if not all of it, it's definitely more consistent. I also fixed the issue where if you've clicked on a section like the All Items or Unique Items DB etc it will still allow tooltip on hover of Equipped Items.

Tested the unsupported Options toggle save/unsave even with the full updateParams clear and didn't see anything wrong. Worst case if that full clear of the table is breaking something we can trim it down to removing index 1 or something just so it triggers the doUpdate in the Tooltip function because the tables are then not identical.

### Link to a build that showcases this PR:
<pre>eNrtHGtv4zby8_pXCAIK3GG7sS3beSFp4TjOA0g2Pju7e_dpwUh0zC4tuiKVxC3632-GlGXJL1GRe59uF-jK1Lw4nBfJUc9-fZty54VGkonw3G0eNFyHhr4IWPh87n55vPp07P76S-1sQNTkYXwRM45vfql9ONPPzgujr_cioOfu7f3gYfjoOj4nUn4mUxga-UDUdZ5IGDB17n4WIXUdIn0aBr0llBmekVBNqAjvyW8iuhbB2jgLc-P-hETEVzS6oy-Ud2MljBgqiuEtx0GYjutMCQtHwv9B1XUk4pkeUyR6purrYtKt7w0XZvThbMDJnEYjRZTzQngM1BoHDc91JIycu13QEnmml2QK_3Xr9hgXcSRVAVrzIMUazSgNttNfgA0i2h-Pqa_YC-1FTPUmJPRpMZ4FbPOgk4W-j7liM85otBUjhb8pFgQU1F6APwpF-OVgVCy2gRTKju43piYXHPS4k_Yqxu1zyBQthTIQTIqw1AysgHsx5-BoVrBDKmn0QhQrECQre09Mn1hYoJ8F8D0JSU9IZQc5oBF4uCqFMKK-gKBQlkdJzDs2pvaQpeaRIJSV5n3z6I9s4UoTfp9AQwhtdpAjEfOdkN4SVG2PN83jjPX_vgtySe-SvllA3YYWs7ikLwLdbbt8raMDr3F0cnLS9g5bnVwI6N8MtuK1jlMPHUzmkvmE35M3No2nEFgfyQ-6g6V3srSs54kKIXy8A_eKRfQdaD3BA3u0Voo2IULa4rUzIYCFN1BVdH0_hipgvp3VyVHW3Szsc0b9UwS9DX1bql_CSEfgHVl7BWMIvoW1wRPfkYQbjc1MEhe1CzBD-kzDhN3cDuWOUn9yDRoeErVdvE4uHlsqFkF3KTZP1EavjS0YhUo6OMkillQTotipaRlaQxo9z0cTRnlQDnohVo_MLNWcxd6l7i3sSqkii1pSJd9IFNjlFjuZmoepUC9E7grPK-oy0FaauqdQVQJCQG3r7UEkfsMqnVuhNY-9NFt0o6mII8tJGOCdUWsttZg9yZAGsa-s1JVuOC44bKlsNZBigaCcl0LtKkX8H5cieLbWt2ZSCiMv3yiezSCKoEUUEPi0DFeYNaEMZzYl0BL2Acx5l1dnGGB-tWWwhC3BIK0ZbLmsIBSyOmzkkr71ZJbARSwgpnfW1vQeYsYUMoHeVd8Li4BzBVsvq22RBrTczw3EKwg_wYMHub362wQN1ZGFKBEN_5hb08-BWzHohwFUWuAN1jxWMZZsHtkUoqiUl0QRR1IS-ZM7WN5z1838uiKcP4Hv61F9fnPFuKLRJbxDqlq2IKnDv5KIkVA19enOyqCHg8j4rK6PrPDps1BUoiw4uvhx9hhR6pBFJPART8uLP5wpkcB9buxKolQKwDNnSN5R7mzrNtAS-plnqXdUJJp382Ah464TioAC2c7xcaul2X44-zK80w8fJkrN5Gm9_vr6ejAjaiLG9A3yyYEvpvUZEAGBP8kfjPNPKFO9C38unrv6jyZUX1A6Mydhsm5-oUNFDPiadanjRLWiUBP40BPhmD0nOjE_RlSliklHHMUUp7gvGpOYK9dhwQJI24hPJxCTaOSE8fSJRrDf8tqwUqE-_6Mhnc7zKcmtb0fFkJVB3Bi3NmOmHEcTUMMIM4vcCd9ZIKC90oXl2bHwBRhyMY81RWDwLlZCaw1nsNg4bUY4auTVljlk3Ixw2Dw5PsmhZMuRzTi4ec0uDR7C7lzK_CxWDia3zLyxhlRWXanJFOhsxdJWU3Ch0aTHpnhQSCMaaHPoiRiyEeVje4GxYiiQ9fjkMC8sps1ixayZH7IqRjvKayapIwXnQxKW8t7VumkzUjtFmqXFtJU3NprtvCZzGwM7A1stVgocX7Jnxh_GOoPDeqep0lL_qW3m7gvqaaTV4dn8wscRRn0JCTJS13QqL-ZQjCzuQOREvHa5-ldMOFNzfH3ujgmXFFOkjtMwlrw1-QkQsPo1xB7nM0xI3bu7LPyduVgJRTRNj6bcPP8r3ArmT5gXWRWlzSaQxUCSL0yWNnPCx9spyuLQN_xnQCKU08xAQ94qYGmkhorjkkFqhrrGR6mNBgxXBEuYOrGk5lzzGyUzEephQ1HLg6DZ3DWEEkLNT51hd9ivmfjn9CZUqlpXqohwB9ZU0eTNqYObt-THBZGLw10wVnhV60VkrGhw6qBstUFEx-zt1PkzQo85bRx0_roTkP9gAxdRwA227NFgZw3G0amIn0i2kUxKAc-CTmqjeKwh8NZtx4_Ejk4dr1FLigxQ26f0b00bzpD-fuocejVYWM58hjDN2p_gJfIUMiyW6YT_HGlnQ9_-KyPWx38cf2p6__zJUcKB0tDpL-CdYQovax9PPAQwa1A7av_ksMV0FoMfm60jhJka43VwmrUvoTSGD3CwSdD-Cv_qcOZoIXB70XEzhroLwiuEaBVCtBe-j0aZt06vyDqHYr5mnK1Gy_u_cRYZ53E7a5yNdxvU_8qAVsxjGUsLQh3EXi4AFnCS3Qk-Dp5gp4B7G5ORLihPk54FuGHkNEugdKFIomV43FA-pe8QytuI0tw8bRHMnXy1a8HomouXZbK30a4Qqgz8EHyjlHI1glcWofWOFXe6T3MpIeQY73I6pdSQarsKGaP-VQrN90xm9EpmVURZmNxGQs39qKbMKqEb70Ux1Wl4qzTapX3_b1JodUG8ikuyNxPr7GFd3i1MRSUcVnb51ntdvjJnb1_BpoxJX3Eif5RibTDK82jtx9HKi9rel17LzOAaK-L9LWm7NOtmZXs83EMc2FsC9SrH1-rVQKeyDO2y9d3fsSaH-0oU5V2xUzG8V7eCfZSnraqr6FU2xerlxuF-wnGzqi72UW3sKbXsw7m8fTnXPgz1sKK77UOGdkUZ2vtS6N7KgMOqJr-PzZNXVYjWvvRaWR25k0pzR4GX6SSgI32d_43ipYY0p_v60B6f9Hm-E1CpWKh718_dLueuM8Jri-AFz3MfheDLSwsym9EwyN0A4D31V0ZfnT-EmP5bC41P_0mu24m-go1QfBxO7i5a7o47A022R7gvzZlaOIuVI1WkP4fpX131e4-3X_vpFR-T_veneDzGb08SLRiU9XshvNX4boYTyBHVp56OLzgnM0nTuekjvORuhAMQCBw_SQN97uKE9ctLqgjj0oraTXpNmqOl6dzkr1ALKH0DrUaMyjyh_huN8PA2fWtDCj_nWBfHyIKtftgoYqcrfZudI2U6x3pEqkwz4m4qeJecJ4IjdlO5nc4IX1FuMma92HjjhlYpNyhF4W3cjPpszHwDY7nqyY16Xjf5tundNPRnNHl8M2SDbD6PyWMnY1Za1R_krGjVjFnZF_XJPI9thmyQ02bWPIF0WISgXStKfU67jONt1crKfhahNnbwmxTAhuA9hJ2kESlP8AH7DBZvbCiBl0TsKVar7pwZt9IV9tbn1bTsti-YC3aP51Az_eQFes22VOej0XqzdWFQWyGRaU7ejZr0BuSQzZjlEpiLhrz6s52_BUpIOhry88_1Pxc4iQ633RfBgvVIsfqyMkHd_bsHubC_tzqZ1YZfK4p6J7ziL8nYVnTTj7AN-4tieD9ZjQh6XDUK6HjVKDyy0FdxRK0IDNeqkeHOGmSJuehBzefqXGNqefy0X_XdFExX7bvRdcuQdfy_pGNdt25IAOmrarRGKg4vQSVqp2MsJ1UglUUQsadlsmWpiZpAYL4w2xDjsp-eVSEEufzGtmjcSintXr-hhONHxoJXI7j5E7udS7CVFn6HE89IGCyoPZQp1bdrD3aWQFT3aF_i9z6ykpR93Zi4pHNWT3Z1Z_XV_5fBfwG3k8bl</pre>

### Before screenshot:
![tooltipBad](https://github.com/user-attachments/assets/3d162977-c9b6-41b1-a2f3-865e6f532d27)

### After screenshot:
![tooltipGood](https://github.com/user-attachments/assets/3bb1ea94-3898-4a6c-8e69-028e84abe347)
