### PR TITLE
Fix Maata's Teaching missing implicit

### DIFF
--- a/src/Data/Uniques/mace.lua
+++ b/src/Data/Uniques/mace.lua
@@ -472,6 +472,7 @@ Variant: Pre 3.25.0
 Variant: Current
 Requires Level 56, 96 Str, 96 Int
 Implicits: 1
+26% increased Elemental Damage
 +(30-40) to Intelligence
 {variant:1}(25-50)% increased Critical Strike Chance
 {variant:2}(15-30)% increased Critical Strike Chance


### PR DESCRIPTION
Fixes #9360 .

### Description of the problem being solved:
Maata's teaching was missing the implicit of `26% increased Elemental Damage`

### Steps taken to verify a working solution:
- Added Maata's teaching with Ice Crash as the main Skill
- Checked the Damage output
- Added the missing implicit to the item and added to build
- Checked that the damage output was increased by the `#% increased Elemental Damage`, and that the item tooltip showed damage changes

### Link to a build that showcases this PR:
N/A, quite simple to set up.

### Before screenshot:
<img width="814" height="1022" alt="image" src="https://github.com/user-attachments/assets/9a4c2ff7-9698-4e78-bae2-c75ba2298047" />

<img width="292" height="489" alt="image" src="https://github.com/user-attachments/assets/f398f101-073e-40e9-85b0-0bd4d14b3bb8" />

### After screenshot:
<img width="379" height="401" alt="image" src="https://github.com/user-attachments/assets/4549d4f8-00ed-455d-8736-ac22843240eb" />

<img width="813" height="1042" alt="image" src="https://github.com/user-attachments/assets/b9fec258-a14b-4067-8341-4df5055d35dd" />


