### PR TITLE
Fix Ancestral and Seismic Cry incorrectly granting damage with Echoes of Creation to some skills

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -294,7 +294,7 @@ skills["AncestralCry"] = {
 	castTime = 0.8,
 	statMap = {
 		["skill_empowers_next_x_melee_attacks"] = {
-			mod("AncestralExertedAttacks", "BASE", nil),
+			mod("AncestralExertedAttacks", "BASE", nil, 0, 0, { type = "SkillType", skillType = SkillType.MeleeSingleTarget }),
 		},
 		["ancestral_cry_elemental_resist_%_per_5_power_up_to_cap"] = {
 			mod("ElementalResist", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry", div = 5, limit = 30 }),
@@ -9054,7 +9054,7 @@ skills["SeismicCry"] = {
 	castTime = 0.8,
 	statMap = {
 		["skill_empowers_next_x_melee_attacks"] = {
-			mod("SeismicExertedAttacks", "BASE", nil),
+			mod("SeismicExertedAttacks", "BASE", nil, 0, 0, { type = "SkillType", skillType = SkillType.Slam }),
 		},
 		["seismic_cry_base_slam_skill_area_+%_final"] = {
 			mod("SeismicAoEMoreMultiplier", "BASE", nil),

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -51,7 +51,7 @@ local skills, mod, flag, skill = ...
 #flags warcry area duration
 	statMap = {
 		["skill_empowers_next_x_melee_attacks"] = {
-			mod("AncestralExertedAttacks", "BASE", nil),
+			mod("AncestralExertedAttacks", "BASE", nil, 0, 0, { type = "SkillType", skillType = SkillType.MeleeSingleTarget }),
 		},
 		["ancestral_cry_elemental_resist_%_per_5_power_up_to_cap"] = {
 			mod("ElementalResist", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Warcry", div = 5, limit = 30 }),
@@ -1723,7 +1723,7 @@ local skills, mod, flag, skill = ...
 #flags warcry area duration
 	statMap = {
 		["skill_empowers_next_x_melee_attacks"] = {
-			mod("SeismicExertedAttacks", "BASE", nil),
+			mod("SeismicExertedAttacks", "BASE", nil, 0, 0, { type = "SkillType", skillType = SkillType.Slam }),
 		},
 		["seismic_cry_base_slam_skill_area_+%_final"] = {
 			mod("SeismicAoEMoreMultiplier", "BASE", nil),


### PR DESCRIPTION
Fixes #9463

### Description of the problem being solved:
Exerts for Seismic and Ancestral Cry were being applied to any skill instead of just slam skills so when the code in Calc Perform went to count the number of Warcries that were exerting a skill, those 2 warcries would count for all melee skills
Now filter the skill types that those 2 can exert

### Link to a build that showcases this PR:
https://pobb.in/RSWyXC5ivo2t

### Before screenshot:
<img width="833" height="207" alt="image" src="https://github.com/user-attachments/assets/d2e3eed5-1683-46d4-8d5b-5517277492a8" />
<img width="829" height="158" alt="image" src="https://github.com/user-attachments/assets/55199d79-3718-4c4f-8049-cf3007324396" />

### After screenshot:
<img width="819" height="190" alt="image" src="https://github.com/user-attachments/assets/e22678db-496a-4ea5-8cf2-7b589beb7be6" />
<img width="805" height="143" alt="image" src="https://github.com/user-attachments/assets/4528ebdf-aae1-4589-b1e6-830b9f16378c" />
