### PR TITLE
Fix missing sourceName of Tattoo mods in CalcsTab breakdowns

### DIFF
--- a/src/Classes/CalcBreakdownControl.lua
+++ b/src/Classes/CalcBreakdownControl.lua
@@ -404,11 +404,14 @@ function CalcBreakdownClass:AddModSection(sectionData, modList)
 		elseif sourceType == "Tree" then
 			-- Modifier is from a passive node, add node name, and add node ID (used to show node location)
 			local nodeId = row.mod.source:match("Tree:(%d+)")
+			local tattooNodeId = row.mod.source:match("Tree:(%w+)")
 			if nodeId then
 				local nodeIdNumber = tonumber(nodeId)
 				local node = build.spec.nodes[nodeIdNumber] or build.spec.tree.nodes[nodeIdNumber] or build.latestTree.nodes[nodeIdNumber]
 				row.sourceName = node.dn
 				row.sourceNameNode = node
+			elseif tattooNodeId then
+				row.sourceName = build.spec.tree.tattoo.idMap[tattooNodeId]
 			end
 		elseif sourceType == "Skill" then
 			-- Extract skill name

--- a/src/Classes/PassiveTree.lua
+++ b/src/Classes/PassiveTree.lua
@@ -703,6 +703,12 @@ local PassiveTreeClass = newClass("PassiveTree", function(self, treeVersion)
 			node.sprites = { }
 		end
 
+		-- create id to dn map for calcs breakdown sourcing
+		if not self.tattoo.idMap then
+			self.tattoo.idMap = { }
+		end
+		self.tattoo.idMap[node.id] = node.dn
+
 		self:ProcessStats(node)
 	end
 


### PR DESCRIPTION
Fixes #8251

### Description of the problem being solved:
Adds tattoo name as sourceName for mods in calcs breakdowns. Created an idMap in PassiveTree at the same time we're processing all the other tattoos. No extra looping.

Runegraft sourceName already works and I couldn't track that down but I'm chalking it up to Runegrafts being Mastery nodes and not regular tree nodes. At the point of the breakdown, Runegrafts have the right Tree:nodeId whereas Tattoos have Tree:tattooId like Tree:Valako1. There are some brute force ways to make tattoos do the same as Masteries but the idMap seemed the cleanest solution I have right now.

### Link to a build that showcases this PR:
<pre>eNrVXG1z4kYS_rz8iimqriqp2IAkENhlJ-V3-2J7HfDuXj6lxmKAiYWGlUb2ktT-9-uekUCAXoFU3W2qHJD66e7pmX6ZUYuTX75NXfLG_IAL77RuNFp1wjxHDLk3Pq1_er4-7NV_-bl28kTl5OPoPOQu3vm59uFEfSYue2Puaf2oTl6oN-TytP4oPFYnjkuD4JFO2Wl94ADrOpHUHzP5OZZk_QGSppR7A-G8Mnnji3AG8uvkjbP3BzEE4N3D08f-c53QwGHe8GLJUYuYUU9OmPAe6J_CvxHDjevcW7nuTKhPHcn8e9T5LJRCi5F-yOowog8nTy6dM38gqSQB_Dmtn4Fh6Jhd0in8BdWoGwKg1Wh3rXa727ZbR1a3U2_mgs9DP5AbHHp2z2i3j0yjl81gMGNsuMAYDbuXRfnks6vRiDmSv7ELn8uLCfWcpTirYZiZUlLoW41cvRDxELqSz1zO_ISCmYjbDRHdLNJnIal7-TRIKNM96lhHBpg8x9gaJuQSlkX5hcvJuQuWrS4EoXdjj0u2HfZJ8EB42w9uBZk5O6HrgouWou2zgPlvVPI1rTJ5i-kL97Yx3QP16IUISswPUj4xH1xeVgIMmCMgSlSVURF5z0esPGWlcUSAqtpsN46rQVm6yoy3U6gP8bEc5UCEbklKuYxO2QGwz74mCbtGFuEl-7Zklyn0zpMlqC7Zm5AqLxYNQjn_1e3TMs522o221Wp1IIX0Wu3MnDCZB9yh7gP9xqfhFELwM31lXoJNL3tZjSfSgyCSiW1nir3mPssWaWZHFneYCTOzYRMqgizc0VG2_3PvFuqVM8cJoSaYLyAdOwvycTSqiEDnLGNtSPPOMRLfeU45l__k-SpwJ6uDvNkcsT54IpYjLy4rC1kKiRx6CWy18mWNmRcJnJcb0D1jzuQGJqVPJSsXvpeznG9YpC1lWCRMMWw2-1VABSMhMN1IRqObB6popiuP-eP5YMKZO6xGHSt2QWcloiyaOYkuZe5VcZVWTBJa0SRfqD8sl4uq6vRGg2Q4N47yzaXJk5YyM0PqA4NyFRBDtl6nZ-8HxJ-4G3Crwc78qQj9kjOuicuNIM5FehvUZ8PQKZf8Fruacxe2iWvjMIthoKnrpmGzbSAldV4vxXBc2mxKSCXEqn6DcDaDMIILYn2EVl6aheqdJ8qgQ6OY-COs5lJOjfl4nb9pF1OXFrCoMdaldEsiyg8Fa4R1KXYZ8tIiFvP5AOFiCmlAbd0fRCI_Z84NbNdK7b0UYck94JN4B80neOISVKOGWmp5bJCpis-8v-al-a-QlxJw5Q2hygJPKC1jHZEm5plPIZIGwSWVlATq2Omau5L5lzDXiEX-ZBhV5p-pz6knDXUotXbRVBcDRn1ncg_g03ry2zV13RcIInAVBZ801VEZfroQ3oiPCdUHNerLgElkphRcXCGSS5fhLmFEQxeWLR_GRGrsDpuAxzGfeOH0hfk4ROKpozHmsekc3fEJCuFmNsBoGe1VUJzB8kAxIOBj7n4cqYUDk4AzlAPrtVcEqeO3PPp2K6afLfJYPEV5OKu1aoWE3-egTLNtrOBWk1XuwI7sTYnFsIW4wQQW4QDzTa79OqvjSoT-KsNahM9iBTewKLIY1m2tKqrPLytMmM9lFes5AhyusvkSma08aD1bVTEeCiwelm0c9Y5WcFE1lmeKTgyYLo5j8ZyR-Wyo7HIhQshFzB3lzkL6SAsCiLWxQAoA3VWLRqWgcN0-9fJN09lYJVGZVM40WD2vho-T5iLSqvisv-HHwSt33SAK0OpLFJ8hA6hQfMOm9_qRhyf86eJ0BcL_RLxjISd8pHmez1gAxeT9PdzRl4LzOeTu6HFDgt1vIXW5nKvcs0J6jfubtTNXlHLmygiDpKf1EXWD6AFGrHGUL3T20WPCj3dTVI-wb_i_J-qjVI1WlHcS-JEwYPrc7gujM-Gp8WsiPUZIt5cc6h1I6g6OUY9HWww5JBMafocsrHImeMZKHuvDZTk_Jp8e7377dFV7njACGwPyiOtvSn1Wg4meBsIj_2bvzK3dMzoO2TE59xl1JrUoER-TJ58Rq2Eajdby2kXog3ayBisfsgcwXdwxa3065GFwTO6xTKjd8ylHAimOiVED-7jc4RJut2p_R3ofG99xf0k6_yJiRHChE712CQ3I1TfpU6LifnR1iTO__-3j0j5uNTqaxQ_2odH6sSof4_sThc3BGwvIGBhK8E0N17EIlzURPoGig1y5qvqkbuJeQECyHnWSJ8yo0PyI9iawAVE7JaK3QAvtJLH02MEwuqRKjnH_upmVdOu0snT7x-1GPcK-gifik8VIyTFOM1xflKNE16ME1vGv4IYqXsG-QMU8opYHPkHp1BMem0dhFlJYhRTxLr2J3pniplYsKstNb3zGvISjfuY-HwK2lKcadtJTq3mvtY33HphJ_8VkXNLvrDz_rcAnbR0q-P79Nz5JIOpcYWsP3lU7s6J22T5s_QPaWRW162ZHmIN_wnrItUyUIXpf_b8bYXIoOuVikJUag859DD0vjL7WvlCf3NLplPmrMcVspISZbtkoE5VXUC60aro9BWJK_xD-q6nir8--qnuJiGMmfdOEFcM9B-JfAIwHMvTIJaQDPEDAabqCMpazpL8cWN8NwPh4MAoIJJhr3PME1iTWtrVEMPqh0zrsdn5MCok3rZvRB1ZTZ0WfKIWq3VnSK9qdTCpz5RZW4ErWQPr8lUU-lFTwpx_M1qGFoRJW61rOzaRb7DySxP9PqzmHwi6k6BZS9FJ9Bqv9nJI9eXA0cAXsDADz9PKpf49nVnqHdM5cSc5e5kGAc6rWO0EHBMq74eLMLRuvpRKDDN7pbBdGN67ASLrGoV2BQ9pQjH0NpQqja5cGr9uINteldqoY0KcjScwdDWZuY7AdtD4XwznRpx27zH366tlqCtJmv72FVSpAzqahy2QFwC1zp5UA8eiWEKvCzFSeiEoLQMgq9H1MEsYeVqlRVck9LApz3_Gts-sg7D1Y0tqDIcx9uerefH735NWp7NG7cNBZZ2-52955-HubUntfjMxdvcXcl3U7O1vX2nUs1n6ytLXt5FQubfZRUKUuJXXrbggM1liJIVOp0rB7i0ce6pyL6EtbBOz2zjFh1wrPrppszaoAaw85ZR95ydzZ1nvbPuyuirWvILhzyWDsJ3DsnmDsytlxTzuTrdPArqbv7CEEWhXjx35M1tmXJ-0eQO39jMjYWZF25fVrVkbsY5Oyj93Wph76LEs_hv9w8uzTIRuoNqovDA8DA_0AWz2XVu1T1HUCffLlzUJs_fLVa4pX19dXF893n68Wz_x54PzxEo5G-IZfJEpDNluZ8On4H_pyRDlgqjtVnZ1FT9TxjLhOHOG6dBaw4fKJePgSaOrT-mfO3hX5JZOUu0EKt9tFg0sBL8XndrUdZoXTF7CSz3GXnc_o6hvz8anEgn6TlXprroQ6Whfsh8ZGujRb6fcV81npc-ULGkjVsb3JBU-Xi5ggTdpQ7qYz6hYaN6LKmGxs3cAmh6CUUSQ2esyYw0fc0ajUWY_7egtsE79csslDvbFYhNdEm2D93mEROqJKsap65bHQqpoqZX0xh86L0JpoE7zo7y9isCAUHtg7hdOVy864i4_gCmf2UXhqsYPfLCCbDB8gyOjG30KGH7EnK6bd5AQ-4fOXUBa7c4IyxVbqhaMCMyFNyljUGzX5UEWTYteVt0wKolGSNjWoFbJQNJvQuL87H6ypUqcgOuQsMH-iJW_VCPHrHwXjT_bYrjqJCq5nb4IPy0SKdfKdGarumj3ohW9B7M5m_bWIFI6qtCn0l4iqFFw3siXRnyTH58C7MUGP240DOt5uHJ6558jQT40a_fVyZBPeT69BFs35ueCYalv8opVqaw66T2JruOpyz4j_l2yk2iBLJYAF8W68sC8gbifYh1p5UaQ6M50vc4aqQ0H0pm6ZKKdJd2cE2fw2vWyswGnxps8toy7-ooNwd2O4_vJyeWYpfsocEc6oN4y5fcwu1qtYT8gAmKq3WC7xtchgJy1Vd0uCz0kz3tedPAqobJA1Xo2_wL6QMdxckb-EiLuvu7ndyEj4H3wjzmw37J4d_evqG7_jDdts2Hbihn57ZyD9-KUd1R5N6GzGvKVVhiyAzRSNigHXrZMBNmQP39B9nmEtBCsN1ah43EsOe4RFWzR-Sf6qjd4Rq7PmIDpqPjBsw-4edHo9yzqw7F7POLA6nRZ8tjqt3oFxZLTbBybcbB20ez2zF_3iTsQpUN0g1J-frQrxuIs_uhNI5s-jchS37RINvPxhHrMTNYzArl59-DCRchYcN5vv7--NGZUTMWLfuMsajpg2Z7oB7lBtpA-RVfMM_p2Pz84ubt8un-bst6vfv76Nw_6v8xv765v_DndPT5WAZiwhOoAPtLjo2-K0wEicw9u2FTfkbNCZ6-f1xXS20Y5f1cVW-YQWJ-g8Ph-yWKn4Oxmiq4UeG6tHEmJEIPCRAfegtPSpm-DdMTrtuDVem_sOnQTrSNk0L_Hvpzt1KWjeeTd0ypqfwYjwvYn8L5A_vomhLXx-05h54zrhji5FYxZqH3oHF4N4LoLmmYQpx-UXKE43ESekshUXPaYP2HU2FT6L270C3MKTdy4n5ONoBJvWoaZbdtoSg2SPXRuqGVsqzXDPVEohYuSZLybCG4ecPAjhvUNtj-EjNqDygYoGPMM4gLo8-5y6zch2aAotGWwTywSKF7aFcZdvED2Coklz_mSrTra1DtDKVnkcQzCdhKpz7p26r_gjS7FNlM_v3SaRxG0tsnwlLcMi6z2AKRZZftVHfE2Mkio9oKI_106a679B9l9cXIEh</pre>

### Before screenshot:
<img width="511" height="146" alt="image" src="https://github.com/user-attachments/assets/3e9d63be-0101-46e6-b734-36ed4897a63b" />
<img width="572" height="260" alt="image" src="https://github.com/user-attachments/assets/111916d9-36f7-4516-b5c5-9ac0e12a6f87" />

### After screenshot:
<img width="551" height="201" alt="image" src="https://github.com/user-attachments/assets/37ab1e69-8bfd-4f3c-8078-643438741676" />
<img width="631" height="222" alt="image" src="https://github.com/user-attachments/assets/220b95db-73e1-409c-9d5f-72aea340ae1f" />
