### PR TITLE
Fix Baranite Preacher Ball Lightning being affected by Area damage mods

### DIFF
--- a/src/Data/Skills/spectre.lua
+++ b/src/Data/Skills/spectre.lua
@@ -4700,7 +4700,6 @@ skills["AtlasCrusaderJudgeBallLightning"] = {
 		spell = true,
 		hit = true,
 		triggerable = true,
-		area = true,
 		projectile = true,
 	},
 	constantStats = {

--- a/src/Export/Skills/spectre.txt
+++ b/src/Export/Skills/spectre.txt
@@ -738,7 +738,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill AtlasCrusaderJudgeBallLightning Ball Lightning
-#flags spell hit triggerable area projectile
+#flags spell hit triggerable projectile
 #mods
 
 #skill AtlasCruasderJudgeFadingNova Nova Spell


### PR DESCRIPTION
Fixes #2132

### Description of the problem being solved:
Ball Lightning doesn't get affected by area damage, no clue why we added this tag at the time