### PR TITLE
Fix Utula's working with The Tides of Time

### DIFF
--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -678,7 +678,7 @@ data.itemTagSpecialExclusionPattern = {
 		},
 		["belt"] = {
 			"Life as Extra Maximum Energy Shield", -- Soul Tether
-			"Life Recovery from Flasks", -- The Druggery
+			"Life Recovery from Flasks is applied to nearby Allies", -- The Druggery
 			"Life Flasks gain", -- The Druggery
 			"when on Full Life",
 			"when on Low Life",


### PR DESCRIPTION
Fixes #9382

### Description of the problem being solved:
While I haven't tested in game, I believe this is correct because of the advanced copy text on the items. We were making all "Life Recovery from Flasks" not count as a life mod. But The Druggery's mod is specific towards allies, which I guess is the reason it has no life tag.

```
Item Class: Belts
Rarity: Unique
The Druggery
Cloth Belt
--------
Requirements:
Level: 48
--------
Item Level: 75
--------
{ Implicit Modifier }
18(15-25)% increased Stun and Block Recovery (implicit)
--------
{ Unique Modifier }
100% of Life Recovery from Flasks is applied to nearby Allies instead of You

{ Unique Modifier }
Life Flasks gain 1 Charge every 3 seconds

{ Unique Modifier — Attribute }
+20(20-30) to all Attributes
(Attributes are Strength, Dexterity, and Intelligence)

{ Unique Modifier }
15(15-25)% increased Flask Charges gained

{ Unique Modifier }
19(10-20)% increased Flask Charges used

{ Unique Modifier }
13(10-20)% increased Flask Effect Duration

--------
"This will help with the pain.
One for you... and one for me."
- Doctor 'Shaky Hands' Opden
--------
Foil Unique (Sunset)
```

```
Item Class: Belts
Rarity: Unique
The Tides of Time
Vanguard Belt
--------
Requirements:
Level: 78
--------
Item Level: 87
--------
{ Implicit Modifier — Defences, Armour, Evasion }
+310(260-320) to Armour and Evasion Rating (implicit)
--------
{ Unique Modifier — Life }
100% increased Life Recovery from Flasks

{ Unique Modifier — Mana }
100% increased Mana Recovery from Flasks

{ Unique Modifier }
Flasks applied to you have 25% increased Effect

{ Unique Modifier }
Life Flasks gain 1(0-3) Charge every 3 seconds

{ Unique Modifier }
Mana Flasks gain 2(0-3) Charges every 3 seconds

{ Unique Modifier }
Utility Flasks gain 3(0-3) Charges every 3 seconds

--------
There is an ebb and flow to all things,
tangible to those who watch and wait.
--------
Shaper Item

```
