### PR TITLE
Dynamically position elements in items tab

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1307,6 +1307,14 @@ function ItemsTabClass:Draw(viewPort, inputEvents)
 
 	self:UpdateSockets()
 
+	if main.portraitMode then
+		self.controls.itemList:SetAnchor("TOPRIGHT", self.lastSlot, "BOTTOMRIGHT", 0, 40)
+	else
+		self.controls.itemList:SetAnchor("TOPLEFT", self.controls.setManage, "TOPRIGHT", 20, 20)
+	end
+	self.controls.craftDisplayItem:SetAnchor("TOPLEFT", main.portraitMode and self.controls.setManage or self.controls.itemList, "TOPRIGHT", 20, main.portraitMode and 0 or -20)
+	self.anchorDisplayItem:SetAnchor("TOPLEFT", main.portraitMode and self.controls.setManage or self.controls.itemList, "TOPRIGHT", 20, main.portraitMode and 0)
+
 	self:DrawControls(viewPort)
 	if self.controls.scrollBarH:IsShown() then
 		self.controls.scrollBarH:Draw(viewPort)
@@ -1423,10 +1431,6 @@ function ItemsTabClass:UpdateSockets()
 	for index, nodeId in ipairs(activeSocketList) do
 		self.sockets[nodeId].label = "Socket #"..index
 		self.lastSlot = self.sockets[nodeId]
-	end
-
-	if main.portraitMode then
-		self.controls.itemList:SetAnchor("TOPRIGHT",self.lastSlot,"BOTTOMRIGHT", 0, 40)
 	end
 end
 


### PR DESCRIPTION
Fixes #9439.

### Description of the problem being solved:
Some UI elements in the items tab are positioned differently based on whether `portraitMode` is set. This is only checked once during initialization and dynamic changes are ignored. This PR fixes the problem by setting the correct anchor points right before drawing the controls in each frame.

I'm not too familiar with the UI layout code so this might not be the best approach. I basically just did something similar to what was done in this commit https://github.com/PathOfBuildingCommunity/PathOfBuilding/pull/2443/changes/1a9f3cb1291a50296a77a446b5ca4d563756cd5f for the skills tab.