### PR TITLE
Fix Ring 3 visibility and Weapon Swap searching in Trader

### DIFF
--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -16,7 +16,7 @@ local m_min = math.min
 local m_ceil = math.ceil
 local s_format = string.format
 
-local baseSlots = { "Weapon 1", "Weapon 2", "Helmet", "Body Armour", "Gloves", "Boots", "Amulet", "Ring 1", "Ring 2", "Ring 3", "Belt", "Flask 1", "Flask 2", "Flask 3", "Flask 4", "Flask 5" }
+local baseSlots = { "Weapon 1", "Weapon 2", "Weapon 1 Swap", "Weapon 2 Swap", "Helmet", "Body Armour", "Gloves", "Boots", "Amulet", "Ring 1", "Ring 2", "Ring 3", "Belt", "Flask 1", "Flask 2", "Flask 3", "Flask 4", "Flask 5" }
 
 local TradeQueryClass = newClass("TradeQuery", function(self, itemsTab)
 	self.itemsTab = itemsTab
@@ -428,7 +428,9 @@ Highest Weight - Displays the order retrieved from trade]]
 	-- Individual slot rows
 	local slotTables = {}
 	for _, slotName in ipairs(baseSlots) do
-		t_insert(slotTables, { slotName = slotName })
+		if self.itemsTab.slots[slotName].shown() then
+			t_insert(slotTables, { slotName = slotName })
+		end
 		-- add abyssal sockets to slotTables if exist for this slot
 		if activeAbyssalSockets[slotName] then
 			for _, abyssalSocket in pairs(activeAbyssalSockets[slotName]) do

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -727,7 +727,7 @@ function TradeQueryGeneratorClass:StartQuery(slot, options)
 				calcNodesInsteadOfMods = true,
 			}
 		end
-	elseif slot.slotName == "Weapon 2" or slot.slotName == "Weapon 1" then
+	elseif slot.slotName:find("^Weapon %d") then
 		if existingItem then
 			if existingItem.type == "Shield" then
 				itemCategoryQueryStr = "armour.shield"


### PR DESCRIPTION
Fixes #9305 

### Description of the problem being solved:
Fixes Ring 3 showing when it shouldn't and fixes finding mods for Weapon 1 Swap and Weapon 2 Swap when searching in TradeQuery. We already have similar functionality in PoB for PoE2, no need to port over.

### Before screenshot:
<img width="1121" height="759" alt="image" src="https://github.com/user-attachments/assets/4e4aa255-750f-4d50-9abe-c5d75e00f7dc" />


### After screenshot:
<img width="1130" height="806" alt="image" src="https://github.com/user-attachments/assets/d6e18116-cf3b-41a9-9a1b-3fcb1f90ec9d" />
<img width="796" height="789" alt="image" src="https://github.com/user-attachments/assets/d30d465c-1fcc-4f8a-b941-da37fe0c3ae0" />
