### PR TITLE
Add Fortification Stats to CalcsTab

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -7212,8 +7212,6 @@ c["Allocates Arcane Blessing if you have the matching modifier on Forbidden Flam
 c["Allocates Arcane Blessing if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="arcane blessing",side="flesh"}}},nil}
 c["Allocates Aspect of Carnage if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="aspect of carnage",side="flame"}}},nil}
 c["Allocates Aspect of Carnage if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="aspect of carnage",side="flesh"}}},nil}
-c["Allocates Assassin if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="assassin",side="flame"}}},nil}
-c["Allocates Assassin if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="assassin",side="flesh"}}},nil}
 c["Allocates Assassination Style if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="assassination style",side="flame"}}},nil}
 c["Allocates Assassination Style if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="assassination style",side="flesh"}}},nil}
 c["Allocates Augury of Penitence if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="augury of penitence",side="flame"}}},nil}
@@ -7228,8 +7226,6 @@ c["Allocates Bastion of Elements if you have the matching modifier on Forbidden 
 c["Allocates Bastion of Elements if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="bastion of elements",side="flesh"}}},nil}
 c["Allocates Bastion of Hope if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="bastion of hope",side="flame"}}},nil}
 c["Allocates Bastion of Hope if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="bastion of hope",side="flesh"}}},nil}
-c["Allocates Berserker if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="berserker",side="flame"}}},nil}
-c["Allocates Berserker if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="berserker",side="flesh"}}},nil}
 c["Allocates Bomb Specialist if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="bomb specialist",side="flame"}}},nil}
 c["Allocates Bomb Specialist if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="bomb specialist",side="flesh"}}},nil}
 c["Allocates Bone Barrier if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="bone barrier",side="flame"}}},nil}
@@ -7244,10 +7240,6 @@ c["Allocates Calculated Risk if you have the matching modifier on Forbidden Flam
 c["Allocates Calculated Risk if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="calculated risk",side="flesh"}}},nil}
 c["Allocates Chain Reaction if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="chain reaction",side="flame"}}},nil}
 c["Allocates Chain Reaction if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="chain reaction",side="flesh"}}},nil}
-c["Allocates Champion if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="champion",side="flame"}}},nil}
-c["Allocates Champion if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="champion",side="flesh"}}},nil}
-c["Allocates Chieftain if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="chieftain",side="flame"}}},nil}
-c["Allocates Chieftain if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="chieftain",side="flesh"}}},nil}
 c["Allocates Commander of Darkness if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="commander of darkness",side="flame"}}},nil}
 c["Allocates Commander of Darkness if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="commander of darkness",side="flesh"}}},nil}
 c["Allocates Conviction of Power if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="conviction of power",side="flame"}}},nil}
@@ -7256,8 +7248,6 @@ c["Allocates Corpse Pact if you have the matching modifier on Forbidden Flame"]=
 c["Allocates Corpse Pact if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="corpse pact",side="flesh"}}},nil}
 c["Allocates Crave the Slaughter if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="crave the slaughter",side="flame"}}},nil}
 c["Allocates Crave the Slaughter if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="crave the slaughter",side="flesh"}}},nil}
-c["Allocates Deadeye if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="deadeye",side="flame"}}},nil}
-c["Allocates Deadeye if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="deadeye",side="flesh"}}},nil}
 c["Allocates Deathmarked if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="deathmarked",side="flame"}}},nil}
 c["Allocates Deathmarked if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="deathmarked",side="flesh"}}},nil}
 c["Allocates Defy Pain if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="defy pain",side="flame"}}},nil}
@@ -7268,8 +7258,6 @@ c["Allocates Determined Survivor if you have the matching modifier on Forbidden 
 c["Allocates Determined Survivor if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="determined survivor",side="flesh"}}},nil}
 c["Allocates Divine Guidance if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="divine guidance",side="flame"}}},nil}
 c["Allocates Divine Guidance if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="divine guidance",side="flesh"}}},nil}
-c["Allocates Elementalist if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="elementalist",side="flame"}}},nil}
-c["Allocates Elementalist if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="elementalist",side="flesh"}}},nil}
 c["Allocates Endless Hunger if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="endless hunger",side="flame"}}},nil}
 c["Allocates Endless Hunger if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="endless hunger",side="flesh"}}},nil}
 c["Allocates Endless Munitions if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="endless munitions",side="flame"}}},nil}
@@ -7302,14 +7290,10 @@ c["Allocates Fury of Nature if you have the matching modifier on Forbidden Flame
 c["Allocates Fury of Nature if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="fury of nature",side="flesh"}}},nil}
 c["Allocates Gathering Winds if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="gathering winds",side="flame"}}},nil}
 c["Allocates Gathering Winds if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="gathering winds",side="flesh"}}},nil}
-c["Allocates Gladiator if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="gladiator",side="flame"}}},nil}
-c["Allocates Gladiator if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="gladiator",side="flesh"}}},nil}
 c["Allocates Gore Dancer if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="gore dancer",side="flame"}}},nil}
 c["Allocates Gore Dancer if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="gore dancer",side="flesh"}}},nil}
 c["Allocates Gratuitous Violence if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="gratuitous violence",side="flame"}}},nil}
 c["Allocates Gratuitous Violence if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="gratuitous violence",side="flesh"}}},nil}
-c["Allocates Guardian if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="guardian",side="flame"}}},nil}
-c["Allocates Guardian if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="guardian",side="flesh"}}},nil}
 c["Allocates Harmony of Purpose if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="harmony of purpose",side="flame"}}},nil}
 c["Allocates Harmony of Purpose if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="harmony of purpose",side="flesh"}}},nil}
 c["Allocates Harness the Void if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="harness the void",side="flame"}}},nil}
@@ -7320,8 +7304,6 @@ c["Allocates Heart of Destruction if you have the matching modifier on Forbidden
 c["Allocates Heart of Destruction if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="heart of destruction",side="flesh"}}},nil}
 c["Allocates Heartstopper if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="heartstopper",side="flame"}}},nil}
 c["Allocates Heartstopper if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="heartstopper",side="flesh"}}},nil}
-c["Allocates Hierophant if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="hierophant",side="flame"}}},nil}
-c["Allocates Hierophant if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="hierophant",side="flesh"}}},nil}
 c["Allocates Hinekora, Death's Fury if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="hinekora, death's fury",side="flame"}}},nil}
 c["Allocates Hinekora, Death's Fury if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="hinekora, death's fury",side="flesh"}}},nil}
 c["Allocates Illuminated Devotion if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="illuminated devotion",side="flame"}}},nil}
@@ -7334,8 +7316,6 @@ c["Allocates Inevitable Judgement if you have the matching modifier on Forbidden
 c["Allocates Inevitable Judgement if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="inevitable judgement",side="flesh"}}},nil}
 c["Allocates Infused Toxins if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="infused toxins",side="flame"}}},nil}
 c["Allocates Infused Toxins if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="infused toxins",side="flesh"}}},nil}
-c["Allocates Inquisitor if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="inquisitor",side="flame"}}},nil}
-c["Allocates Inquisitor if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="inquisitor",side="flesh"}}},nil}
 c["Allocates Inspirational if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="inspirational",side="flame"}}},nil}
 c["Allocates Inspirational if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="inspirational",side="flesh"}}},nil}
 c["Allocates Instruments of Virtue if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="instruments of virtue",side="flame"}}},nil}
@@ -7344,8 +7324,6 @@ c["Allocates Instruments of Zeal if you have the matching modifier on Forbidden 
 c["Allocates Instruments of Zeal if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="instruments of zeal",side="flesh"}}},nil}
 c["Allocates Jagged Technique if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="jagged technique",side="flame"}}},nil}
 c["Allocates Jagged Technique if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="jagged technique",side="flesh"}}},nil}
-c["Allocates Juggernaut if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="juggernaut",side="flame"}}},nil}
-c["Allocates Juggernaut if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="juggernaut",side="flesh"}}},nil}
 c["Allocates Knife in the Back if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="knife in the back",side="flame"}}},nil}
 c["Allocates Knife in the Back if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="knife in the back",side="flesh"}}},nil}
 c["Allocates Lesson of the Seasons if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="lesson of the seasons",side="flame"}}},nil}
@@ -7388,8 +7366,6 @@ c["Allocates Nature's Boon if you have the matching modifier on Forbidden Flame"
 c["Allocates Nature's Boon if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="nature's boon",side="flesh"}}},nil}
 c["Allocates Nature's Reprisal if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="nature's reprisal",side="flame"}}},nil}
 c["Allocates Nature's Reprisal if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="nature's reprisal",side="flesh"}}},nil}
-c["Allocates Necromancer if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="necromancer",side="flame"}}},nil}
-c["Allocates Necromancer if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="necromancer",side="flesh"}}},nil}
 c["Allocates Ngamahu, Flame's Advance if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="ngamahu, flame's advance",side="flame"}}},nil}
 c["Allocates Ngamahu, Flame's Advance if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="ngamahu, flame's advance",side="flesh"}}},nil}
 c["Allocates Nine Lives if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="nine lives",side="flame"}}},nil}
@@ -7400,8 +7376,6 @@ c["Allocates Oath of Summer if you have the matching modifier on Forbidden Flame
 c["Allocates Oath of Summer if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="oath of summer",side="flesh"}}},nil}
 c["Allocates Oath of Winter if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="oath of winter",side="flame"}}},nil}
 c["Allocates Oath of Winter if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="oath of winter",side="flesh"}}},nil}
-c["Allocates Occultist if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="occultist",side="flame"}}},nil}
-c["Allocates Occultist if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="occultist",side="flesh"}}},nil}
 c["Allocates Occupying Force if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="occupying force",side="flame"}}},nil}
 c["Allocates Occupying Force if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="occupying force",side="flesh"}}},nil}
 c["Allocates One Step Ahead if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="one step ahead",side="flame"}}},nil}
@@ -7410,8 +7384,6 @@ c["Allocates Opportunistic if you have the matching modifier on Forbidden Flame"
 c["Allocates Opportunistic if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="opportunistic",side="flesh"}}},nil}
 c["Allocates Overwhelm if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="overwhelm",side="flame"}}},nil}
 c["Allocates Overwhelm if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="overwhelm",side="flesh"}}},nil}
-c["Allocates Pathfinder if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="pathfinder",side="flame"}}},nil}
-c["Allocates Pathfinder if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="pathfinder",side="flesh"}}},nil}
 c["Allocates Perfect Crime if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="perfect crime",side="flame"}}},nil}
 c["Allocates Perfect Crime if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="perfect crime",side="flesh"}}},nil}
 c["Allocates Pious Path if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="pious path",side="flame"}}},nil}
@@ -7440,8 +7412,6 @@ c["Allocates Rite of Ruin if you have the matching modifier on Forbidden Flame"]
 c["Allocates Rite of Ruin if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="rite of ruin",side="flesh"}}},nil}
 c["Allocates Ritual of Awakening if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="ritual of awakening",side="flame"}}},nil}
 c["Allocates Ritual of Awakening if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="ritual of awakening",side="flesh"}}},nil}
-c["Allocates Saboteur if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="saboteur",side="flame"}}},nil}
-c["Allocates Saboteur if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="saboteur",side="flesh"}}},nil}
 c["Allocates Sanctuary if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="sanctuary",side="flame"}}},nil}
 c["Allocates Sanctuary if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="sanctuary",side="flesh"}}},nil}
 c["Allocates Sanctuary of Thought if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="sanctuary of thought",side="flame"}}},nil}
@@ -7464,8 +7434,6 @@ c["Allocates Sign of Purpose if you have the matching modifier on Forbidden Flam
 c["Allocates Sign of Purpose if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="sign of purpose",side="flesh"}}},nil}
 c["Allocates Sione, Sun's Roar if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="sione, sun's roar",side="flame"}}},nil}
 c["Allocates Sione, Sun's Roar if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="sione, sun's roar",side="flesh"}}},nil}
-c["Allocates Slayer if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="slayer",side="flame"}}},nil}
-c["Allocates Slayer if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="slayer",side="flesh"}}},nil}
 c["Allocates Soul Drinker if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="soul drinker",side="flame"}}},nil}
 c["Allocates Soul Drinker if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="soul drinker",side="flesh"}}},nil}
 c["Allocates Spellbreaker if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="spellbreaker",side="flame"}}},nil}
@@ -7478,8 +7446,6 @@ c["Allocates Time of Need if you have the matching modifier on Forbidden Flame"]
 c["Allocates Time of Need if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="time of need",side="flesh"}}},nil}
 c["Allocates Toxic Delivery if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="toxic delivery",side="flame"}}},nil}
 c["Allocates Toxic Delivery if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="toxic delivery",side="flesh"}}},nil}
-c["Allocates Trickster if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="trickster",side="flame"}}},nil}
-c["Allocates Trickster if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="trickster",side="flesh"}}},nil}
 c["Allocates Tukohama, War's Herald if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="tukohama, war's herald",side="flame"}}},nil}
 c["Allocates Tukohama, War's Herald if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="tukohama, war's herald",side="flesh"}}},nil}
 c["Allocates Unbreakable if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="unbreakable",side="flame"}}},nil}
@@ -7520,8 +7486,6 @@ c["Allocates War Bringer if you have the matching modifier on Forbidden Flame"]=
 c["Allocates War Bringer if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="war bringer",side="flesh"}}},nil}
 c["Allocates War of Attrition if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="war of attrition",side="flame"}}},nil}
 c["Allocates War of Attrition if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="war of attrition",side="flesh"}}},nil}
-c["Allocates Warden if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="warden",side="flame"}}},nil}
-c["Allocates Warden if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="warden",side="flesh"}}},nil}
 c["Allocates Weapon Master if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="weapon master",side="flame"}}},nil}
 c["Allocates Weapon Master if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="weapon master",side="flesh"}}},nil}
 c["Allocates Wind Ward if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="wind ward",side="flame"}}},nil}
@@ -10888,44 +10852,8 @@ c["Requires Class Ranger Allocates Seasoned Hunter if you have the matching modi
 c["Requires Class Ranger Allocates Wind Ward if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Ranger Allocates Wind Ward if you have the matching modifier on Forbidden Flame "}
 c["Requires Class Ranger Allocates Wind Ward if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Ranger Allocates Wind Ward if you have the matching modifier on Forbidden Flesh "}
 c["Requires Class Scion"]={nil,"Requires Class Scion "}
-c["Requires Class Scion Allocates Assassin if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Assassin if you have the matching modifier on Forbidden Flame "}
-c["Requires Class Scion Allocates Assassin if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Assassin if you have the matching modifier on Forbidden Flesh "}
-c["Requires Class Scion Allocates Berserker if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Berserker if you have the matching modifier on Forbidden Flame "}
-c["Requires Class Scion Allocates Berserker if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Berserker if you have the matching modifier on Forbidden Flesh "}
-c["Requires Class Scion Allocates Champion if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Champion if you have the matching modifier on Forbidden Flame "}
-c["Requires Class Scion Allocates Champion if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Champion if you have the matching modifier on Forbidden Flesh "}
-c["Requires Class Scion Allocates Chieftain if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Chieftain if you have the matching modifier on Forbidden Flame "}
-c["Requires Class Scion Allocates Chieftain if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Chieftain if you have the matching modifier on Forbidden Flesh "}
-c["Requires Class Scion Allocates Deadeye if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Deadeye if you have the matching modifier on Forbidden Flame "}
-c["Requires Class Scion Allocates Deadeye if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Deadeye if you have the matching modifier on Forbidden Flesh "}
-c["Requires Class Scion Allocates Elementalist if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Elementalist if you have the matching modifier on Forbidden Flame "}
-c["Requires Class Scion Allocates Elementalist if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Elementalist if you have the matching modifier on Forbidden Flesh "}
-c["Requires Class Scion Allocates Gladiator if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Gladiator if you have the matching modifier on Forbidden Flame "}
-c["Requires Class Scion Allocates Gladiator if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Gladiator if you have the matching modifier on Forbidden Flesh "}
-c["Requires Class Scion Allocates Guardian if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Guardian if you have the matching modifier on Forbidden Flame "}
-c["Requires Class Scion Allocates Guardian if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Guardian if you have the matching modifier on Forbidden Flesh "}
-c["Requires Class Scion Allocates Hierophant if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Hierophant if you have the matching modifier on Forbidden Flame "}
-c["Requires Class Scion Allocates Hierophant if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Hierophant if you have the matching modifier on Forbidden Flesh "}
-c["Requires Class Scion Allocates Inquisitor if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Inquisitor if you have the matching modifier on Forbidden Flame "}
-c["Requires Class Scion Allocates Inquisitor if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Inquisitor if you have the matching modifier on Forbidden Flesh "}
-c["Requires Class Scion Allocates Juggernaut if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Juggernaut if you have the matching modifier on Forbidden Flame "}
-c["Requires Class Scion Allocates Juggernaut if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Juggernaut if you have the matching modifier on Forbidden Flesh "}
-c["Requires Class Scion Allocates Necromancer if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Necromancer if you have the matching modifier on Forbidden Flame "}
-c["Requires Class Scion Allocates Necromancer if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Necromancer if you have the matching modifier on Forbidden Flesh "}
-c["Requires Class Scion Allocates Occultist if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Occultist if you have the matching modifier on Forbidden Flame "}
-c["Requires Class Scion Allocates Occultist if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Occultist if you have the matching modifier on Forbidden Flesh "}
-c["Requires Class Scion Allocates Pathfinder if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Pathfinder if you have the matching modifier on Forbidden Flame "}
-c["Requires Class Scion Allocates Pathfinder if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Pathfinder if you have the matching modifier on Forbidden Flesh "}
-c["Requires Class Scion Allocates Saboteur if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Saboteur if you have the matching modifier on Forbidden Flame "}
-c["Requires Class Scion Allocates Saboteur if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Saboteur if you have the matching modifier on Forbidden Flesh "}
-c["Requires Class Scion Allocates Slayer if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Slayer if you have the matching modifier on Forbidden Flame "}
-c["Requires Class Scion Allocates Slayer if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Slayer if you have the matching modifier on Forbidden Flesh "}
-c["Requires Class Scion Allocates Trickster if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Trickster if you have the matching modifier on Forbidden Flame "}
-c["Requires Class Scion Allocates Trickster if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Trickster if you have the matching modifier on Forbidden Flesh "}
 c["Requires Class Scion Allocates Unleashed Potential if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Unleashed Potential if you have the matching modifier on Forbidden Flame "}
 c["Requires Class Scion Allocates Unleashed Potential if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Unleashed Potential if you have the matching modifier on Forbidden Flesh "}
-c["Requires Class Scion Allocates Warden if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Warden if you have the matching modifier on Forbidden Flame "}
-c["Requires Class Scion Allocates Warden if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Warden if you have the matching modifier on Forbidden Flesh "}
 c["Requires Class Shadow"]={nil,"Requires Class Shadow "}
 c["Requires Class Shadow Allocates Assassination Style if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Shadow Allocates Assassination Style if you have the matching modifier on Forbidden Flame "}
 c["Requires Class Shadow Allocates Assassination Style if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Shadow Allocates Assassination Style if you have the matching modifier on Forbidden Flesh "}

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -7212,6 +7212,8 @@ c["Allocates Arcane Blessing if you have the matching modifier on Forbidden Flam
 c["Allocates Arcane Blessing if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="arcane blessing",side="flesh"}}},nil}
 c["Allocates Aspect of Carnage if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="aspect of carnage",side="flame"}}},nil}
 c["Allocates Aspect of Carnage if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="aspect of carnage",side="flesh"}}},nil}
+c["Allocates Assassin if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="assassin",side="flame"}}},nil}
+c["Allocates Assassin if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="assassin",side="flesh"}}},nil}
 c["Allocates Assassination Style if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="assassination style",side="flame"}}},nil}
 c["Allocates Assassination Style if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="assassination style",side="flesh"}}},nil}
 c["Allocates Augury of Penitence if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="augury of penitence",side="flame"}}},nil}
@@ -7226,6 +7228,8 @@ c["Allocates Bastion of Elements if you have the matching modifier on Forbidden 
 c["Allocates Bastion of Elements if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="bastion of elements",side="flesh"}}},nil}
 c["Allocates Bastion of Hope if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="bastion of hope",side="flame"}}},nil}
 c["Allocates Bastion of Hope if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="bastion of hope",side="flesh"}}},nil}
+c["Allocates Berserker if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="berserker",side="flame"}}},nil}
+c["Allocates Berserker if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="berserker",side="flesh"}}},nil}
 c["Allocates Bomb Specialist if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="bomb specialist",side="flame"}}},nil}
 c["Allocates Bomb Specialist if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="bomb specialist",side="flesh"}}},nil}
 c["Allocates Bone Barrier if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="bone barrier",side="flame"}}},nil}
@@ -7240,6 +7244,10 @@ c["Allocates Calculated Risk if you have the matching modifier on Forbidden Flam
 c["Allocates Calculated Risk if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="calculated risk",side="flesh"}}},nil}
 c["Allocates Chain Reaction if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="chain reaction",side="flame"}}},nil}
 c["Allocates Chain Reaction if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="chain reaction",side="flesh"}}},nil}
+c["Allocates Champion if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="champion",side="flame"}}},nil}
+c["Allocates Champion if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="champion",side="flesh"}}},nil}
+c["Allocates Chieftain if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="chieftain",side="flame"}}},nil}
+c["Allocates Chieftain if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="chieftain",side="flesh"}}},nil}
 c["Allocates Commander of Darkness if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="commander of darkness",side="flame"}}},nil}
 c["Allocates Commander of Darkness if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="commander of darkness",side="flesh"}}},nil}
 c["Allocates Conviction of Power if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="conviction of power",side="flame"}}},nil}
@@ -7248,6 +7256,8 @@ c["Allocates Corpse Pact if you have the matching modifier on Forbidden Flame"]=
 c["Allocates Corpse Pact if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="corpse pact",side="flesh"}}},nil}
 c["Allocates Crave the Slaughter if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="crave the slaughter",side="flame"}}},nil}
 c["Allocates Crave the Slaughter if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="crave the slaughter",side="flesh"}}},nil}
+c["Allocates Deadeye if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="deadeye",side="flame"}}},nil}
+c["Allocates Deadeye if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="deadeye",side="flesh"}}},nil}
 c["Allocates Deathmarked if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="deathmarked",side="flame"}}},nil}
 c["Allocates Deathmarked if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="deathmarked",side="flesh"}}},nil}
 c["Allocates Defy Pain if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="defy pain",side="flame"}}},nil}
@@ -7258,6 +7268,8 @@ c["Allocates Determined Survivor if you have the matching modifier on Forbidden 
 c["Allocates Determined Survivor if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="determined survivor",side="flesh"}}},nil}
 c["Allocates Divine Guidance if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="divine guidance",side="flame"}}},nil}
 c["Allocates Divine Guidance if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="divine guidance",side="flesh"}}},nil}
+c["Allocates Elementalist if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="elementalist",side="flame"}}},nil}
+c["Allocates Elementalist if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="elementalist",side="flesh"}}},nil}
 c["Allocates Endless Hunger if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="endless hunger",side="flame"}}},nil}
 c["Allocates Endless Hunger if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="endless hunger",side="flesh"}}},nil}
 c["Allocates Endless Munitions if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="endless munitions",side="flame"}}},nil}
@@ -7290,10 +7302,14 @@ c["Allocates Fury of Nature if you have the matching modifier on Forbidden Flame
 c["Allocates Fury of Nature if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="fury of nature",side="flesh"}}},nil}
 c["Allocates Gathering Winds if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="gathering winds",side="flame"}}},nil}
 c["Allocates Gathering Winds if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="gathering winds",side="flesh"}}},nil}
+c["Allocates Gladiator if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="gladiator",side="flame"}}},nil}
+c["Allocates Gladiator if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="gladiator",side="flesh"}}},nil}
 c["Allocates Gore Dancer if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="gore dancer",side="flame"}}},nil}
 c["Allocates Gore Dancer if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="gore dancer",side="flesh"}}},nil}
 c["Allocates Gratuitous Violence if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="gratuitous violence",side="flame"}}},nil}
 c["Allocates Gratuitous Violence if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="gratuitous violence",side="flesh"}}},nil}
+c["Allocates Guardian if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="guardian",side="flame"}}},nil}
+c["Allocates Guardian if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="guardian",side="flesh"}}},nil}
 c["Allocates Harmony of Purpose if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="harmony of purpose",side="flame"}}},nil}
 c["Allocates Harmony of Purpose if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="harmony of purpose",side="flesh"}}},nil}
 c["Allocates Harness the Void if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="harness the void",side="flame"}}},nil}
@@ -7304,6 +7320,8 @@ c["Allocates Heart of Destruction if you have the matching modifier on Forbidden
 c["Allocates Heart of Destruction if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="heart of destruction",side="flesh"}}},nil}
 c["Allocates Heartstopper if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="heartstopper",side="flame"}}},nil}
 c["Allocates Heartstopper if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="heartstopper",side="flesh"}}},nil}
+c["Allocates Hierophant if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="hierophant",side="flame"}}},nil}
+c["Allocates Hierophant if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="hierophant",side="flesh"}}},nil}
 c["Allocates Hinekora, Death's Fury if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="hinekora, death's fury",side="flame"}}},nil}
 c["Allocates Hinekora, Death's Fury if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="hinekora, death's fury",side="flesh"}}},nil}
 c["Allocates Illuminated Devotion if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="illuminated devotion",side="flame"}}},nil}
@@ -7316,6 +7334,8 @@ c["Allocates Inevitable Judgement if you have the matching modifier on Forbidden
 c["Allocates Inevitable Judgement if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="inevitable judgement",side="flesh"}}},nil}
 c["Allocates Infused Toxins if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="infused toxins",side="flame"}}},nil}
 c["Allocates Infused Toxins if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="infused toxins",side="flesh"}}},nil}
+c["Allocates Inquisitor if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="inquisitor",side="flame"}}},nil}
+c["Allocates Inquisitor if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="inquisitor",side="flesh"}}},nil}
 c["Allocates Inspirational if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="inspirational",side="flame"}}},nil}
 c["Allocates Inspirational if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="inspirational",side="flesh"}}},nil}
 c["Allocates Instruments of Virtue if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="instruments of virtue",side="flame"}}},nil}
@@ -7324,6 +7344,8 @@ c["Allocates Instruments of Zeal if you have the matching modifier on Forbidden 
 c["Allocates Instruments of Zeal if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="instruments of zeal",side="flesh"}}},nil}
 c["Allocates Jagged Technique if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="jagged technique",side="flame"}}},nil}
 c["Allocates Jagged Technique if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="jagged technique",side="flesh"}}},nil}
+c["Allocates Juggernaut if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="juggernaut",side="flame"}}},nil}
+c["Allocates Juggernaut if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="juggernaut",side="flesh"}}},nil}
 c["Allocates Knife in the Back if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="knife in the back",side="flame"}}},nil}
 c["Allocates Knife in the Back if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="knife in the back",side="flesh"}}},nil}
 c["Allocates Lesson of the Seasons if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="lesson of the seasons",side="flame"}}},nil}
@@ -7366,6 +7388,8 @@ c["Allocates Nature's Boon if you have the matching modifier on Forbidden Flame"
 c["Allocates Nature's Boon if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="nature's boon",side="flesh"}}},nil}
 c["Allocates Nature's Reprisal if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="nature's reprisal",side="flame"}}},nil}
 c["Allocates Nature's Reprisal if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="nature's reprisal",side="flesh"}}},nil}
+c["Allocates Necromancer if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="necromancer",side="flame"}}},nil}
+c["Allocates Necromancer if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="necromancer",side="flesh"}}},nil}
 c["Allocates Ngamahu, Flame's Advance if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="ngamahu, flame's advance",side="flame"}}},nil}
 c["Allocates Ngamahu, Flame's Advance if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="ngamahu, flame's advance",side="flesh"}}},nil}
 c["Allocates Nine Lives if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="nine lives",side="flame"}}},nil}
@@ -7376,6 +7400,8 @@ c["Allocates Oath of Summer if you have the matching modifier on Forbidden Flame
 c["Allocates Oath of Summer if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="oath of summer",side="flesh"}}},nil}
 c["Allocates Oath of Winter if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="oath of winter",side="flame"}}},nil}
 c["Allocates Oath of Winter if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="oath of winter",side="flesh"}}},nil}
+c["Allocates Occultist if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="occultist",side="flame"}}},nil}
+c["Allocates Occultist if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="occultist",side="flesh"}}},nil}
 c["Allocates Occupying Force if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="occupying force",side="flame"}}},nil}
 c["Allocates Occupying Force if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="occupying force",side="flesh"}}},nil}
 c["Allocates One Step Ahead if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="one step ahead",side="flame"}}},nil}
@@ -7384,6 +7410,8 @@ c["Allocates Opportunistic if you have the matching modifier on Forbidden Flame"
 c["Allocates Opportunistic if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="opportunistic",side="flesh"}}},nil}
 c["Allocates Overwhelm if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="overwhelm",side="flame"}}},nil}
 c["Allocates Overwhelm if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="overwhelm",side="flesh"}}},nil}
+c["Allocates Pathfinder if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="pathfinder",side="flame"}}},nil}
+c["Allocates Pathfinder if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="pathfinder",side="flesh"}}},nil}
 c["Allocates Perfect Crime if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="perfect crime",side="flame"}}},nil}
 c["Allocates Perfect Crime if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="perfect crime",side="flesh"}}},nil}
 c["Allocates Pious Path if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="pious path",side="flame"}}},nil}
@@ -7412,6 +7440,8 @@ c["Allocates Rite of Ruin if you have the matching modifier on Forbidden Flame"]
 c["Allocates Rite of Ruin if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="rite of ruin",side="flesh"}}},nil}
 c["Allocates Ritual of Awakening if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="ritual of awakening",side="flame"}}},nil}
 c["Allocates Ritual of Awakening if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="ritual of awakening",side="flesh"}}},nil}
+c["Allocates Saboteur if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="saboteur",side="flame"}}},nil}
+c["Allocates Saboteur if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="saboteur",side="flesh"}}},nil}
 c["Allocates Sanctuary if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="sanctuary",side="flame"}}},nil}
 c["Allocates Sanctuary if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="sanctuary",side="flesh"}}},nil}
 c["Allocates Sanctuary of Thought if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="sanctuary of thought",side="flame"}}},nil}
@@ -7434,6 +7464,8 @@ c["Allocates Sign of Purpose if you have the matching modifier on Forbidden Flam
 c["Allocates Sign of Purpose if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="sign of purpose",side="flesh"}}},nil}
 c["Allocates Sione, Sun's Roar if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="sione, sun's roar",side="flame"}}},nil}
 c["Allocates Sione, Sun's Roar if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="sione, sun's roar",side="flesh"}}},nil}
+c["Allocates Slayer if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="slayer",side="flame"}}},nil}
+c["Allocates Slayer if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="slayer",side="flesh"}}},nil}
 c["Allocates Soul Drinker if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="soul drinker",side="flame"}}},nil}
 c["Allocates Soul Drinker if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="soul drinker",side="flesh"}}},nil}
 c["Allocates Spellbreaker if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="spellbreaker",side="flame"}}},nil}
@@ -7446,6 +7478,8 @@ c["Allocates Time of Need if you have the matching modifier on Forbidden Flame"]
 c["Allocates Time of Need if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="time of need",side="flesh"}}},nil}
 c["Allocates Toxic Delivery if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="toxic delivery",side="flame"}}},nil}
 c["Allocates Toxic Delivery if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="toxic delivery",side="flesh"}}},nil}
+c["Allocates Trickster if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="trickster",side="flame"}}},nil}
+c["Allocates Trickster if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="trickster",side="flesh"}}},nil}
 c["Allocates Tukohama, War's Herald if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="tukohama, war's herald",side="flame"}}},nil}
 c["Allocates Tukohama, War's Herald if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="tukohama, war's herald",side="flesh"}}},nil}
 c["Allocates Unbreakable if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="unbreakable",side="flame"}}},nil}
@@ -7486,6 +7520,8 @@ c["Allocates War Bringer if you have the matching modifier on Forbidden Flame"]=
 c["Allocates War Bringer if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="war bringer",side="flesh"}}},nil}
 c["Allocates War of Attrition if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="war of attrition",side="flame"}}},nil}
 c["Allocates War of Attrition if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="war of attrition",side="flesh"}}},nil}
+c["Allocates Warden if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="warden",side="flame"}}},nil}
+c["Allocates Warden if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="warden",side="flesh"}}},nil}
 c["Allocates Weapon Master if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="weapon master",side="flame"}}},nil}
 c["Allocates Weapon Master if you have the matching modifier on Forbidden Flesh"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="weapon master",side="flesh"}}},nil}
 c["Allocates Wind Ward if you have the matching modifier on Forbidden Flame"]={{[1]={flags=0,keywordFlags=0,name="GrantedAscendancyNode",type="LIST",value={name="wind ward",side="flame"}}},nil}
@@ -10852,8 +10888,44 @@ c["Requires Class Ranger Allocates Seasoned Hunter if you have the matching modi
 c["Requires Class Ranger Allocates Wind Ward if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Ranger Allocates Wind Ward if you have the matching modifier on Forbidden Flame "}
 c["Requires Class Ranger Allocates Wind Ward if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Ranger Allocates Wind Ward if you have the matching modifier on Forbidden Flesh "}
 c["Requires Class Scion"]={nil,"Requires Class Scion "}
+c["Requires Class Scion Allocates Assassin if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Assassin if you have the matching modifier on Forbidden Flame "}
+c["Requires Class Scion Allocates Assassin if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Assassin if you have the matching modifier on Forbidden Flesh "}
+c["Requires Class Scion Allocates Berserker if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Berserker if you have the matching modifier on Forbidden Flame "}
+c["Requires Class Scion Allocates Berserker if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Berserker if you have the matching modifier on Forbidden Flesh "}
+c["Requires Class Scion Allocates Champion if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Champion if you have the matching modifier on Forbidden Flame "}
+c["Requires Class Scion Allocates Champion if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Champion if you have the matching modifier on Forbidden Flesh "}
+c["Requires Class Scion Allocates Chieftain if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Chieftain if you have the matching modifier on Forbidden Flame "}
+c["Requires Class Scion Allocates Chieftain if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Chieftain if you have the matching modifier on Forbidden Flesh "}
+c["Requires Class Scion Allocates Deadeye if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Deadeye if you have the matching modifier on Forbidden Flame "}
+c["Requires Class Scion Allocates Deadeye if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Deadeye if you have the matching modifier on Forbidden Flesh "}
+c["Requires Class Scion Allocates Elementalist if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Elementalist if you have the matching modifier on Forbidden Flame "}
+c["Requires Class Scion Allocates Elementalist if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Elementalist if you have the matching modifier on Forbidden Flesh "}
+c["Requires Class Scion Allocates Gladiator if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Gladiator if you have the matching modifier on Forbidden Flame "}
+c["Requires Class Scion Allocates Gladiator if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Gladiator if you have the matching modifier on Forbidden Flesh "}
+c["Requires Class Scion Allocates Guardian if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Guardian if you have the matching modifier on Forbidden Flame "}
+c["Requires Class Scion Allocates Guardian if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Guardian if you have the matching modifier on Forbidden Flesh "}
+c["Requires Class Scion Allocates Hierophant if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Hierophant if you have the matching modifier on Forbidden Flame "}
+c["Requires Class Scion Allocates Hierophant if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Hierophant if you have the matching modifier on Forbidden Flesh "}
+c["Requires Class Scion Allocates Inquisitor if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Inquisitor if you have the matching modifier on Forbidden Flame "}
+c["Requires Class Scion Allocates Inquisitor if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Inquisitor if you have the matching modifier on Forbidden Flesh "}
+c["Requires Class Scion Allocates Juggernaut if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Juggernaut if you have the matching modifier on Forbidden Flame "}
+c["Requires Class Scion Allocates Juggernaut if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Juggernaut if you have the matching modifier on Forbidden Flesh "}
+c["Requires Class Scion Allocates Necromancer if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Necromancer if you have the matching modifier on Forbidden Flame "}
+c["Requires Class Scion Allocates Necromancer if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Necromancer if you have the matching modifier on Forbidden Flesh "}
+c["Requires Class Scion Allocates Occultist if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Occultist if you have the matching modifier on Forbidden Flame "}
+c["Requires Class Scion Allocates Occultist if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Occultist if you have the matching modifier on Forbidden Flesh "}
+c["Requires Class Scion Allocates Pathfinder if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Pathfinder if you have the matching modifier on Forbidden Flame "}
+c["Requires Class Scion Allocates Pathfinder if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Pathfinder if you have the matching modifier on Forbidden Flesh "}
+c["Requires Class Scion Allocates Saboteur if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Saboteur if you have the matching modifier on Forbidden Flame "}
+c["Requires Class Scion Allocates Saboteur if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Saboteur if you have the matching modifier on Forbidden Flesh "}
+c["Requires Class Scion Allocates Slayer if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Slayer if you have the matching modifier on Forbidden Flame "}
+c["Requires Class Scion Allocates Slayer if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Slayer if you have the matching modifier on Forbidden Flesh "}
+c["Requires Class Scion Allocates Trickster if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Trickster if you have the matching modifier on Forbidden Flame "}
+c["Requires Class Scion Allocates Trickster if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Trickster if you have the matching modifier on Forbidden Flesh "}
 c["Requires Class Scion Allocates Unleashed Potential if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Unleashed Potential if you have the matching modifier on Forbidden Flame "}
 c["Requires Class Scion Allocates Unleashed Potential if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Unleashed Potential if you have the matching modifier on Forbidden Flesh "}
+c["Requires Class Scion Allocates Warden if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Scion Allocates Warden if you have the matching modifier on Forbidden Flame "}
+c["Requires Class Scion Allocates Warden if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Scion Allocates Warden if you have the matching modifier on Forbidden Flesh "}
 c["Requires Class Shadow"]={nil,"Requires Class Shadow "}
 c["Requires Class Shadow Allocates Assassination Style if you have the matching modifier on Forbidden Flame"]={nil,"Requires Class Shadow Allocates Assassination Style if you have the matching modifier on Forbidden Flame "}
 c["Requires Class Shadow Allocates Assassination Style if you have the matching modifier on Forbidden Flesh"]={nil,"Requires Class Shadow Allocates Assassination Style if you have the matching modifier on Forbidden Flesh "}

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -4881,7 +4881,7 @@ c["30% increased Fire Damage if you have used a Cold Skill Recently"]={{[1]={[1]
 c["30% increased Fire Damage with Attack Skills"]={{[1]={flags=0,keywordFlags=65536,name="FireDamage",type="INC",value=30}},nil}
 c["30% increased Fire Damage with Hits and Ailments against Blinded Enemies"]={{[1]={[1]={actor="enemy",type="ActorCondition",var="Blinded"},flags=0,keywordFlags=786432,name="FireDamage",type="INC",value=30}},nil}
 c["30% increased Flask Recovery rate"]={{[1]={flags=0,keywordFlags=0,name="FlaskRecoveryRate",type="INC",value=30}},nil}
-c["30% increased Fortification Duration"]={{[1]={flags=0,keywordFlags=0,name="FortificationDuration",type="INC",value=30}},nil}
+c["30% increased Fortification Duration"]={{[1]={flags=0,keywordFlags=0,name="FortifyDuration",type="INC",value=30}},nil}
 c["30% increased Freeze Duration on Enemies"]={{[1]={flags=0,keywordFlags=0,name="EnemyFreezeDuration",type="INC",value=30}},nil}
 c["30% increased Global Accuracy Rating"]={{[1]={[1]={type="Global"},flags=0,keywordFlags=0,name="Accuracy",type="INC",value=30}},nil}
 c["30% increased Global Critical Strike Chance"]={{[1]={[1]={type="Global"},flags=0,keywordFlags=0,name="CritChance",type="INC",value=30}},nil}
@@ -5094,7 +5094,7 @@ c["35% increased Effect of your Curses"]={{[1]={flags=0,keywordFlags=0,name="Cur
 c["35% increased Elemental Damage"]={{[1]={flags=0,keywordFlags=0,name="ElementalDamage",type="INC",value=35}},nil}
 c["35% increased Elemental Damage with Hits and Ailments for each type of Elemental Ailment on Enemy"]={{[1]={[1]={actor="enemy",type="ActorCondition",var="Frozen"},flags=0,keywordFlags=786432,name="ElementalDamage",type="INC",value=35},[2]={[1]={actor="enemy",type="ActorCondition",var="Chilled"},flags=0,keywordFlags=786432,name="ElementalDamage",type="INC",value=35},[3]={[1]={actor="enemy",type="ActorCondition",var="Ignited"},flags=0,keywordFlags=786432,name="ElementalDamage",type="INC",value=35},[4]={[1]={actor="enemy",type="ActorCondition",var="Shocked"},flags=0,keywordFlags=786432,name="ElementalDamage",type="INC",value=35},[5]={[1]={actor="enemy",type="ActorCondition",var="Scorched"},flags=0,keywordFlags=786432,name="ElementalDamage",type="INC",value=35},[6]={[1]={actor="enemy",type="ActorCondition",var="Brittle"},flags=0,keywordFlags=786432,name="ElementalDamage",type="INC",value=35},[7]={[1]={actor="enemy",type="ActorCondition",var="Sapped"},flags=0,keywordFlags=786432,name="ElementalDamage",type="INC",value=35}},nil}
 c["35% increased Fire Damage"]={{[1]={flags=0,keywordFlags=0,name="FireDamage",type="INC",value=35}},nil}
-c["35% increased Fortification Duration"]={{[1]={flags=0,keywordFlags=0,name="FortificationDuration",type="INC",value=35}},nil}
+c["35% increased Fortification Duration"]={{[1]={flags=0,keywordFlags=0,name="FortifyDuration",type="INC",value=35}},nil}
 c["35% increased Global Critical Strike Chance"]={{[1]={[1]={type="Global"},flags=0,keywordFlags=0,name="CritChance",type="INC",value=35}},nil}
 c["35% increased Global maximum Energy Shield and reduced Lightning Resistance"]={{[1]={[1]={type="Global"},flags=0,keywordFlags=0,name="EnergyShield",type="INC",value=35},[2]={flags=0,keywordFlags=0,name="LightningResist",type="INC",value=-35}},nil}
 c["35% increased Life Recovery from Flasks"]={{[1]={flags=0,keywordFlags=0,name="FlaskLifeRecovery",type="INC",value=35}},nil}
@@ -5330,7 +5330,7 @@ c["40% increased Evasion Rating while Phasing"]={{[1]={[1]={type="Condition",var
 c["40% increased Evasion Rating while you have Onslaught"]={{[1]={[1]={type="Condition",var="Onslaught"},flags=0,keywordFlags=0,name="Evasion",type="INC",value=40}},nil}
 c["40% increased Fire Damage"]={{[1]={flags=0,keywordFlags=0,name="FireDamage",type="INC",value=40}},nil}
 c["40% increased Fire Damage with Hits and Ailments against Blinded Enemies"]={{[1]={[1]={actor="enemy",type="ActorCondition",var="Blinded"},flags=0,keywordFlags=786432,name="FireDamage",type="INC",value=40}},nil}
-c["40% increased Fortification Duration"]={{[1]={flags=0,keywordFlags=0,name="FortificationDuration",type="INC",value=40}},nil}
+c["40% increased Fortification Duration"]={{[1]={flags=0,keywordFlags=0,name="FortifyDuration",type="INC",value=40}},nil}
 c["40% increased Global Accuracy Rating"]={{[1]={[1]={type="Global"},flags=0,keywordFlags=0,name="Accuracy",type="INC",value=40}},nil}
 c["40% increased Global Critical Strike Chance"]={{[1]={[1]={type="Global"},flags=0,keywordFlags=0,name="CritChance",type="INC",value=40}},nil}
 c["40% increased Global Critical Strike Chance while wielding a Staff"]={{[1]={[1]={type="Global"},[2]={type="Condition",var="UsingStaff"},flags=0,keywordFlags=0,name="CritChance",type="INC",value=40}},nil}

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -663,6 +663,10 @@ return {
 ["fortify_duration_+%"] = {
 	mod("FortifyDuration", "INC", nil),
 },
+["gain_fortify_on_melee_hit_ms"] = {
+	mod("FortifyDuration", "OVERRIDE", nil),
+	div = 1000,
+},
 ["support_swift_affliction_skill_effect_and_damaging_ailment_duration_+%_final"] = {
 	mod("Duration", "MORE", nil),
 	mod("DamagingAilmentDuration", "MORE", nil),

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -617,12 +617,16 @@ local function doActorMisc(env, actor)
 			local maxStacks = modDB:Override(nil, "MaximumFortification") or modDB:Sum("BASE", skillCfg, "MaximumFortification")
 			local minStacks = m_min(modDB:Flag(nil, "Condition:HaveMaxFortification") and maxStacks or modDB:Sum("BASE", nil, "MinimumFortification"), maxStacks)
 			local stacks = m_min(modDB:Override(nil, "FortificationStacks") or (alliedFortify > 0 and alliedFortify) or (minStacks > 0 and minStacks) or maxStacks, maxStacks)
+			local duration = modDB:Sum("INC", nil, "FortificationDuration")
+			output.MaximumFortification = maxStacks
+			output.MinimumFortification = minStacks
 			output.FortificationStacks = stacks
 			output.FortificationStacksOver20 = m_min(m_max(0, stacks - 20), maxStacks - 20)
+			output.FortificationDuration = (6 + (env.player.mainSkill.skillCfg.skillName == "Vigilant Strike" and 2 or 0)) * (1 + duration / 100)
+			output.FortificationEffect = "0" -- string allows shown for Willowgift mod
 			if not modDB:Flag(nil,"Condition:NoFortificationMitigation") then
-				local effectScale = 1 + modDB:Sum("INC", nil, "BuffEffectOnSelf") / 100
-				local effect = m_floor(effectScale * stacks)
-				modDB:NewMod("DamageTakenWhenHit", "MORE", -effect, "Fortification")
+				output.FortificationEffect = stacks
+				modDB:NewMod("DamageTakenWhenHit", "MORE", -stacks, "Fortification")
 			end
 			if stacks >= maxStacks then
 				modDB:NewMod("Condition:HaveMaximumFortification", "FLAG", true, "")

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -614,15 +614,16 @@ local function doActorMisc(env, actor)
 		end
 		-- Fortify
 		if modDB:Flag(nil, "Fortified") or modDB:Sum("BASE", nil, "Multiplier:Fortification") > 0 then
+			local skillModList = actor.mainSkill.skillModList
 			local maxStacks = modDB:Override(nil, "MaximumFortification") or modDB:Sum("BASE", skillCfg, "MaximumFortification")
 			local minStacks = m_min(modDB:Flag(nil, "Condition:HaveMaxFortification") and maxStacks or modDB:Sum("BASE", nil, "MinimumFortification"), maxStacks)
 			local stacks = m_min(modDB:Override(nil, "FortificationStacks") or (alliedFortify > 0 and alliedFortify) or (minStacks > 0 and minStacks) or maxStacks, maxStacks)
-			local duration = modDB:Sum("INC", nil, "FortificationDuration")
+			local increasedDuration = skillModList:Sum("INC", nil, "FortifyDuration")
 			output.MaximumFortification = maxStacks
 			output.MinimumFortification = minStacks
 			output.FortificationStacks = stacks
 			output.FortificationStacksOver20 = m_min(m_max(0, stacks - 20), maxStacks - 20)
-			output.FortificationDuration = (6 + (env.player.mainSkill.skillCfg.skillName == "Vigilant Strike" and 2 or 0)) * (1 + duration / 100)
+			output.FortifyDuration = (skillModList:Override(nil, "FortifyDuration") or data.misc.FortifyBaseDuration) * (1 + increasedDuration / 100)
 			output.FortificationEffect = "0" -- string allows shown for Willowgift mod
 			if not modDB:Flag(nil,"Condition:NoFortificationMitigation") then
 				output.FortificationEffect = stacks

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -1740,6 +1740,11 @@ return {
 	{ label = "Exposure Effect", { format = "{1:output:ExposureEffectOnSelf}%", { modName = "ExposureEffectOnSelf" }, }, },
 	{ label = "Wither Effect", { format = "{1:output:WitherEffectOnSelf}%", { modName = "WitherEffectOnSelf" }, }, },
 	{ label = "Debuff Dur. Mult.", haveOutput = "showDebuffExpirationModifier", { format = "{1:output:DebuffExpirationModifier}%", { modName = "SelfDebuffExpirationRate" }, }, },
+} }, { defaultCollapsed = false, label = "Fortification", data = {
+	{ label = "Maximum Stacks", haveOutput = "MaximumFortification", { format = "{0:output:MaximumFortification}",  { breakdown = "MaximumFortification" }, { modName = "MaximumFortification" }, }, },
+	{ label = "Minimum Stacks", haveOutput = "MinimumFortification", { format = "{0:output:MinimumFortification}",  { breakdown = "MinimumFortification" }, { modName = "MinimumFortification" }, }, },
+	{ label = "Duration", haveOutput = "FortificationDuration", { format = "{2:output:FortificationDuration}s",  { breakdown = "FortificationDuration" }, { modName = "FortificationDuration" }, }, },
+	{ label = "Less Dmg. Taken", haveOutput = "FortificationEffect", { format = "{output:FortificationEffect}%",  { breakdown = "FortificationEffect" }, { modName = "Condition:NoFortificationMitigation" }, }, },
 } }, { defaultCollapsed = false, label = "Stun Duration", data = {
 	{ label = "Stun Avoid Chance", haveOutput = "StunAvoidChance", { format = "{0:output:StunAvoidChance}%",  { breakdown = "StunAvoidChance" }, { modName = "AvoidStun" }, }, },
 	{ label = "Stun Threshold", { format = "{0:output:StunThreshold}", { breakdown = "StunThreshold" }, { modName = { "StunThreshold", "StunThresholdManaPercent", "StunThresholdEnergyShieldPercent" } }, }, },

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -1743,7 +1743,7 @@ return {
 } }, { defaultCollapsed = false, label = "Fortification", data = {
 	{ label = "Maximum Stacks", haveOutput = "MaximumFortification", { format = "{0:output:MaximumFortification}",  { breakdown = "MaximumFortification" }, { modName = "MaximumFortification" }, }, },
 	{ label = "Minimum Stacks", haveOutput = "MinimumFortification", { format = "{0:output:MinimumFortification}",  { breakdown = "MinimumFortification" }, { modName = "MinimumFortification" }, }, },
-	{ label = "Duration", haveOutput = "FortificationDuration", { format = "{2:output:FortificationDuration}s",  { breakdown = "FortificationDuration" }, { modName = "FortificationDuration" }, }, },
+	{ label = "Duration", haveOutput = "FortifyDuration", { format = "{2:output:FortifyDuration}s",  { breakdown = "FortifyDuration" }, { modName = "FortifyDuration" }, }, },
 	{ label = "Less Dmg. Taken", haveOutput = "FortificationEffect", { format = "{output:FortificationEffect}%",  { breakdown = "FortificationEffect" }, { modName = "Condition:NoFortificationMitigation" }, }, },
 } }, { defaultCollapsed = false, label = "Stun Duration", data = {
 	{ label = "Stun Avoid Chance", haveOutput = "StunAvoidChance", { format = "{0:output:StunAvoidChance}%",  { breakdown = "StunAvoidChance" }, { modName = "AvoidStun" }, }, },

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -177,6 +177,7 @@ data.misc = { -- magic numbers
 	SuppressionChanceCap = 100,
 	SuppressionEffect = 40,
 	AvoidChanceCap = 75,
+	FortifyBaseDuration = 6,
 	ManaRegenBase = data.characterConstants["mana_regeneration_rate_per_minute_%"] / 60 / 100,
 	EnergyShieldRechargeBase = data.characterConstants["energy_shield_recharge_rate_per_minute_%"] / 60 / 100,
 	EnergyShieldRechargeBase = 0.33,

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -454,7 +454,7 @@ local modNameList = {
 	["rage effect"] = "RageEffect",
 	["maximum fortification"] = "MaximumFortification",
 	["fortification"] = "MinimumFortification",
-	["fortification duration"] = "FortificationDuration",
+	["fortification duration"] = "FortifyDuration",
 	["maximum valour"] = "MaximumValour",
 	-- Charges
 	["maximum power charge"] = "PowerChargesMax",


### PR DESCRIPTION
Fixes #8964 

### Description of the problem being solved:
Adds maximum and minimum stacks, duration, and less damage taken, which is only ever not equal to stacks when using Willowgift, to Other Defences Section of CalcsTab. Minimum stacks only ever set with Champion Ascendancy "Fortitude". Section data only shown if Fortified config is set, # of stacks > 0, or Fortitude is allocated.

Also fixing a bug where we are wrongly scaling Fortify Effect by BuffEffectOnSelf/Ichimonji as per wiki: "The buff itself grants nothing. This means increasing Buff Effect with Ichimonji has no effect on Fortification." <https://www.poewiki.net/wiki/Fortification>

### Steps taken to verify a working solution:
- Test multiple sources of maximum fortification
- Test increased Fortification duration nodes
- Test with Vigilant Strike and verify base duration is 8s instead of 6s
- Test Willowgift sets Less Damage Taken output to 0%
- Verify Ichimonji has no effect on Less Damage Taken effect

### Link to a build that showcases this PR:
<pre>eNrtHGtz2kjyc_gVU1TdVbbWYD15-Oy9wm9f2YkXnOT2vqTG0gBKhESkkR12K__9umckIUBCEnD7YeuSqkTI_Z7unu5mxqf__D5zyQsLQsf3zppqW2kS5lm-7XiTs-aHp-tWr_nPXxqnj5RP34_PI8fFn_zSeHMqnsmMOt7It74yfhP40fysqTUJp8GE8Y8JTf0z0JxTj0-Z7z3QL35w49tnzXe-xzLvHW_lveXSMHxHZ-yseRkx1wk5vJvSgFqcBffshbmDiPsPvg0APIgAg4YW8-yLJd7FlM7mIEGTuAgPyplN8uKwV4l19_D4fvjUJM_Usx0e8wXF3pw-unTBghGnnITwz1lzAPahE3ZJZ_Av0KBuBAQ6vbZh9tVeRzObx1sRz6Mg5PWxR3PG7BRBa6t9tVsM_Riwq_GYWdx5YReBw0F9z1ryK8TLgVXa_W3QD5HLnbnrsCDFUNuF9G83yKu9Itgnn1P38nG0BDWVtmLoXaXf7-ndEjyfLzUogvzk8Om5C3bdgQvi3k08h7MdkR99J_S9PfTLohaqeBG5LsRoJdghC1nwQrmzKlYxbX_27Hg7We_C913bf_XKmTxQj1744XI1VW0b6CMLIPL5CoZSgjBilg_JIouiddq6onQrcMrHL2R574xZdcha2sQIdaXZTY-rUVW42oR3E2gI-bQa5MiP3IqQPJPUFL04br6tQJqF6e-SfU_BjG30soCqWuiHd95SC8PYQi8L2OkVi_fic7FJlllG5KCr28cUUteMdl8xDU3Vun1VLdyXpovQsaj7QL87s2gG28ET_cqWDDvKFl-dTLkHuawIV1cKLXDtBGwHtAtIUrugTakfFuFp3S35y_FuoQAZWFYEtc0i41H9bRG8pN3Tt5QP1gkC33lWtbzwwQvEfpCtOorpI8YQwhVrnGeXVUVZMomjPhNvynZeE-bFDJeG6re3GuqeMWt6A1YeUs6qbQ9LeYzOVtsicCXbImCObbfQX8WoYShEzDeU1t7KraahrjwWTBajqcNcux50ItgFnVdIx2jnLHYle6-yyzNGJdSaJvlEA7vaplVXphcaZlN0cf0szSXBs5ZSC7enBwbFMGDYbL0HKO4z_C_YZbj10AbBzI-WO6ZpaluVkODVdEh2GNlhDZkdWStbWvFmmjZM5y70sFVVSbFAUtethTrgnFpfL317UtlwgkktjFX5RtF8DokEXaIqAdw7oTNwMgVTq1MB-j34c6Wwxl22OoMldGUGaeVQncsaSnVdcOuvocwSvDKLdEEfIGPMYCcQk4EHP7OVFC4ONIPZZk3X9XZP7XT7imboxcMEgZbfb8YUR18d101afEZfFgQKYudrtsvX292urvQUzewb3SYJEeORBoAAHyC6LYAqJvrRmTgu9fgG3bV2cyvdzVzhv4LRpzihCivkugw0VHdLKxbaLWDe74vK9FfAKzG48mwoFCGK13lUxshj8-TMYB8Iw0vKKbHjluAjDRywv4retf5SEy9DMfi7dlzOgktwaOSC2pKQ0cCa3sOra-q6z5DyxNqkb-P1OT0WQ0R8egoYIzTJWhaSF5LhB8Lhh5lxotaN54N3NvRATeL5Ngvhqav3-ke60umrR5rZ7alHqtHXlSNV72saPOs946hjqqp21FFMpQdvup3uUUczAQYejwylB591w1AAx1DMzpGp9HudI83oA6ahQY9zpGldRT8ydL0LfGc0BMUXMjpDqSF2rzRYDJbDSBTSc9yVASW-04WCb04_DO_Fw5sp5_Pw5Pj49fW1Pad86o_Zd9hl25Y_O54DEpimJXy9hfY4HsCf88mvl1fPX2279e4rf5qP3s3ujIdH87fu9asZfB5eDOzF2Df-M3kXOZ6nOi_fPhmAdXYmGB8nnE_lADc8lp8wLQUOmFT6xjEugVgsXCN8EFEagkuMaeTyGzb7NaKuwxdy6af-68Dl8Sv4IRhmTN2QobsECB2eLyDUr7HCWhsoIS5uVxLuaTHHZR3c3zczvO7lLNfzg1naUzYTz0HBRozHzpnhFg-JpUvFUMSxEzeLXxLHs9zIhoYpzkfJbJl52OHYyUcceg-WHAW7tXcX1LVC8QOXPqPAks-bUxCJWH7kSSFTwrGJ4km1Bob06CwOhY1M-C1rb-SG_pRArQHhjy6l9Zpkwmb4-YFxakOoH99xMNAxWulYSA1P62ReZMDncZDC37j-M3W1VVPJl2r88ni77hIxV_VrWERnvMiorGV1jp1lHaqyzqmvpRQy6q4T_xPUXd1Ic5dZgOy5xis0MhqvvK-p7qmk_j-NJpFGq8XTFiP_RcIpY_D4EXKayNMyP-OjEChOjvic5kZMtFAdXDqwd0ENYmGilQyjkMkZ7CdG574nMGRyEpyQSqKE-LIvk0SH8JovTsiHd3e_frhq3FlTZ-Z7X5zGhR-E1AnI6NUP7EZcQpyQx4ARrd1pK8tXF1EA4vDGCMoRizObpD_RGvGWAo9KI96xTshNC_42xKYwZN9OiNlr3M3mrmM5-FOt8Ucs64n6Q-39DV0yYDQEwtKkJBm8EejxofZfwms_DKUOvPrjD6iyJuxEaZs_3naUVk_5KYufNKlEdqlZRlnEntLqm9sRl9AD2w7JW7OlKj8R7pO3qt7S4LGQ1aqMqtJSV1nJ7pSI7qJIQE1paVuw1BWjydKI-GNyHo3HIfE9svCjNSCcPpHMF1GIBesHXrlATOnNjYHrOiz8O_hk-A8ygDWISdo-1H-cUMkJqf8GLUAxBBV0RABBAzVExWIfJkJL_PbTTEJsBUIrhdBLIYxSCLMUolMK0S2F6JVC9EshVKUcJMeqpyJNLpOJNG1eAnmaMnKBfQl3wJnPIexY48Z3HaiNyQ2FlO9CCmjISdEJMXpK_HwObhWPTKF-PiFqfuoYtsTfbPLQs8lDaawFpqphSN8tHV9wa6gr7zLBQOYsILJ8gHBE185S_PmtmgRuXMauwYrRHLkFWcg48GfxdhXHQwy7-NMcOW_Z9NxlGzI0IUQftYEcRDCHdTwPfPgvmPq-3XiKgm-R74SMDGYRrCGsAJ1EsFC3DHrDzHp0lOx6qI0_OJ2EJ1_YK3NdaLw-Uw4meY44-7Fq105LM4RhL9l36NBAOEI9G1aJA6Izwf1OZonE8GmPTOImmTghYbjlI5VFFlS27AlcIy81WmLMhpiuD0rSVRzyOmUiDeJWCz98CijoK5d1hVwX3SObKJNv0EkyOkbjZtFD6XFZbo2f1UIPE9DrqlfSyNtAW2o1gdJtzZP_Wsl2PRLWqyEjNyo-wfr4rxNnzBv_onbq-ivFkN5WK1dDmayl7RQlsLa6sholW1Bxyw5wsg5SQCJi3oRPt4GbWcctZhCIQSj6UVa41ltdaYlkC9LheJkMU7iKJH5GEkZMAgfIWRIQ-0lV4HhTLIC5uyCcQnbFKVhcN5GxH5ApfYEybz2LL0ujn41sdCSzdiIm7wmdnG1A6GCJ-dERFVvGUYhbxmqBZhaUWpjMLgA53mZep7DNEcqha8rbR_5f6pRE8HIWVNL9QGPrgs944nihhCAqdDV0TgbPizCE7UJWFwRTAVB-fP4wvMfBIH7Ank9JRMwQOvftRVxLrJPp1CBz7dLwK1FrYCQaFKCoOSgyaxUg6DkIt8ydFSJsEUoTZt3NijWwoKt7wSF6LoKWy8bnYQ0GQ8weal2EWu7DXF7LTqDAup-ph3FXdZd13iNyVnxlnZC5QyTsTSjXusYukqzR0Gt6xD6ZRAbFARY33576oQjVsetNQMe8dlwd3BU6hwk0c-_VrGM7mcMP4NXaPnrI_e0QsaTu6QX63rbT9_Wj_UUw9zSCtrcLdvaU4ECbln4Aj-ocatPSds2Ne6_GgSpW7VDJ_WAm1WvnmEN4hHaA7GgcygT7JjzjML5hHMo3DlFn7p9B1b1jzjyAHvVbxINV2J29TXiIKFH33UvNut1Z_YxiHiCj7OIs-5pm_01eP5Sz7V-wdmq3C-oBlq1EbjmKkt_c4yk4arOROCb3ieF51FAekxPf4yfH5D467HXbN_jymN2IB8jud9-f_XbWbKl6t9PWNVU18I8pfxCfperIT_9GsI7e7puK0u9rZl-TFwZOxekLOS3z5lGi8MwJrc_P0XiM12mBKw_EleGr6-uri6e7j1exflkUcbjisxfNnvHqqPx_eXZ1xMSxbTGKi88z4Ni7SSzfdek8zByTCqPnUELjMQr2KsAvGaeOG-ZQu3XS27fbaQk6S-hNSp_AtIGDE6PthK6-swDPB6Twm6TEddUK4khZ8PsePKWZZyt5TXg7KTk5xqGxuMywSQUv9pYRQZg8Ve5mc-qWGjeGKlhsPO2HDh1WMgrHs4FzZuGUW2Llrnpy4L3ENsnlq00a4qpwGb4E2kSW133LsGOoHKuKq8alVpVQOf7FLLoow5ZAm8jp1ZcyAimg74G9cyhduWzguHhovXRl3_mecHaImxRlk-AD5J34yG0Zwff4lXMCu0lpkHxdFVaIngQyx1biPl6JmRAmRxdx3Ww7qoDJsevKBaySbJSFzU1qpSQEzCZqcu9hO7KEyl2CeGBfYn4JlWOE5GZUif4xWE6QiOQ6ePEdu0qmWAffm6C4PHQAufB60P5k1u8L5VAU9WxpvMRQldDjoiWD_YE7eFpnPyIYcftRwMDbj8KT41k8CnKzxnC9HNlEH-bXIOnNj63ICdSu-OkBj50pyHMoO6OLuzcF-f-SjUXJW2kDSIH3o7XypfqetEY88i7BvHVJbVpJaLgtIdWmJXfeLUaTSSW-4l4lX0rQ_QlBXXCbX4DWoJTepbtl1MVfyeK7-xFcv_VfnVhOxDPLj-bUsxNq74vL_jrWg9YeiIrLVpd49zjcS0ooJ2aLDJ3T46RDPH3nQ42EpPFt8uEUKn8IHsK-4394U2-RiCn7S98bO5P4mLr8EB9UF0Kmb5JDGtzhLlsew5eteLbPxK50NVzJM6wzo97qCfosThSyzbt1uViPLrXY1HdtFsS4DA2CzVHSZSatra4UI-GNO5bcmst0w2YxymgK1cIIG7lwo33Og5-nV7U3-RhKiT5iOLCE7xnF8CHeZHg_FhkbxBOmqyDeyPLFoKKyPlKu5J7uIzpqaumqWEnFmiCaZXbA82fr66ppRpmYK9eCq_hDyqy2hNnb1JWRVi_N11ItHjgkGF1FqWr8esxm6e8Zw1-exQJmC1-5wNs-I-aOqwWNkCDpMxKEjtrv9SuYdQfr4BLWcs20iUm1UVRDryBcLS7xL0eAvC6OxmWXr4onrxui1-9UyIfJ_CX1ymTomeZ0uX2IT_goNgdC53PmLbcyG28AeDTuBV1ISiO8ZGq_IPEnSNFhZjs5PV7_VYX_BSPev4M=</pre>
### Before screenshot:
Ichi has effect on fortification effect and is affecting EHP/Max Hit
<img width="413" height="690" alt="image" src="https://github.com/user-attachments/assets/25a6b551-5645-45c0-ba72-8a4a3ed7590f" />

### After screenshot:
No EHP/Max Hit change for Ichi
<img width="407" height="622" alt="image" src="https://github.com/user-attachments/assets/10540b89-c9ae-4530-b01d-150741cb856b" />


<img width="269" height="330" alt="image" src="https://github.com/user-attachments/assets/200b5c89-5295-4c1e-a9d3-870836ebddb9" />
<img width="662" height="231" alt="image" src="https://github.com/user-attachments/assets/545e7306-89e6-4cbf-96e6-ecf7395c5c72" />
<img width="531" height="168" alt="image" src="https://github.com/user-attachments/assets/ef502335-9698-428f-b4ac-f3eef60e3540" />
<img width="507" height="168" alt="image" src="https://github.com/user-attachments/assets/d3e86c9d-c072-427a-8da1-eecb54ccb596" />
