### PR TITLE
Fix error when loading Kinetic Fusillade

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -11244,7 +11244,7 @@ skills["KineticFusillade"] = {
 		["kinetic_fusillade_damage_+%_final_per_projectile_fired"] = {
 			skill("damagePerProjectile", nil),
 		},
-		["kinetic_fusillade_base_delay_between_projectiles_ms+%_final_per_projectile_fired"] = {
+		["kinetic_fusillade_base_delay_between_projectiles_ms"] = {
 			skill("delayPerProjectile", nil),
 			div = 1000,
 		},
@@ -11253,6 +11253,7 @@ skills["KineticFusillade"] = {
 	},
 	baseFlags = {
 		attack = true,
+		projectile = true,
 		area = true,
 		duration = true,
 	},

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -2264,7 +2264,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill KineticFusillade
-#flags attack area duration
+#flags attack projectile area duration
 	parts = {
 		{
 			name = "All Projectiles",
@@ -2367,7 +2367,7 @@ local skills, mod, flag, skill = ...
 		["kinetic_fusillade_damage_+%_final_per_projectile_fired"] = {
 			skill("damagePerProjectile", nil),
 		},
-		["kinetic_fusillade_base_delay_between_projectiles_ms+%_final_per_projectile_fired"] = {
+		["kinetic_fusillade_base_delay_between_projectiles_ms"] = {
 			skill("delayPerProjectile", nil),
 			div = 1000,
 		},


### PR DESCRIPTION
Fixes #9325 .

### Description of the problem being solved:
Stat name changed and it was missing the projectile tag