### PR TITLE
Fix Kinetic Fusillade projectile damage scaling not being capped by projectile count

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -11181,6 +11181,8 @@ skills["KineticFusillade"] = {
 					end
 					t_insert(breakdownSequential, s_format("^8Average more multiplier:^7 %.1f%%", avgMoreMult))
 					breakdown.KineticFusilladeSequentialBreakdown = breakdownSequential
+					breakdown.ProjectileCount = breakdown.ProjectileCount or {}
+					t_insert(breakdown.ProjectileCount,s_format("^8Maximum number of Kinetic Fusilade projectiles:^7 %d", activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "ProjectileCountMaximum")))
 				end
 			end
 		end
@@ -11249,6 +11251,10 @@ skills["KineticFusillade"] = {
 			div = 1000,
 		},
 		["quality_display_kinetic_fusillade_is_gem"] = {
+			-- Display only
+		},
+		["kinetic_fusillade_maximum_floating_projectiles"] = {
+			mod("ProjectileCountMaximum", "BASE", nil)
 		},
 	},
 	baseFlags = {

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -2304,6 +2304,8 @@ local skills, mod, flag, skill = ...
 					end
 					t_insert(breakdownSequential, s_format("^8Average more multiplier:^7 %.1f%%", avgMoreMult))
 					breakdown.KineticFusilladeSequentialBreakdown = breakdownSequential
+					breakdown.ProjectileCount = breakdown.ProjectileCount or {}
+					t_insert(breakdown.ProjectileCount,s_format("^8Maximum number of Kinetic Fusilade projectiles:^7 %d", activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "ProjectileCountMaximum")))
 				end
 			end
 		end
@@ -2372,6 +2374,10 @@ local skills, mod, flag, skill = ...
 			div = 1000,
 		},
 		["quality_display_kinetic_fusillade_is_gem"] = {
+			-- Display only
+		},
+		["kinetic_fusillade_maximum_floating_projectiles"] = {
+			mod("ProjectileCountMaximum", "BASE", nil)
 		},
 	},
 #mods

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1029,9 +1029,11 @@ function calcs.offence(env, actor, activeSkill)
 			output.ProjectileCount = 1
 		else
 			local projMin = skillModList:Sum("BASE", skillCfg, "ProjectileCountMinimum")
+			local projMax = skillModList:Sum("BASE", skillCfg, "ProjectileCountMaximum")
 			local projBase = skillModList:Sum("BASE", skillCfg, "ProjectileCount")
 			local projMore = skillModList:More(skillCfg, "ProjectileCount")
-			output.ProjectileCount = m_max(m_floor(projBase * projMore), projMin)
+			local proj = m_floor(projBase * projMore)
+			output.ProjectileCount = m_max(m_min(proj, projMax), projMin)
 		end
 		if skillModList:Flag(skillCfg, "AdditionalProjectilesAddBouncesInstead") then
 			local projBase = skillModList:Flag(skillCfg, "SingleProjectile") and 0 or skillModList:Sum("BASE", skillCfg, "ProjectileCount") + skillModList:Sum("BASE", skillCfg, "BounceCount") - 1

--- a/src/Modules/CalcSections.lua
+++ b/src/Modules/CalcSections.lua
@@ -661,7 +661,7 @@ return {
 	{ label = "Reserve Uptime", haveOutput = "ReserveDurationUptime", { format = "{2:output:ReserveDurationUptime}%", { breakdown = "ReserveDurationUptime" }, }, },
 	{ label = "Sustainable Trauma", haveOutput = "SustainableTrauma", { format = "{0:output:SustainableTrauma}", { breakdown = "SustainableTrauma" }, { modName = { "ExtraTrauma", "RepeatCount", "Duration", "PrimaryDuration", "SecondaryDuration"}, cfg = "skill" }, }, },
 	{ label = "Repeat Count", haveOutput = "RepeatCount", { format = "{output:Repeats}", { modName = { "RepeatCount" }, cfg = "skill" }, }, },
-	{ label = "Projectile Count", flag = "projectile", { format = "{output:ProjectileCount}", { modName = { "NoAdditionalProjectiles", "SingleProjectile" , "ProjectileCount", "ProjectileCountMinimum" }, cfg = "skill" }, }, },
+	{ label = "Projectile Count", flag = "projectile", { format = "{output:ProjectileCount}", { breakdown = "ProjectileCount" }, { modName = { "NoAdditionalProjectiles", "SingleProjectile" , "ProjectileCount", "ProjectileCountMinimum" }, cfg = "skill" }, }, },
 	{ label = "Pierce Count", haveOutput = "PierceCount", { format = "{output:PierceCountString}", { modName = { "CannotPierce", "PierceCount", "PierceAllTargets" }, cfg = "skill" }, }, },
 	{ label = "Fork Count", haveOutput = "ForkCountMax", { format = "{output:ForkCountString}", { modName = { "CannotFork", "ForkCountMax" }, cfg = "skill" }, }, },
 	{ label = "Max Chain Count", haveOutput = "ChainMax", { format = "{output:ChainMaxString}", { modName = { "CannotChain", "ChainCountMax", "NoAdditionalChains" }, cfg = "skill" }, }, },


### PR DESCRIPTION
Closes #9381

### Description of the problem being solved:

Simply caps the ProjectileCount property by the exported `kinetic_fusillade_maximum_floating_projectiles` constant

### Steps taken to verify a working solution:
- Test case from issue

### Link to a build that showcases this PR:
See issue
