### PR TITLE
Warn the player when mine skills and Eternal Blessing support are used together

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1663,6 +1663,29 @@ function buildMode:AddDisplayStatList(statList, actor)
 	end
 
 	do
+		if actor == self.calcsTab.mainEnv.player and actor.activeSkillList then
+			local hasEternalBlessing = false
+			local hasMineSkill = false
+
+			for _, activeSkill in ipairs(actor.activeSkillList) do
+				hasMineSkill = hasMineSkill or activeSkill.skillFlags.mine
+				for _, supportEffect in ipairs(activeSkill.supportList) do
+					if supportEffect.grantedEffect and supportEffect.grantedEffect.id == "SupportEternalBlessing" then
+						hasEternalBlessing = true
+						break
+					end
+				end
+				if hasEternalBlessing and hasMineSkill then
+					break
+				end			
+			end
+			if hasEternalBlessing and hasMineSkill then
+				InsertIfNew(self.controls.warnings.lines, "Eternal Blessing and mine skills cannot be used together")
+			end
+		end
+	end
+
+	do
 		local aspectCount = 0
 		aspectCount = aspectCount + (actor.output.CrabBarriersMax > 0 and actor.output.CrabBarriers > 0 and 1 or 0)
 		aspectCount = aspectCount + (aspectCount < 2 and actor.modDB:Flag(nil, "Condition:AspectOfTheSpiderActive") and 1 or 0)


### PR DESCRIPTION
Fixes #9477 .

### Description of the problem being solved:
In-game mine skills cannot be used if Eternal Blessing support is used to enable an aura. This adds a warning to indicate that.

### Steps taken to verify a working solution:
- Equip Eternal Blessing + any aura
- Toggle various on/off various mine skills to ensure the warning appears and doesn't duplicate.
- Test the warning disappears when eternal blessing is disabled.

### Link to a build that showcases this PR:
https://pobb.in/kFJIjkyEdpXV

### Before screenshot:
<img width="307" height="68" alt="eb-nowarning-1" src="https://github.com/user-attachments/assets/b76ffac2-bf7d-434a-97ea-74cf6ab2936f" />

### After screenshot:
<img width="477" height="57" alt="eb-warning-1" src="https://github.com/user-attachments/assets/495b7efd-c3a3-4c0b-bbe7-58865f51713d" />
