### PR TITLE
Add compareJewelsOfSameType option for ItemsTab

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -3984,14 +3984,17 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 		for _, compareSlot in pairs(compareSlots) do
 			if not main.slotOnlyTooltips or (slot and (slot.nodeId == compareSlot.nodeId or slot.slotName == compareSlot.slotName)) or not slot or slot == compareSlot then
 				local selItem = self.items[compareSlot.selItemId]
-				local output = calcFunc({ repSlotName = compareSlot.slotName, repItem = item ~= selItem and item or nil})
-				local header
-				if item == selItem then
-					header = "^7Removing this item from "..compareSlot.label.." will give you:"
-				else
-					header = string.format("^7Equipping this item in %s will give you:%s", compareSlot.label, selItem and "\n(replacing "..colorCodes[selItem.rarity]..selItem.name.."^7)" or "")
+
+				if not (main.compareJewelsOfSameType and item.type == "Jewel" and not self:IsSameBase(item, selItem)) then
+					local output = calcFunc({ repSlotName = compareSlot.slotName, repItem = item ~= selItem and item or nil})
+					local header
+					if item == selItem then
+						header = "^7Removing this item from "..compareSlot.label.." will give you:"
+					else
+						header = string.format("^7Equipping this item in %s will give you:%s", compareSlot.label, selItem and "\n(replacing "..colorCodes[selItem.rarity]..selItem.name.."^7)" or "")
+					end
+					self.build:AddStatComparesToTooltip(tooltip, calcBase, output, header)
 				end
-				self.build:AddStatComparesToTooltip(tooltip, calcBase, output, header)
 			end
 		end
 	end
@@ -4004,6 +4007,26 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 			tooltip:AddLine(14, "^7"..modLib.formatMod(mod))
 		end
 	end
+end
+
+function ItemsTabClass:IsSameBase(firstItem, secondItem)
+	if not secondItem then
+		return false
+	end
+
+	if not firstItem.base or not secondItem.base then
+		return firstItem.type == secondItem.type
+	end
+
+	if not firstItem.base.subType and not secondItem.base.subType then
+		return firstItem.base.type == secondItem.base.type
+	end
+
+	if firstItem.base.subType == secondItem.base.subType then
+		return true
+	end
+
+	return false
 end
 
 function ItemsTabClass:CreateUndoState()

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -114,6 +114,7 @@ function main:Init()
 	self.showFlavourText = true
 	self.showAnimations = true
 	self.showAllItemAffixes = true
+	self.compareJewelsOfSameType = false
 	self.errorReadingSettings = false
 
 	if not SetDPIScaleOverridePercent then SetDPIScaleOverridePercent = function(scale) end end
@@ -660,6 +661,9 @@ function main:LoadSettings(ignoreBuild)
 					self.dpiScaleOverridePercent = tonumber(node.attrib.dpiScaleOverridePercent) or 0
 					SetDPIScaleOverridePercent(self.dpiScaleOverridePercent)
 				end
+				if node.attrib.compareJewelsOfSameType then
+					self.compareJewelsOfSameType = node.attrib.compareJewelsOfSameType == "true"
+				end
 			end
 		end
 	end
@@ -791,6 +795,7 @@ function main:SaveSettings()
 		showAnimations = tostring(self.showAnimations),
 		showAllItemAffixes = tostring(self.showAllItemAffixes),
 		dpiScaleOverridePercent = tostring(self.dpiScaleOverridePercent),
+		compareJewelsOfSameType = tostring(self.compareJewelsOfSameType),
 	} })
 	local res, errMsg = common.xml.SaveXMLFile(setXML, self.userPath.."Settings.xml")
 	if not res then
@@ -1078,6 +1083,13 @@ function main:OpenOptionsPopup()
 	end)
 	controls.invertSliderScrollDirection.tooltipText = "Default scroll direction is:\nScroll Up = Move right\nScroll Down = Move left"
 	controls.invertSliderScrollDirection.state = self.invertSliderScrollDirection
