### PR TITLE
Fix for Foulborn Choir of the Storm calculation

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -534,7 +534,9 @@ function doActorLifeManaReservation(actor)
 		for _, value in ipairs(modDB:List(nil, "GrantReserved"..pool.."AsAura")) do
 			local auraMod = copyTable(value.mod)
 			auraMod.value = m_floor(auraMod.value * m_min(reserved, max))
-			modDB:NewMod("ExtraAura", "LIST", { mod = auraMod })
+			if not modDB:ReplaceModInternal(auraMod) then
+				modDB:AddMod(auraMod)
+			end
 		end
 	end
 end

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5540,7 +5540,7 @@ local specialModList = {
 		return { mod("EnergyShield", "OVERRIDE", 1, { type = "PercentStat", stat = "Life", percent = num }) }
 	end,
 	["immun[ei]t?y? to elemental ailments while bleeding"] = { flag("ElementalAilmentImmune", { type = "Condition", var = "Bleeding" }) },
-	["mana is increased by (%d+)%% of overcapped lightning resistance"] = function(num) return { mod("Mana", "INC", num / 100, { type = "PerStat", stat = "LightningResistOverCap" }) } end,
+	["mana is increased by (%d+)%% of overcapped lightning resistance"] = function(num) return { mod("Mana", "INC", num / 50, { type = "PerStat", stat = "LightningResistOverCap", div = 2 }) } end,
 }
 for _, name in ipairs(data.keystones) do
 	specialModList[name:lower()] = { mod("Keystone", "LIST", name) }


### PR DESCRIPTION
Fixes #9410 .

### Description of the problem being solved:
Foulborn Choir of the Storm along with Radiant Faith was producing incorrect values for both the % increased mana gained (in-game values round down) and for the base ES granted by Radiant Faith when the amulet is equipped.

### Steps taken to verify a working solution:
- Import given PoB (https://pobb.in/JX6dPx2-Tt5H)
- Remove the custom modifier that gives 478% increased maximum mana and edit/uncomment the equipped Foulborn Choir of the Storm to have its "Mana is increased by 50% of Overcapped Lightning Resistance" active.
- Verify corrected values (with 957% overcapped lightning resistance, Foulborn Choir of the Storm should give 478% increased maximum mana and with 16,777 mana reserved Radiant Faith should give 1,677 base energy shield).
- Run docker tests

### Link to a build that showcases this PR:
Supplied PoB: https://pobb.in/JX6dPx2-Tt5H
With Step 2 above applied: https://pobb.in/iT5syI5O5TeM

### Before screenshot:
<img width="262" height="171" alt="Choir-fix-before-1" src="https://github.com/user-attachments/assets/80f5292c-3ede-452a-84e4-6cfa5fc4c5b1" />
<img width="724" height="38" alt="Choir-fix-before-2" src="https://github.com/user-attachments/assets/4c1502a4-b0c4-4cc9-b4f2-09a2b2ea6c2d" />
<img width="420" height="82" alt="Choir-fix-before-3" src="https://github.com/user-attachments/assets/3042dc64-e572-4e7f-bff0-29da37050f3a" />


### After screenshot:
<img width="270" height="179" alt="Choir-fix-after-1" src="https://github.com/user-attachments/assets/b155f7fa-9197-4f1a-b001-90c26b0bf30f" />
<img width="718" height="37" alt="Choir-fix-after-2" src="https://github.com/user-attachments/assets/0a7cd25c-b7e1-4066-bf23-866dcf0bc785" />
<img width="423" height="80" alt="Choir-fix-after-3" src="https://github.com/user-attachments/assets/986e064d-bd3e-4fc8-9ccf-5cb62ec9cafe" />


**Note**: I did not want to change the stat calculations and steps in `CalcPerform.lua` to avoid causing more bugs, but the issue is caused by `doActorLifeManaReservation` being called more than once (once in `CalcPerform.lua` and afterwards in `CalcDefence.lua`). Only the latter call has the correct value of maximum mana and hence reserved mana/base ES granted by Radiant Faith because it accounts the increases by Foulborn Choir of the Storm by that point in the calculations.

Edit: Seems to be similar to https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/9399