### PR TITLE
Fix nodeId check for cluster nodes for power report

### DIFF
--- a/src/Classes/CalcsTab.lua
+++ b/src/Classes/CalcsTab.lua
@@ -573,7 +573,7 @@ function CalcsTabClass:PowerBuilder()
 			node.power = {}
 		end
 		wipeTable(node.power)
-		if not node.alloc and node.modKey ~= "" and not self.mainEnv.grantedPassives[nodeId] then
+		if not node.alloc and node.modKey ~= "" and not self.mainEnv.grantedPassives[node.id] then
 			if not cache[node.modKey] then
 				cache[node.modKey] = calcFunc({ addNodes = { [node] = true } }, useFullDPS)
 			end


### PR DESCRIPTION
### Description of the problem being solved:
`nodeId` is always nil here since nodeId isn't in the scope of the loop. I think this might have been copied from above where we do this:
```
for nodeId, node in pairs(self.build.spec.nodes) do
```

In this loop we have `nodeName` but I don't think this is the correct thing to use and `node.id` seem to be working.

### Steps taken to verify a working solution:
- open power report
- select full DPS
- select show unallocated & clusters

### Link to a build that showcases this PR:
N/A

### Before screenshot:
<img width="840" height="255" alt="image" src="https://github.com/user-attachments/assets/d2126f7b-934a-4a18-81e6-62ff82625406" />

### After screenshot:
<img width="846" height="256" alt="image" src="https://github.com/user-attachments/assets/ca51a134-11b7-4e0c-9cca-861d4cdca78e" />


I guess this is more of a potential performance improvement since it'll be doing less uneeded work.
