### PR TITLE
Add missing screen size conversions

### DIFF
--- a/src/Export/Launch.lua
+++ b/src/Export/Launch.lua
@@ -67,7 +67,7 @@ function launch:OnFrame()
 		self:DrawPopup(r, g, b, "^0%s", self.promptMsg)
 	end
 	if self.doRestart then
-		local screenW, screenH = GetScreenSize()
+		local screenW, screenH = GetVirtualScreenSize()
 		SetDrawColor(0, 0, 0, 0.75)
 		DrawImage(nil, 0, 0, screenW, screenH)
 		SetDrawColor(1, 1, 1)
@@ -180,7 +180,7 @@ function launch:RunPromptFunc(key)
 end
 
 function launch:DrawPopup(r, g, b, fmt, ...)
-	local screenW, screenH = GetScreenSize()
+	local screenW, screenH = GetVirtualScreenSize()
 	SetDrawColor(0, 0, 0, 0.5)
 	DrawImage(nil, 0, 0, screenW, screenH)
 	local txt = string.format(fmt, ...)

--- a/src/Export/Main.lua
+++ b/src/Export/Main.lua
@@ -415,7 +415,7 @@ function main:Shutdown()
 end
 
 function main:OnFrame()
-	self.screenW, self.screenH = GetScreenSize()
+	self.screenW, self.screenH = GetVirtualScreenSize()
 
 	self.viewPort = { x = 0, y = 0, width = self.screenW, height = self.screenH }
 

--- a/src/Launch.lua
+++ b/src/Launch.lua
@@ -122,7 +122,7 @@ function launch:OnFrame()
 		self:DrawPopup(r, g, b, "^0%s", self.promptMsg)
 	end
 	if self.doRestart then
-		local screenW, screenH = GetScreenSize()
+		local screenW, screenH = GetVirtualScreenSize()
 		SetDrawColor(0, 0, 0, 0.75)
 		DrawImage(nil, 0, 0, screenW, screenH)
 		SetDrawColor(1, 1, 1)
@@ -387,7 +387,7 @@ function launch:RunPromptFunc(key)
 end
 
 function launch:DrawPopup(r, g, b, fmt, ...)
-	local screenW, screenH = GetScreenSize()
+	local screenW, screenH = GetVirtualScreenSize()
 	SetDrawColor(0, 0, 0, 0.5)
 	DrawImage(nil, 0, 0, screenW, screenH)
 	local txt = string.format(fmt, ...)

--- a/src/Modules/Common.lua
+++ b/src/Modules/Common.lua
@@ -963,3 +963,14 @@ function ImportBuild(importLink, callback)
 		callback(Inflate(common.base64.decode(importLink:gsub("-", "+"):gsub("_", "/"))), nil)
 	end
 end
+
+-- Returns virtual screen size
+function GetVirtualScreenSize()
+	local width, height = GetScreenSize()
+	local scale = GetScreenScale and GetScreenScale() or 1.0
+	if scale ~= 1.0 then
+		width = math.floor(width / scale)
+		height = math.floor(height / scale)
+	end
+	return width, height
+end

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -339,12 +339,7 @@ function main:Shutdown()
 end
 
 function main:OnFrame()
-	self.screenW, self.screenH = GetScreenSize()
-	self.screenScale = GetScreenScale and GetScreenScale() or 1
-	if self.screenScale ~= 1.0 then
-		self.screenW = math.floor(self.screenW / self.screenScale)
-		self.screenH = math.floor(self.screenH / self.screenScale)
-	end
+	self.screenW, self.screenH = GetVirtualScreenSize()
 
 	if self.screenH > self.screenW then
 		self.portraitMode = true


### PR DESCRIPTION
`GetScreenSize` returns the size in physical units if the `DPI_AWARE` flag is passed to `RenderInit`. The error popup and restart screen have the wrong position and size at UI scaling factor != 1.0 due to missing conversions to virtual units.

This introduces a utility function for getting the virtual screen size and uses it to add the missing conversions.

### Before screenshot:
<img width="1920" height="1050" alt="image" src="https://github.com/user-attachments/assets/511b9406-bbd6-4e61-ae33-74ff9aee9b15" />

### After screenshot:
<img width="1920" height="1050" alt="image" src="https://github.com/user-attachments/assets/a06f1cf5-cbe5-4e2b-875d-ded83779fd11" />
