### PR TITLE
Update The Queen's Hunger to show new veiled mods

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -573,7 +573,6 @@ c["+188 to maximum Energy Shield"]={{[1]={flags=0,keywordFlags=0,name="EnergyShi
 c["+19 to Armour"]={{[1]={flags=0,keywordFlags=0,name="Armour",type="BASE",value=19}},nil}
 c["+19 to Evasion Rating"]={{[1]={flags=0,keywordFlags=0,name="Evasion",type="BASE",value=19}},nil}
 c["+19 to all Attributes"]={{[1]={flags=0,keywordFlags=0,name="Str",type="BASE",value=19},[2]={flags=0,keywordFlags=0,name="Dex",type="BASE",value=19},[3]={flags=0,keywordFlags=0,name="Int",type="BASE",value=19},[4]={flags=0,keywordFlags=0,name="All",type="BASE",value=19}},nil}
-c["+19 to maximum Life"]={{[1]={flags=0,keywordFlags=0,name="Life",type="BASE",value=19}},nil}
 c["+19% to Chaos Resistance"]={{[1]={flags=0,keywordFlags=0,name="ChaosResist",type="BASE",value=19}},nil}
 c["+190 to Accuracy Rating"]={{[1]={flags=0,keywordFlags=0,name="Accuracy",type="BASE",value=190}},nil}
 c["+190 to Armour"]={{[1]={flags=0,keywordFlags=0,name="Armour",type="BASE",value=190}},nil}
@@ -1279,7 +1278,6 @@ c["+325 to Accuracy Rating"]={{[1]={flags=0,keywordFlags=0,name="Accuracy",type=
 c["+325 to Armour"]={{[1]={flags=0,keywordFlags=0,name="Armour",type="BASE",value=325}},nil}
 c["+33 to Maximum Life"]={{[1]={flags=0,keywordFlags=0,name="Life",type="BASE",value=33}},nil}
 c["+33 to Strength and Dexterity"]={{[1]={flags=0,keywordFlags=0,name="Str",type="BASE",value=33},[2]={flags=0,keywordFlags=0,name="Dex",type="BASE",value=33},[3]={flags=0,keywordFlags=0,name="StrDex",type="BASE",value=33}},nil}
-c["+33 to Strength and Intelligence"]={{[1]={flags=0,keywordFlags=0,name="Str",type="BASE",value=33},[2]={flags=0,keywordFlags=0,name="Int",type="BASE",value=33},[3]={flags=0,keywordFlags=0,name="StrInt",type="BASE",value=33}},nil}
 c["+33 to maximum Energy Shield"]={{[1]={flags=0,keywordFlags=0,name="EnergyShield",type="BASE",value=33}},nil}
 c["+33 to maximum Life"]={{[1]={flags=0,keywordFlags=0,name="Life",type="BASE",value=33}},nil}
 c["+33% to Cold Resistance"]={{[1]={flags=0,keywordFlags=0,name="ColdResist",type="BASE",value=33}},nil}
@@ -5033,8 +5031,6 @@ c["320% increased Evasion Rating"]={{[1]={flags=0,keywordFlags=0,name="Evasion",
 c["320% increased Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalDamage",type="INC",value=320}},nil}
 c["325% Increased Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalDamage",type="INC",value=325}},nil}
 c["325% increased Energy Shield"]={{[1]={flags=0,keywordFlags=0,name="EnergyShield",type="INC",value=325}},nil}
-c["33% chance to Avoid Elemental Ailments"]={{[1]={flags=0,keywordFlags=0,name="AvoidElementalAilments",type="BASE",value=33}},nil}
-c["33% chance to Avoid being Stunned"]={{[1]={flags=0,keywordFlags=0,name="AvoidStun",type="BASE",value=33}},nil}
 c["33% chance to Blind nearby Enemies when gaining Her Blessing"]={{}," to Blind nearby Enemies when gaining Her Blessing "}
 c["33% chance to Blind nearby Enemies when gaining Her Blessing 100% chance to Avoid being Ignited, Chilled or Frozen with Her Blessing"]={{[1]={flags=0,keywordFlags=0,name="AvoidIgnite",type="BASE",value=33}}," to Blind nearby Enemies when gaining Her Blessing 100% chance , Chilled or Frozen with Her Blessing "}
 c["33% chance to gain a Frenzy Charge on Kill"]={nil,"a Frenzy Charge  "}
@@ -10623,6 +10619,7 @@ c["Regenerate 175 Life per Second while in Blood Stance"]={{[1]={[1]={type="Cond
 c["Regenerate 2 Mana per Second per Power Charge"]={{[1]={[1]={type="Multiplier",var="PowerCharge"},flags=0,keywordFlags=0,name="ManaRegen",type="BASE",value=2}},nil}
 c["Regenerate 2 Mana per second"]={{[1]={flags=0,keywordFlags=0,name="ManaRegen",type="BASE",value=2}},nil}
 c["Regenerate 2% of Energy Shield per second"]={{[1]={flags=0,keywordFlags=0,name="EnergyShieldRegenPercent",type="BASE",value=2}},nil}
+c["Regenerate 2% of Energy Shield per second if you've Consumed a Corpse Recently"]={{[1]={[1]={type="Condition",var="ConsumedCorpseRecently"},flags=0,keywordFlags=0,name="EnergyShieldRegenPercent",type="BASE",value=2}},nil}
 c["Regenerate 2% of Energy Shield per second if you've Killed an Enemy Recently"]={{[1]={[1]={type="Condition",var="KilledRecently"},flags=0,keywordFlags=0,name="EnergyShieldRegenPercent",type="BASE",value=2}},nil}
 c["Regenerate 2% of Energy Shield per second while on Low Life"]={{[1]={[1]={type="Condition",var="LowLife"},flags=0,keywordFlags=0,name="EnergyShieldRegenPercent",type="BASE",value=2}},nil}
 c["Regenerate 2% of Life per Second for each Trap Triggered Recently, up to 10% per second"]={{[1]={[1]={limit=10,limitTotal=true,type="Multiplier",var="TrapTriggeredRecently"},flags=0,keywordFlags=0,name="LifeRegenPercent",type="BASE",value=2}},nil}
@@ -10639,6 +10636,7 @@ c["Regenerate 2% of Life per second on Chilled Ground"]={{[1]={[1]={type="Condit
 c["Regenerate 2% of Life per second while affected by Vitality"]={{[1]={[1]={type="Condition",var="AffectedByVitality"},flags=0,keywordFlags=0,name="LifeRegenPercent",type="BASE",value=2}},nil}
 c["Regenerate 2% of Life per second while stationary"]={{[1]={[1]={type="Condition",var="Stationary"},flags=0,keywordFlags=0,name="LifeRegenPercent",type="BASE",value=2}},nil}
 c["Regenerate 2% of Life per second with at least 400 Strength"]={{[1]={[1]={stat="Str",threshold=400,type="StatThreshold"},flags=0,keywordFlags=0,name="LifeRegenPercent",type="BASE",value=2}},nil}
+c["Regenerate 2% of Mana per second if you've Consumed a corpse Recently"]={{[1]={[1]={type="Condition",var="ConsumedCorpseRecently"},flags=0,keywordFlags=0,name="ManaRegenPercent",type="BASE",value=2}},nil}
 c["Regenerate 2.5% of Energy Shield per Second while affected by Discipline"]={{[1]={[1]={type="Condition",var="AffectedByDiscipline"},flags=0,keywordFlags=0,name="EnergyShieldRegenPercent",type="BASE",value=2.5}},nil}
 c["Regenerate 2.5% of Life per Second if you've Detonated a Mine Recently"]={{[1]={[1]={type="Condition",var="DetonatedMinesRecently"},flags=0,keywordFlags=0,name="LifeRegenPercent",type="BASE",value=2.5}},nil}
 c["Regenerate 20 Life per second"]={{[1]={flags=0,keywordFlags=0,name="LifeRegen",type="BASE",value=20}},nil}
@@ -12420,6 +12418,8 @@ c["You can have an Offering of each type"]={nil,"You can have an Offering of eac
 c["You can have an Offering of each type Offering Skills have 50% reduced Duration"]={nil,"You can have an Offering of each type Offering Skills have 50% reduced Duration "}
 c["You can have an additional Brand Attached to an Enemy"]={{[1]={flags=0,keywordFlags=0,name="BrandsAttachedLimit",type="BASE",value=1}},nil}
 c["You can have an additional Tincture active"]={{[1]={flags=0,keywordFlags=0,name="TinctureLimit",type="BASE",value=1}},nil}
+c["You can have two Offerings of different types"]={nil,"You can have two Offerings of different types "}
+c["You can have two Offerings of different types 35% chance to Avoid Elemental Ailments"]={nil,"You can have two Offerings of different types 35% chance to Avoid Elemental Ailments "}
 c["You can have two different Banners at the same time"]={{},nil}
 c["You can inflict Bleeding on an Enemy up to 8 times"]={{[1]={flags=0,keywordFlags=0,name="BleedStacksMax",type="OVERRIDE",value=8},[2]={flags=0,keywordFlags=0,name="Condition:HaveCrimsonDance",type="FLAG",value=true}},nil}
 c["You can inflict an additional Ignite on an Enemy"]={{[1]={flags=0,keywordFlags=0,name="IgniteCanStack",type="FLAG",value=true},[2]={flags=0,keywordFlags=0,name="IgniteStacks",type="BASE",value=1}},nil}

--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -51,22 +51,12 @@ local getVeiledMods = function (veiledPool, baseType, specificType1, specificTyp
 	return veiledMods
 end
 
-local function tableHasValue (table, lookup)
-	for index, value in ipairs(table) do
-		if value == lookup then
-			return true
-		end
-	end
-
-	return false
-end
-
 local getVeiledModsByName = function (modNames) 
 	local veiledMods = { }
 	for veiledModIndex, veiledMod in pairs(data.veiledMods) do
 		local veiledName = parseVeiledModName(veiledModIndex)
 
-		if tableHasValue(modNames, veiledName) or tableHasValue(modNames, veiledModIndex) then
+		if isValueInArray(modNames, veiledName) or isValueInArray(modNames, veiledModIndex) then
 
 		veiledName = "("..veiledMod.type..") "..veiledName
 

--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -51,6 +51,40 @@ local getVeiledMods = function (veiledPool, baseType, specificType1, specificTyp
 	return veiledMods
 end
 
+local function tableHasValue (table, lookup)
+    for index, value in ipairs(table) do
+        if value == lookup then
+            return true
+        end
+    end
+
+    return false
+end
+
+local getVeiledModsByName = function (modNames) 
+	local veiledMods = { }
+	for veiledModIndex, veiledMod in pairs(data.veiledMods) do
+		local veiledName = parseVeiledModName(veiledModIndex)
+
+		if tableHasValue(modNames, veiledName) or tableHasValue(modNames, veiledModIndex) then
+
+		veiledName = "("..veiledMod.type..") "..veiledName
+
+		local veiled = { veiledName = veiledName, veiledLines = { } }
+		for line, value in ipairs(veiledMod) do
+			veiled.veiledLines[line] = value
+		end
+
+		table.insert(veiledMods, veiled)
+		end
+	end
+
+	table.sort(veiledMods, function (m1, m2) return m1.veiledName < m2.veiledName end )
+
+	return veiledMods
+end
+
+
 local paradoxicaMods = getVeiledMods("base", "weapon", "one_hand_weapon")
 local paradoxica = {
 	"Paradoxica",
@@ -155,7 +189,39 @@ end
 
 table.insert(data.uniques.generated, table.concat(replicaParadoxica, "\n"))
 
-local queensHungerMods = getVeiledMods("base", "body_armour", "int_armour")
+local queensHungerMods = getVeiledModsByName({
+	-- "Chosen" Veiled Prefixes
+	"JunMasterVeiledLocalIncreasedEnergyShieldAndLifeHigh",
+	"JunMasterVeiledPhysicalDamageReductionRatingDuringSoulGainPrevention",
+	"JunMasterVeiledPercentageLifeAndMana",
+	"JunMasterVeiledBlockPercent",
+	"JunMasterVeiledAvoidStunAndElementalStatusAilments",
+	"JunMasterVeiledSpellBlockPercent____",
+    -- "Catarina's" Veiled Prefixes
+	"JunMasterVeiledOfferingEffect",
+	"JunMasterVeiledLifeRegenerationRatePercentageIfCorpseConsumedRecently",
+	"JunMasterVeiledManaRegenerationRatePercentageIfCorpseConsumedRecently",
+	"JunMasterVeiledEnergyShieldRegenerationRatePercentageIfCorpseConsumedRecently",
+	"JunMasterVeiledAllow2Offerings",
+	"JunMasterVeiledOfferingDuration",
+	-- "of the Order" Veiled Suffixes
+	"JunMasterVeiledStrengthAndDexterity",
+	"JunMasterVeiledDexterityAndIntelligence",
+	"JunMasterVeiledStrengthAndIntelligence",
+	"JunMasterVeiledAvoidElementalDamageChanceDuringSoulGainPrevention",
+	"JunMasterVeiledEnergyShieldRegenerationRatePerMinuteIfRareOrUniqueEnemyNearby",
+	"JunMasterVeiledLifeRegenerationPerEvasionDuringFocus",
+	"JunMasterVeiledRestoreManaAndEnergyShieldOnFocus",
+	"JunMasterVeiledFortifyEffectWhileFocused_",
+	"JunMasterVeiledDamageRemovedFromManaBeforeLifeWhileFocused",
+	"JunMasterVeiledFireAndChaosDamageResistance",
+	"JunMasterVeiledLightningAndChaosDamageResistance",
+	"JunMasterVeiledColdAndChaosDamageResistance",
+	"JunMasterVeiledStrengthAndAvoidIgnite",
+	"JunMasterVeiledDexterityAndAvoidFreeze",
+	"JunMasterVeiledIntelligenceAndAvoidShock"
+})
+
 local queensHunger = {
 	"The Queen's Hunger",
 	"Vaal Regalia",
@@ -179,7 +245,7 @@ table.insert(queensHunger, "(6-10)% increased maximum Life")
 
 for index, mod in pairs(queensHungerMods) do
 	for _, value in pairs(mod.veiledLines) do
-		table.insert(queensHunger, "{variant:"..index.."}"..value.."")
+		table.insert(queensHunger, "{variant:"..index.."}{crafted}"..value.."")
 	end
 end
 

--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -52,13 +52,13 @@ local getVeiledMods = function (veiledPool, baseType, specificType1, specificTyp
 end
 
 local function tableHasValue (table, lookup)
-    for index, value in ipairs(table) do
-        if value == lookup then
-            return true
-        end
-    end
+	for index, value in ipairs(table) do
+		if value == lookup then
+			return true
+		end
+	end
 
-    return false
+	return false
 end
 
 local getVeiledModsByName = function (modNames) 
@@ -197,7 +197,7 @@ local queensHungerMods = getVeiledModsByName({
 	"JunMasterVeiledBlockPercent",
 	"JunMasterVeiledAvoidStunAndElementalStatusAilments",
 	"JunMasterVeiledSpellBlockPercent____",
-    -- "Catarina's" Veiled Prefixes
+	-- "Catarina's" Veiled Prefixes
 	"JunMasterVeiledOfferingEffect",
 	"JunMasterVeiledLifeRegenerationRatePercentageIfCorpseConsumedRecently",
 	"JunMasterVeiledManaRegenerationRatePercentageIfCorpseConsumedRecently",
@@ -971,12 +971,12 @@ for _, gem in pairs(data.gems) do
 end
 
 local replicaDragonfangsFlight = {
-    [[Replica Dragonfang's Flight
-    Onyx Amulet
-    Selected Variant: 2
-    Has Alt Variant: true
-    Selected Alt Variant: 3
-    LevelReq: 56
+	[[Replica Dragonfang's Flight
+	Onyx Amulet
+	Selected Variant: 2
+	Has Alt Variant: true
+	Selected Alt Variant: 3
+	LevelReq: 56
 	]]
 }
 

--- a/src/Data/Uniques/Special/Generated.lua
+++ b/src/Data/Uniques/Special/Generated.lua
@@ -55,22 +55,16 @@ local getVeiledModsByName = function (modNames)
 	local veiledMods = { }
 	for veiledModIndex, veiledMod in pairs(data.veiledMods) do
 		local veiledName = parseVeiledModName(veiledModIndex)
-
 		if isValueInArray(modNames, veiledName) or isValueInArray(modNames, veiledModIndex) then
-
-		veiledName = "("..veiledMod.type..") "..veiledName
-
-		local veiled = { veiledName = veiledName, veiledLines = { } }
-		for line, value in ipairs(veiledMod) do
-			veiled.veiledLines[line] = value
-		end
-
-		table.insert(veiledMods, veiled)
+			veiledName = "("..veiledMod.type..") "..veiledName
+			local veiled = { veiledName = veiledName, veiledLines = { } }
+			for line, value in ipairs(veiledMod) do
+				veiled.veiledLines[line] = value
+			end
+			table.insert(veiledMods, veiled)
 		end
 	end
-
 	table.sort(veiledMods, function (m1, m2) return m1.veiledName < m2.veiledName end )
-
 	return veiledMods
 end
 


### PR DESCRIPTION
Fixes #9413  .

### Description of the problem being solved:
In 3.26 the item "The Queen's Hunger" would pull random Prefix and Suffixes from the ordinary pool. This doesn't seem to be the case in 3.27 according to the [POE Wiki Entry](https://www.poewiki.net/wiki/The_Queen%27s_Hunger). As reported in the issue, a few mods were missing and a few don't seem to be available in the mod pool.

I couldn't find a prettier way to include all the mods that should display in the dropdowns, so I added the mod pool manually for the item.

### Steps taken to verify a working solution:
- Create a new build
- Go to the items tab and select `The Queen's Hunger` to add to the build
- Check that the available Prefixes and Suffixed match the expected mod pool

### Link to a build that showcases this PR:
N/A as it's simple to set up.

### Before screenshot:
Missing prefixes.
<img width="911" height="1256" alt="image" src="https://github.com/user-attachments/assets/295f4b76-5d86-40ea-a8f6-5a8a2f27e61a" />

### After screenshot:
Offering modifiers now available as an option and other missing prefixes are added.
<img width="921" height="1166" alt="image" src="https://github.com/user-attachments/assets/e5e41a2f-744a-4e49-bcd0-30c0eb66adb8" />
