### PR TITLE
Kinetic Fusillade MaxAPS calculation

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -11201,29 +11201,28 @@ skills["KineticFusillade"] = {
 		-- Projectiles orbit for base_skill_effect_duration before firing
 		-- Recasting resets the timer, so attacking too fast wastes potential damage
 		local baseDuration = skillData.duration
-		local actualDuration = output.Duration or baseDuration
-		local ticksNeededForInitialDelay = math.ceil(actualDuration / data.misc.ServerTickTime)
+		local actualDuration = baseDuration * output.DurationMod
 		local timePerProjectile = baseDelayBetweenProjectiles * output.DurationMod
 		local timeForAllProjectiles = timePerProjectile * projectileCount
-		local effectiveDelay = ticksNeededForInitialDelay * data.misc.ServerTickTime + math.ceil(timeForAllProjectiles / data.misc.ServerTickTime) * data.misc.ServerTickTime
+		local effectiveDelay = actualDuration + timeForAllProjectiles
 		local maxEffectiveAPS = 1 / effectiveDelay
 		local currentAPS = output.Speed
+		local MissProjectile = math.ceil((effectiveDelay - (1/currentAPS)) / timePerProjectile)
 
 		output.KineticFusilladeMaxEffectiveAPS = maxEffectiveAPS
 
 		if breakdown then
 			local breakdownAPS = {}
-			t_insert(breakdownAPS, s_format("^1(These calculations are speculative and best-effort)", actualDuration))
+			t_insert(breakdownAPS, s_format("^1(These calculations are still in beta testing)", actualDuration))
+			t_insert(breakdownAPS, "")
 			t_insert(breakdownAPS, s_format("^8Delay of^7 %.3fs ^8before projectiles start firing", actualDuration))
 			t_insert(breakdownAPS, s_format("^8Each projectile fires sequentially with a^7 %.3fs ^8delay between each projectile", timePerProjectile))
-			t_insert(breakdownAPS, s_format("^8Server tick time:^7 %.3fs", data.misc.ServerTickTime))
-			t_insert(breakdownAPS, s_format("^8Ticks needed:^7 %d ^8(rounded up)", ticksNeededForInitialDelay + math.ceil(timeForAllProjectiles / data.misc.ServerTickTime)))
 			t_insert(breakdownAPS, s_format("^8Effective delay:^7 %.3fs", effectiveDelay))
 			t_insert(breakdownAPS, s_format("^8Max effective attack rate:^7 1 / %.3f = %.2f", effectiveDelay, maxEffectiveAPS))
 			if currentAPS and currentAPS > maxEffectiveAPS then
 				t_insert(breakdownAPS, "")
 				t_insert(breakdownAPS, s_format("^1Current attack rate (%.2f) exceeds max effective rate!", currentAPS))
-				t_insert(breakdownAPS, s_format("^1DPS is reduced by %.1f%%", (1 - maxEffectiveAPS / currentAPS) * 100))
+				t_insert(breakdownAPS, s_format("^1You will lose up to %d projectiles per volley.", MissProjectile))
 			elseif currentAPS then
 				t_insert(breakdownAPS, "")
 				t_insert(breakdownAPS, s_format("^2Current attack rate (%.2f) is within effective limits", currentAPS))

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -2324,29 +2324,28 @@ local skills, mod, flag, skill = ...
 		-- Projectiles orbit for base_skill_effect_duration before firing
 		-- Recasting resets the timer, so attacking too fast wastes potential damage
 		local baseDuration = skillData.duration
-		local actualDuration = output.Duration or baseDuration
-		local ticksNeededForInitialDelay = math.ceil(actualDuration / data.misc.ServerTickTime)
+		local actualDuration = baseDuration * output.DurationMod
 		local timePerProjectile = baseDelayBetweenProjectiles * output.DurationMod
 		local timeForAllProjectiles = timePerProjectile * projectileCount
-		local effectiveDelay = ticksNeededForInitialDelay * data.misc.ServerTickTime + math.ceil(timeForAllProjectiles / data.misc.ServerTickTime) * data.misc.ServerTickTime
+		local effectiveDelay = actualDuration + timeForAllProjectiles
 		local maxEffectiveAPS = 1 / effectiveDelay
 		local currentAPS = output.Speed
+		local MissProjectile = math.ceil((effectiveDelay - (1/currentAPS)) / timePerProjectile)
 
 		output.KineticFusilladeMaxEffectiveAPS = maxEffectiveAPS
 
+
 		if breakdown then
 			local breakdownAPS = {}
-			t_insert(breakdownAPS, s_format("^1(These calculations are speculative and best-effort)", actualDuration))
 			t_insert(breakdownAPS, s_format("^8Delay of^7 %.3fs ^8before projectiles start firing", actualDuration))
 			t_insert(breakdownAPS, s_format("^8Each projectile fires sequentially with a^7 %.3fs ^8delay between each projectile", timePerProjectile))
-			t_insert(breakdownAPS, s_format("^8Server tick time:^7 %.3fs", data.misc.ServerTickTime))
-			t_insert(breakdownAPS, s_format("^8Ticks needed:^7 %d ^8(rounded up)", ticksNeededForInitialDelay + math.ceil(timeForAllProjectiles / data.misc.ServerTickTime)))
 			t_insert(breakdownAPS, s_format("^8Effective delay:^7 %.3fs", effectiveDelay))
 			t_insert(breakdownAPS, s_format("^8Max effective attack rate:^7 1 / %.3f = %.2f", effectiveDelay, maxEffectiveAPS))
 			if currentAPS and currentAPS > maxEffectiveAPS then
 				t_insert(breakdownAPS, "")
 				t_insert(breakdownAPS, s_format("^1Current attack rate (%.2f) exceeds max effective rate!", currentAPS))
-				t_insert(breakdownAPS, s_format("^1DPS is reduced by %.1f%%", (1 - maxEffectiveAPS / currentAPS) * 100))
+				t_insert(breakdownAPS, s_format("^1You will lose up to %d projectiles per volley.", MissProjectile))
+
 			elseif currentAPS then
 				t_insert(breakdownAPS, "")
 				t_insert(breakdownAPS, s_format("^2Current attack rate (%.2f) is within effective limits", currentAPS))


### PR DESCRIPTION

Fixes Kinetic Fusillade max APS.

### Description of the problem being solved:
Actual calculation of KF is taking account "server ticks". After a lot of poison test made by me and several reddit users, my calculator https://nemrod10.github.io/KF/ is accurate. Can add all sources if needed.
I adjusted calculation and added an information of number of projectiles lost. 
To Do Later : 
Add some information of how much atk speed add or remove for perfect breakpoint.

### Steps taken to verify a working solution:
-Poison reflection test
-Several community poison test
-checked several case with different breakpoints

### Link to a build that showcases this PR:
https://pobb.in/ROZkuZddzcuc

### Before screenshot:
12 proj : 
<img width="717" height="171" alt="image" src="https://github.com/user-attachments/assets/dcff2326-bd79-46e2-bbe2-b533758d4fe4" />

8 proj : 
<img width="718" height="168" alt="image" src="https://github.com/user-attachments/assets/cf5ac503-fe27-45ed-94b4-e37d870026b9" />


### After screenshot:
12 proj : 
<img width="714" height="153" alt="image" src="https://github.com/user-attachments/assets/5c9db584-95fc-44e0-a215-34af8b6cc59a" />

8 proj : 
<img width="717" height="139" alt="image" src="https://github.com/user-attachments/assets/3231f604-0c06-497e-94cd-3e5821961d19" />

