### PR TITLE
Fix Radius Jewels in Shared Items Crashing on Load

### DIFF
--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -118,10 +118,6 @@ function main:Init()
 
 	if not SetDPIScaleOverridePercent then SetDPIScaleOverridePercent = function(scale) end end
 
-	if self.userPath then
-		self:ChangeUserPath(self.userPath, ignoreBuild)
-	end
-
 	if launch.devMode and IsKeyDown("CTRL") or os.getenv("REGENERATE_MOD_CACHE") == "1" then
 		-- If modLib.parseMod doesn't find a cache entry it generates it.
 		-- Not loading pre-generated cache causes it to be rebuilt
@@ -142,6 +138,10 @@ function main:Init()
 
 	self.tree = { }
 	self:LoadTree(latestTreeVersion)
+
+	if self.userPath then
+		self:ChangeUserPath(self.userPath, ignoreBuild)
+	end
 
 	self.uniqueDB = { list = { }, loading = true }
 	self.rareDB = { list = { }, loading = true }


### PR DESCRIPTION
Fixes #9348


### Description of the problem being solved:
We are loading Shared Items before LoadTree is called, so data.jewelRadius isn't set yet. I'm moving the ChangeUserPath a few lines down under LoadTree in Main. Alternatively, we could move LoadTree up a few lines above where ChangeUserPath was, or we could check if data.jewelRadius is set in Item.ParseRaw and if not, run the function. A few ways to do it.

### Steps taken to verify a working solution:
- Throw any radius jewel into shared and reload, verify crash vs success
- Have a radius jewel in shared items, close and reopen PoB

### After screenshot:
![sharedItemsGood](https://github.com/user-attachments/assets/b3e316ed-8dbb-4ada-965f-fb946c78732a)
