### PR TITLE
Updated Lori's Lantern text to match in-game description

### DIFF
--- a/src/Data/Uniques/ring.lua
+++ b/src/Data/Uniques/ring.lua
@@ -755,7 +755,7 @@ Implicits: 2
 {tags:speed}(6-8)% increased Movement Speed when on Low Life
 31% increased Light Radius
 {tags:chaos,jewellery_resistance}+(20-25)% Chaos Resistance when on Low Life
-While on Low Life, Enemies are Unlucky when Damaging you
+Damage of Enemies Hitting you is Unlucky while you are on Low Life
 ]],[[
 Malachai's Artifice
 Unset Ring


### PR DESCRIPTION
Fixes #8588 .

### Description of the problem being solved:
Lori's Lantern has an incorrect tooltip description for it's last line.

### Steps taken to verify a working solution:
- Create a character with Lori's Lantern equipped and verify the updated text.

### Link to a build that showcases this PR:
https://pobb.in/3ZN1J9sIRtkr [new]
https://pobb.in/l_Oui3frNUuj [old]

### Before screenshot:
<img width="655" height="493" alt="lori-old" src="https://github.com/user-attachments/assets/daf06c11-1c3d-4fbd-8a6e-d8c7de10f771" />

### After screenshot:
<img width="657" height="578" alt="lori-new" src="https://github.com/user-attachments/assets/0dc6a2d9-ece7-444b-a5bc-ae4d41489221" />
