### PR TITLE
Fix misc calculations based on spell suppression when evasion mastery is active

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -471,18 +471,11 @@ local function incomingDamageBreakdown(breakdownTable, poolsRemaining, output)
 	return breakdownTable
 end
 
--- Performs all ingame and related defensive calculations
-function calcs.defence(env, actor)
+-- Performs defensive calculations used by conditionals
+function calcs.defenceForConditionals(env, actor)
 	local modDB = actor.modDB
-	local enemyDB = actor.enemy.modDB
 	local output = actor.output
-	local breakdown = actor.breakdown
 
-	local condList = modDB.conditions
-
-	-- Action Speed
-	output.ActionSpeedMod = calcs.actionSpeedMod(actor)
-	
 	-- Armour defence types for conditionals
 	for _, slot in pairs({"Helmet","Gloves","Boots","Body Armour","Weapon 2","Weapon 3"}) do
 		local armourData = actor.itemList[slot] and actor.itemList[slot].armourData
@@ -505,6 +498,19 @@ function calcs.defence(env, actor)
 			end
 		end
 	end
+end
+
+-- Performs all ingame and related defensive calculations
+function calcs.defence(env, actor)
+	local modDB = actor.modDB
+	local enemyDB = actor.enemy.modDB
+	local output = actor.output
+	local breakdown = actor.breakdown
+
+	local condList = modDB.conditions
+
+	-- Action Speed
+	output.ActionSpeedMod = calcs.actionSpeedMod(actor)
 
 	-- Resistances
 	output["PhysicalResist"] = 0

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3216,7 +3216,7 @@ function calcs.perform(env, skipEHP)
 		modDB:AddList(env.weaponModList1)
 	end
 
-	-- Process prerequisits for conditionals
+	-- Process prerequisites for conditionals
 	calcs.defenceForConditionals(env, env.player)
 	if env.minion then
 		calcs.defenceForConditionals(env, env.minion)

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3216,6 +3216,12 @@ function calcs.perform(env, skipEHP)
 		modDB:AddList(env.weaponModList1)
 	end
 
+	-- Process prerequisits for conditionals
+	calcs.defenceForConditionals(env, env.player)
+	if env.minion then
+		calcs.defenceForConditionals(env, env.minion)
+	end
+
 	-- Process misc buffs/modifiers
 	doActorCharges(env, env.player)
 	doActorMisc(env, env.player)


### PR DESCRIPTION
Fixes #9385 .

### Description of the problem being solved:
Spell suppression is used for ailment avoidance calculation in `doActorMisc()` when `SpellSuppressionAppliesToAilmentAvoidance`. However, spell suppression from the evasion mastery `+15% chance to Suppress Spell Damage if Equipped Helmet, Body Armour, Gloves, and Boots all have Evasion Rating` was only calculated in a later step, at the beginning of `calcs.defence()`. This lead to incorrect results.

To fix in the safest way possible, I moved the execution of as minimal code as possible as little as possible. I moved code from `calcs.defence()` to a separate function that is called right before the `doActorMisc()` step.

If this is not the correct way to address this, let me know and I will change my implementation.

### Steps taken to verify a working solution:
- With the same setup as in the issue, the ailment value is now correct while it was not before.
- Checked the values while running the code via inspection: Now the spell suppression value in the `modDB` is correct right before the ailment avoidance calculation step, while it wasn't before.
- I also checked whether the modified functions are called anywhere else to see if more changes are needed.

### Link to a build that showcases this PR:
https://pobb.in/mLdCGe4ojsq-

### Before and after screenshots:
You can see that the ailments are wrongly applied before the change, but not applied after.

<img width="309" height="1200" alt="image" src="https://github.com/user-attachments/assets/6b855ff8-56e4-4cc6-9ab2-50d0151c58ea" />
<img width="308" height="1197" alt="image" src="https://github.com/user-attachments/assets/83a5b5f6-fecc-4bfd-91f1-a9f06415db88" />
