### PR TITLE
Fix using Max Unleash Seals with Vortex

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -5549,7 +5549,8 @@ function calcs.offence(env, actor, activeSkill)
 			elseif skillFlags.totem then
 				useSpeed = (output.Cooldown and output.Cooldown > 0 and (output.TotemPlacementSpeed > 0 and output.TotemPlacementSpeed or 1 / output.Cooldown) or output.TotemPlacementSpeed) / repeats
 				timeType = "totem placement"
-			elseif skillModList:Flag(nil, "HasSeals") and skillModList:Flag(nil, "UseMaxUnleash") then
+			-- nil check until ailment pass for skills like Vortex
+			elseif skillModList:Flag(nil, "HasSeals") and skillModList:Flag(nil, "UseMaxUnleash") and env.player.mainSkill.skillData.hitTimeOverride then
 				useSpeed = env.player.mainSkill.skillData.hitTimeOverride / repeats
 				timeType = "full unleash"
 			else


### PR DESCRIPTION
Fixes #9319

### Description of the problem being solved:
Vortex's ground dot doesn't get initialized/set up until much later in the ailment pass in calcOffense, so I'm adding a nil check for hitTimeOverride. It really only needs to calc for the hit portion anyways.

### Link to a build that showcases this PR:
<pre>https://pobb.in/8PAIFT2O9RaX</pre>

### After screenshot:
<img width="695" height="384" alt="image" src="https://github.com/user-attachments/assets/4d96c11f-6180-4447-84cd-a1fed7ed3c85" />
