### PR TITLE
Fixed Kinetic Fusillade DPS and attack speed breakpoint calcs

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -11202,12 +11202,11 @@ skills["KineticFusillade"] = {
 		-- Calculate effective attack rate accounting for delayed projectile firing
 		-- Projectiles orbit for base_skill_effect_duration before firing
 		-- Recasting resets the timer, so attacking too fast wastes potential damage
-		local baseDuration = skillData.duration
-		local actualDuration = output.Duration or baseDuration
-		local ticksNeededForInitialDelay = math.ceil(actualDuration / data.misc.ServerTickTime)
-		local timePerProjectile = baseDelayBetweenProjectiles * output.DurationMod
-		local timeForAllProjectiles = timePerProjectile * projectileCount
-		local effectiveDelay = ticksNeededForInitialDelay * data.misc.ServerTickTime + math.ceil(timeForAllProjectiles / data.misc.ServerTickTime) * data.misc.ServerTickTime
+		-- Formula: totalTime = (hoverDelay + delayBetweenProj * nProj) * durationMod
+		local hoverDelay = skillData.duration
+		local durationMod = output.DurationMod
+		local baseTimeForAllProjectiles = baseDelayBetweenProjectiles * projectileCount
+		local effectiveDelay = (hoverDelay + baseTimeForAllProjectiles) * durationMod
 		local maxEffectiveAPS = 1 / effectiveDelay
 		local currentAPS = output.Speed
 
@@ -11216,12 +11215,12 @@ skills["KineticFusillade"] = {
 		if breakdown then
 			local breakdownAPS = {}
 			t_insert(breakdownAPS, s_format("^1(These calculations are speculative and best-effort)", actualDuration))
-			t_insert(breakdownAPS, s_format("^8Delay of^7 %.3fs ^8before projectiles start firing", actualDuration))
-			t_insert(breakdownAPS, s_format("^8Each projectile fires sequentially with a^7 %.3fs ^8delay between each projectile", timePerProjectile))
-			t_insert(breakdownAPS, s_format("^8Server tick time:^7 %.3fs", data.misc.ServerTickTime))
-			t_insert(breakdownAPS, s_format("^8Ticks needed:^7 %d ^8(rounded up)", ticksNeededForInitialDelay + math.ceil(timeForAllProjectiles / data.misc.ServerTickTime)))
-			t_insert(breakdownAPS, s_format("^8Effective delay:^7 %.3fs", effectiveDelay))
-			t_insert(breakdownAPS, s_format("^8Max effective attack rate:^7 1 / %.3f = %.2f", effectiveDelay, maxEffectiveAPS))
+			t_insert(breakdownAPS, s_format("^8Base hover delay:^7 %.3fs", hoverDelay))
+			t_insert(breakdownAPS, s_format("^8Base delay between projectiles:^7 %.3fs", baseDelayBetweenProjectiles))
+			t_insert(breakdownAPS, s_format("^8Base time for^7 %d ^8projectiles:^7 %.3fs x %d = %.3fs", projectileCount, baseDelayBetweenProjectiles, projectileCount, baseTimeForAllProjectiles))
+			t_insert(breakdownAPS, s_format("^8Duration modifier:^7 %.4f", durationMod))
+			t_insert(breakdownAPS, s_format("^8Effective delay:^7 (%.3f + %.3f) x %.4f = %.4fs", hoverDelay, baseTimeForAllProjectiles, durationMod, effectiveDelay))
+			t_insert(breakdownAPS, s_format("^8Max effective attack rate:^7 1 / %.4f = %.2f", effectiveDelay, maxEffectiveAPS))
 			if currentAPS and currentAPS > maxEffectiveAPS then
 				t_insert(breakdownAPS, "")
 				t_insert(breakdownAPS, s_format("^1Current attack rate (%.2f) exceeds max effective rate!", currentAPS))

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -11214,20 +11214,26 @@ skills["KineticFusillade"] = {
 
 		if breakdown then
 			local breakdownAPS = {}
-			t_insert(breakdownAPS, s_format("^1(These calculations are speculative and best-effort)", actualDuration))
+			t_insert(breakdownAPS, s_format("^1(These calculations are speculative and best-effort)"))
 			t_insert(breakdownAPS, s_format("^8Base hover delay:^7 %.3fs", hoverDelay))
 			t_insert(breakdownAPS, s_format("^8Base delay between projectiles:^7 %.3fs", baseDelayBetweenProjectiles))
 			t_insert(breakdownAPS, s_format("^8Base time for^7 %d ^8projectiles:^7 %.3fs x %d = %.3fs", projectileCount, baseDelayBetweenProjectiles, projectileCount, baseTimeForAllProjectiles))
 			t_insert(breakdownAPS, s_format("^8Duration modifier:^7 %.4f", durationMod))
 			t_insert(breakdownAPS, s_format("^8Effective delay:^7 (%.3f + %.3f) x %.4f = %.4fs", hoverDelay, baseTimeForAllProjectiles, durationMod, effectiveDelay))
 			t_insert(breakdownAPS, s_format("^8Max effective attack rate:^7 1 / %.4f = %.2f", effectiveDelay, maxEffectiveAPS))
-			if currentAPS and currentAPS > maxEffectiveAPS then
+			if currentAPS then
+				local currentInc = activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "Speed")
+				local neededInc = ((maxEffectiveAPS / currentAPS) * (1 + currentInc / 100) - 1) * 100
+				local additionalInc = neededInc - currentInc
 				t_insert(breakdownAPS, "")
-				t_insert(breakdownAPS, s_format("^1Current attack rate (%.2f) exceeds max effective rate!", currentAPS))
-				t_insert(breakdownAPS, s_format("^1DPS is reduced by %.1f%%", (1 - maxEffectiveAPS / currentAPS) * 100))
-			elseif currentAPS then
-				t_insert(breakdownAPS, "")
-				t_insert(breakdownAPS, s_format("^2Current attack rate (%.2f) is within effective limits", currentAPS))
+				if currentAPS > maxEffectiveAPS then
+					t_insert(breakdownAPS, s_format("^1Current attack rate (%.2f) exceeds max effective rate!", currentAPS))
+					t_insert(breakdownAPS, s_format("^1Reduce attack speed by at least^7 %d%% ^1", math.ceil(-additionalInc)))
+					t_insert(breakdownAPS, s_format("^1DPS is reduced by %.1f%%", (1 - maxEffectiveAPS / currentAPS) * 100))
+				else
+					t_insert(breakdownAPS, s_format("^2Current attack rate (%.2f) is within effective limits", currentAPS))
+					t_insert(breakdownAPS, s_format("^2You can add up to^7 %d%% ^2increased attack speed", math.floor(additionalInc)))
+				end
 			end
 			breakdown.KineticFusilladeMaxEffectiveAPS = breakdownAPS
 		end


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/9424

### Description of the problem being solved:
When comparing attack speed breakpoints for KF in PoB vs in game it is noticeable that PoB is wrong. For example, you can "gatling" in game holding right click when PoB tells you that you shouldn't be able to.

The issue is that PoB uses server ticks for KF attack speed breakpoint calcs where they apparently don't matter (see the video in https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/9424)

### Steps taken to verify a working solution:
- I compared the breakpoints I fixed to nemrod's calc https://nemrod10.github.io/KF/
- I can gatling with these values in game but old PoB told me that I couldn't

### Link to a build that showcases this PR:
https://pobb.in/kKi1MvaNfdKG

### Before screenshot:
<img width="1206" height="450" alt="image" src="https://github.com/user-attachments/assets/7b7c5d8c-242f-4671-b2cc-b4c5ad71f69d" />

### After screenshot:
<img width="1052" height="448" alt="image" src="https://github.com/user-attachments/assets/b6342d92-3a4e-43b0-abef-3a0497a3d0fe" />
How it looks like when you're above the breakpoint
<img width="1060" height="466" alt="image" src="https://github.com/user-attachments/assets/52a8e6bc-8921-4565-a271-269ec13f16ef" />
