### PR TITLE
Fix crash on adding support gems and importing items to many builds

### DIFF
--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -109,9 +109,11 @@ function calcs.createActiveSkill(activeEffect, supportList, actor, socketGroup, 
 
 	for index, supportEffect in ipairs(supportList) do
 		-- Pass 1: Add skill types from compatible supports
-		if calcLib.canGrantedEffectSupportActiveSkill(supportEffect.grantedEffect, activeSkill) then
-			for _, skillType in pairs(supportEffect.grantedEffect.addSkillTypes) do
-				activeSkill.skillTypes[skillType] = true
+		if supportEffect.grantedEffect.support then
+			if calcLib.canGrantedEffectSupportActiveSkill(supportEffect.grantedEffect, activeSkill) then
+				for _, skillType in pairs(supportEffect.grantedEffect.addSkillTypes) do
+					activeSkill.skillTypes[skillType] = true
+				end
 			end
 		else
 			t_insert(rejectedSupportsIndices, index)
@@ -125,11 +127,13 @@ function calcs.createActiveSkill(activeEffect, supportList, actor, socketGroup, 
 		notAddedNewSupport = true
 		for index, supportEffectIndex in ipairs(rejectedSupportsIndices) do
 			local supportEffect = supportList[supportEffectIndex]
-			if calcLib.canGrantedEffectSupportActiveSkill(supportEffect.grantedEffect, activeSkill) then
-				notAddedNewSupport = false
-				rejectedSupportsIndices[index] = nil
-				for _, skillType in pairs(supportEffect.grantedEffect.addSkillTypes) do
-					activeSkill.skillTypes[skillType] = true
+			if supportEffect.grantedEffect.support then
+				if calcLib.canGrantedEffectSupportActiveSkill(supportEffect.grantedEffect, activeSkill) then
+					notAddedNewSupport = false
+					rejectedSupportsIndices[index] = nil
+					for _, skillType in pairs(supportEffect.grantedEffect.addSkillTypes) do
+						activeSkill.skillTypes[skillType] = true
+					end
 				end
 			end
 		end
@@ -137,15 +141,17 @@ function calcs.createActiveSkill(activeEffect, supportList, actor, socketGroup, 
 	
 	for _, supportEffect in ipairs(supportList) do
 		-- Pass 2: Add all compatible supports
-		if calcLib.canGrantedEffectSupportActiveSkill(supportEffect.grantedEffect, activeSkill) then
-			t_insert(activeSkill.effectList, supportEffect)
-			if supportEffect.isSupporting and activeEffect.srcInstance then
-				supportEffect.isSupporting[activeEffect.srcInstance] = true
-			end
-			if supportEffect.grantedEffect.addFlags and not summonSkill then
-				-- Support skill adds flags to supported skills (eg. Remote Mine adds 'mine')
-				for k in pairs(supportEffect.grantedEffect.addFlags) do
-					skillFlags[k] = true
+		if supportEffect.grantedEffect.support then
+			if calcLib.canGrantedEffectSupportActiveSkill(supportEffect.grantedEffect, activeSkill) then
+				t_insert(activeSkill.effectList, supportEffect)
+				if supportEffect.isSupporting and activeEffect.srcInstance then
+					supportEffect.isSupporting[activeEffect.srcInstance] = true
+				end
+				if supportEffect.grantedEffect.addFlags and not summonSkill then
+					-- Support skill adds flags to supported skills (eg. Remote Mine adds 'mine')
+					for k in pairs(supportEffect.grantedEffect.addFlags) do
+						skillFlags[k] = true
+					end
 				end
 			end
 		end

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -107,36 +107,13 @@ function calcs.createActiveSkill(activeEffect, supportList, actor, socketGroup, 
 	activeSkill.effectList = { activeEffect }
 	local rejectedSupportsIndices = {}
 
-	-- Return first compatible support grantedEffect plus a flag indicating the support has a support component
-	local function getGrantedSupportEffect(supportEffect)
-		local hasSupport = false
-		if supportEffect.gemData then
-			for _, grantedEffect in ipairs(supportEffect.gemData.grantedEffectList) do
-				if grantedEffect and grantedEffect.support then
-					hasSupport = true
-					if calcLib.canGrantedEffectSupportActiveSkill(grantedEffect, activeSkill) then
-						return grantedEffect, true
-					end
-				end
-			end
-		elseif supportEffect.grantedEffect then
-			hasSupport = true
-			if calcLib.canGrantedEffectSupportActiveSkill(supportEffect.grantedEffect, activeSkill) then
-				return supportEffect.grantedEffect, true
-			end
-		end
-		return nil, hasSupport
-	end
-
 	for index, supportEffect in ipairs(supportList) do
-		-- Loop through grantedEffectList until we find a support gem if the gem has an active and support component e.g. Autoexertion
-		local grantedSupportEffect, hasSupport = getGrantedSupportEffect(supportEffect)
-		if grantedSupportEffect then
-			-- Pass 1: Add skill types from compatible supports
-			for _, skillType in pairs(grantedSupportEffect.addSkillTypes) do
+		-- Pass 1: Add skill types from compatible supports
+		if calcLib.canGrantedEffectSupportActiveSkill(supportEffect.grantedEffect, activeSkill) then
+			for _, skillType in pairs(supportEffect.grantedEffect.addSkillTypes) do
 				activeSkill.skillTypes[skillType] = true
 			end
-		elseif hasSupport then
+		else
 			t_insert(rejectedSupportsIndices, index)
 		end
 	end
@@ -148,11 +125,10 @@ function calcs.createActiveSkill(activeEffect, supportList, actor, socketGroup, 
 		notAddedNewSupport = true
 		for index, supportEffectIndex in ipairs(rejectedSupportsIndices) do
 			local supportEffect = supportList[supportEffectIndex]
-			local grantedSupportEffect = getGrantedSupportEffect(supportEffect)
-			if grantedSupportEffect then
+			if calcLib.canGrantedEffectSupportActiveSkill(supportEffect.grantedEffect, activeSkill) then
 				notAddedNewSupport = false
 				rejectedSupportsIndices[index] = nil
-				for _, skillType in pairs(grantedSupportEffect.addSkillTypes) do
+				for _, skillType in pairs(supportEffect.grantedEffect.addSkillTypes) do
 					activeSkill.skillTypes[skillType] = true
 				end
 			end
@@ -161,15 +137,14 @@ function calcs.createActiveSkill(activeEffect, supportList, actor, socketGroup, 
 	
 	for _, supportEffect in ipairs(supportList) do
 		-- Pass 2: Add all compatible supports
-		local grantedSupportEffect = getGrantedSupportEffect(supportEffect)
-		if grantedSupportEffect then
+		if calcLib.canGrantedEffectSupportActiveSkill(supportEffect.grantedEffect, activeSkill) then
 			t_insert(activeSkill.effectList, supportEffect)
 			if supportEffect.isSupporting and activeEffect.srcInstance then
 				supportEffect.isSupporting[activeEffect.srcInstance] = true
 			end
-			if grantedSupportEffect.addFlags and not summonSkill then
+			if supportEffect.grantedEffect.addFlags and not summonSkill then
 				-- Support skill adds flags to supported skills (eg. Remote Mine adds 'mine')
-				for k in pairs(grantedSupportEffect.addFlags) do
+				for k in pairs(supportEffect.grantedEffect.addFlags) do
 					skillFlags[k] = true
 				end
 			end

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1580,12 +1580,8 @@ function calcs.initEnv(build, mode, override, specEnv)
 											for _, otherSocketGroup in ipairs(build.skillsTab.socketGroupList) do
 												if otherSocketGroup.slot and otherSocketGroup.slot == group.slot and not (otherSocketGroup.source and otherSocketGroup.source == group.source) then
 													for _, gem in ipairs(otherSocketGroup.gemList) do
-														if gem.gemData and gem.gemData.grantedEffectList then
-															for _, grantedEffect in ipairs(gem.gemData.grantedEffectList) do
-																if grantedEffect.support then
-																	t_insert(group.displayGemList, gem)
-																end
-															end
+														if gem.gemData and gem.gemData.grantedEffect and gem.gemData.grantedEffect.support then
+															t_insert(group.displayGemList, gem)
 														end
 													end
 												end


### PR DESCRIPTION
Fixes #9326, Fixes #9329, Fixes #9334, Fixes #9336

### Description of the problem being solved:
Previous code from PR #9143 was too big of a change and causing issues so instead made the fix very simple where we check to make sure a gem is a support before adding it as a potential support effect