+
+	nextRow()
+	controls.compareJewelsOfSameType = new("CheckBoxControl", { "TOPLEFT", nil, "TOPLEFT" }, { defaultLabelPlacementX, currentY, 20 }, "^7Compare jewels of the same type:", function(state)
+		self.compareJewelsOfSameType = state
+	end)
+	controls.compareJewelsOfSameType.tooltipText = "Enabling this option will force comparing jewels only jewels of the same type."
+	controls.compareJewelsOfSameType.state = self.compareJewelsOfSameType
 	
 	if launch.devMode then
 		nextRow()
@@ -1118,6 +1130,7 @@ function main:OpenOptionsPopup()
 	local initialShowAnimations = self.showAnimations
 	local initialShowAllItemAffixes = self.showAllItemAffixes
 	local initialDpiScaleOverridePercent = self.dpiScaleOverridePercent
+	local initialCompareJewelsOfSameType = self.compareJewelsOfSameType
 
 	-- last line with buttons has more spacing
 	nextRow(1.5)
@@ -1175,6 +1188,7 @@ function main:OpenOptionsPopup()
 		self.showAllItemAffixes = initialShowAllItemAffixes
 		self.dpiScaleOverridePercent = initialDpiScaleOverridePercent
 		SetDPIScaleOverridePercent(self.dpiScaleOverridePercent)
+		self.compareJewelsOfSameType = initialCompareJewelsOfSameType
 		main:ClosePopup()
 	end)
 	nextRow(1.5)


### PR DESCRIPTION
Compare only jewels of the same type when the option is set to true. Maintain existing behavior by defaulting the option to false.
This PR picks up the work started by @michelrtm in #6314. I've updated it to work with the tip of tree.

Fixes #6275.

### Description of the problem being solved:
Currently, jewels (e.g., Abyss, Crimson, Cobalt, Viridian) are compared against all occupied jewel slots, including incompatible types like Cluster Jewels, which creates irrelevant data. This change introduces a toggle to ensure jewels are only compared against slots containing the same jewel type.

### Steps taken to verify a working solution:
- Hover on existing jewels with the option enabled/disabled
- Hover on unused jewels with the option enabled/disabled

### Link to a build that showcases this PR:
https://pobb.in/6z027yW7pPix

### Before screenshot:
With option default disabled.

- Hover on existing abyss jewel
<img width="2071" height="1845" alt="Screenshot 2026-02-14 112622" src="https://github.com/user-attachments/assets/78b6bc2a-2af6-4418-994e-889db9b90d24" />

- Hover on unused abyss jewel
<img width="1818" height="1556" alt="Screenshot 2026-02-14 112642" src="https://github.com/user-attachments/assets/bb260ed9-2bf4-4cc6-bd87-d85bea8eed84" />

- Hover on existing crimson jewel
<img width="1828" height="1804" alt="Screenshot 2026-02-14 112707" src="https://github.com/user-attachments/assets/719c4f7a-b445-4133-8f98-1246b22d055e" />

- Hover on unused viridian jewel
<img width="2397" height="1803" alt="Screenshot 2026-02-14 112730" src="https://github.com/user-attachments/assets/e8c26f84-78dd-4135-b8e2-3b21379f2b03" />

### After screenshot:
Enable the option.
<img width="1978" height="1672" alt="Screenshot 2026-02-14 112825" src="https://github.com/user-attachments/assets/a82b56d8-ca7c-4689-b865-45e92d84c08c" />

- Hover on existing abyss jewel
<img width="1815" height="1562" alt="Screenshot 2026-02-14 112949" src="https://github.com/user-attachments/assets/6ea58099-a497-4825-89c0-34f467493b25" />

- Hover on unused abyss jewel
<img width="1875" height="1575" alt="Screenshot 2026-02-14 113008" src="https://github.com/user-attachments/assets/160d4434-649d-431f-afeb-cfd29a8111eb" />

- Hover on existing crimson jewel
<img width="1861" height="1551" alt="Screenshot 2026-02-14 113021" src="https://github.com/user-attachments/assets/f9bfa0db-0f4d-4521-8532-23894c6f5347" />

- Hover on unused viridian jewel
<img width="1840" height="1571" alt="Screenshot 2026-02-14 113030" src="https://github.com/user-attachments/assets/d041c741-e09b-494f-97ca-86792735e948" />
