### PR TITLE
Change Effective Max Hit to use the harmonic mean

### DIFF
--- a/src/Modules/BuildDisplayStats.lua
+++ b/src/Modules/BuildDisplayStats.lua
@@ -108,7 +108,6 @@ local displayStats = {
 	{ stat = "ColdMaximumHitTaken", label = "Cold Max Hit", fmt = ".0f", color = colorCodes.COLD, compPercent = true, condFunc = function(v,o) return o.LightningMaximumHitTaken ~= o.ColdMaximumHitTaken or o.LightningMaximumHitTaken ~= o.FireMaximumHitTaken end },
 	{ stat = "LightningMaximumHitTaken", label = "Lightning Max Hit", fmt = ".0f", color = colorCodes.LIGHTNING, compPercent = true, condFunc = function(v,o) return o.LightningMaximumHitTaken ~= o.ColdMaximumHitTaken or o.LightningMaximumHitTaken ~= o.FireMaximumHitTaken end },
 	{ stat = "ChaosMaximumHitTaken", label = "Chaos Max Hit", fmt = ".0f", color = colorCodes.CHAOS, compPercent = true },
-	{ stat = "EffectiveMaximumHitTaken", label = "Effective Max Hit", fmt = ".0f", compPercent = true },
 	{ },
 	{ stat = "MainHand", childStat = "Accuracy", label = "MH Accuracy", fmt = "d", condFunc = function(v,o) return o.PreciseTechnique end, warnFunc = function(v,o) return v < o.Life and "You do not have enough Accuracy for Precise Technique" end, warnColor = true },
 	{ stat = "OffHand", childStat = "Accuracy", label = "OH Accuracy", fmt = "d", condFunc = function(v,o) return o.PreciseTechnique end, warnFunc = function(v,o) return v < o.Life and "You do not have enough Accuracy for Precise Technique" end, warnColor = true },

--- a/src/Modules/BuildDisplayStats.lua
+++ b/src/Modules/BuildDisplayStats.lua
@@ -108,6 +108,7 @@ local displayStats = {
 	{ stat = "ColdMaximumHitTaken", label = "Cold Max Hit", fmt = ".0f", color = colorCodes.COLD, compPercent = true, condFunc = function(v,o) return o.LightningMaximumHitTaken ~= o.ColdMaximumHitTaken or o.LightningMaximumHitTaken ~= o.FireMaximumHitTaken end },
 	{ stat = "LightningMaximumHitTaken", label = "Lightning Max Hit", fmt = ".0f", color = colorCodes.LIGHTNING, compPercent = true, condFunc = function(v,o) return o.LightningMaximumHitTaken ~= o.ColdMaximumHitTaken or o.LightningMaximumHitTaken ~= o.FireMaximumHitTaken end },
 	{ stat = "ChaosMaximumHitTaken", label = "Chaos Max Hit", fmt = ".0f", color = colorCodes.CHAOS, compPercent = true },
+	{ stat = "EffectiveMaximumHitTaken", label = "Effective Max Hit", fmt = ".0f", compPercent = true },
 	{ },
 	{ stat = "MainHand", childStat = "Accuracy", label = "MH Accuracy", fmt = "d", condFunc = function(v,o) return o.PreciseTechnique end, warnFunc = function(v,o) return v < o.Life and "You do not have enough Accuracy for Precise Technique" end, warnColor = true },
 	{ stat = "OffHand", childStat = "Accuracy", label = "OH Accuracy", fmt = "d", condFunc = function(v,o) return o.PreciseTechnique end, warnFunc = function(v,o) return v < o.Life and "You do not have enough Accuracy for Precise Technique" end, warnColor = true },

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -3246,18 +3246,13 @@ function calcs.buildDefenceEstimations(env, actor)
 			end
 		end
 
-		-- second minimum used for power calcs, as there are issues using average or minimum
-		local minimum = m_huge
-		local SecondMinimum = m_huge
+		-- harmonic mean used for power calcs (equivalent to the maximum hit when the hit is equally split between all damage types)
+		-- ideally there should be weights to account for the fact that damage types usually have different scales (phys hits are smaller than ele hits)
+		local reciprocalSum = 0
 		for _, damageType in ipairs(dmgTypeList) do
-			if output[damageType.."MaximumHitTaken"] < minimum then
-				SecondMinimum = minimum
-				minimum = output[damageType.."MaximumHitTaken"]
-			elseif output[damageType.."MaximumHitTaken"] < SecondMinimum then
-				SecondMinimum = output[damageType.."MaximumHitTaken"]
-			end
+			reciprocalSum = reciprocalSum + 1 / output[damageType .. "MaximumHitTaken"]
 		end
-		output.SecondMinimalMaximumHitTaken = SecondMinimum
+		output.EffectiveMaximumHitTaken = 5 / reciprocalSum
 	end
 
 	-- effective health pool vs dots

--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -142,7 +142,7 @@ data.powerStatList = {
 	{ stat="SpellAvoidChance", label="Spell avoid chance" },
 	{ stat="ProjectileAvoidChance", label="Projectile avoid chance" },
 	{ stat="TotalEHP", label="Effective Hit Pool" },
-	{ stat="SecondMinimalMaximumHitTaken", label="Eff. Maximum Hit Taken" },
+	{ stat="EffectiveMaximumHitTaken", label="Eff. Maximum Hit Taken" },
 	{ stat="PhysicalTakenHit", label="Taken Phys dmg", transform=function(value) return -value end },
 	{ stat="LightningTakenHit", label="Taken Lightning dmg", transform=function(value) return -value end },
 	{ stat="ColdTakenHit", label="Taken Cold dmg", transform=function(value) return -value end },


### PR DESCRIPTION
### What this PR does    
Changes the Effective Max Hit to be the harmonic mean of the max hits instead of the second lowest max hit.      
Additionally, it adds the Effective Max Hit to the detail stats, making them show up in the stats panel on the left, beneath the individual max hits, as well as in the tooltips that display the stat changes from taking passives, equipping items, etc          

### Description of the problem being solved:
The second lowest max hit is not a very intuitive definition for max hit because it ignores 4/5 of the max hits, including the lowest one (which is usually the most important one)

The harmonic mean allows all the max hits to affect the effective max hit while still behaving well with infinite max hit (chaos innoculation)

I think the an obvious example of the second lowest max hit being misleading is any CI build with around the same phys and ele max hits: if you take out CI and sort nodes by effective max hit, CI doesn't even show up because it doesn't really affect the second lowest max hit, despite the fact that the build is extremely squishy without CI.

### Link to a build that showcases this PR:
https://pobb.in/ccUdP4u3vwZw

### Before screenshot:
<img width="195" height="70" alt="image" src="https://github.com/user-attachments/assets/4cfb7919-ad23-4397-a5b5-bb22af597a42" />

<img width="928" height="242" alt="image" src="https://github.com/user-attachments/assets/335ebc9c-07d5-488a-8817-168bb62f10bc" />


### After screenshot:
<img width="191" height="90" alt="image" src="https://github.com/user-attachments/assets/f9efca2e-6445-4b5e-a5e4-3ceb1ac6c8e8" />

<img width="935" height="240" alt="image" src="https://github.com/user-attachments/assets/13539c51-e54e-4c92-8bb2-e951cf38e639" />

<img width="398" height="424" alt="image" src="https://github.com/user-attachments/assets/afcaaf68-d524-4075-b9e2-bd63fd8af35b" />
