### PR TITLE
Add save as build sorting options

### DIFF
--- a/src/Classes/FolderListControl.lua
+++ b/src/Classes/FolderListControl.lua
@@ -9,6 +9,7 @@ local t_insert = table.insert
 local FolderListClass = newClass("FolderListControl", "ListControl", function(self, anchor, rect, subPath, onChange)
 	self.ListControl(anchor, rect, 16, "VERTICAL", false, { })
 	self.subPath = subPath or ""
+	self.sortMode = "NAME"
 	self.onChangeCallback = onChange
 
 	self.controls.path = new("PathControl", {"BOTTOM",self,"TOP"}, {0, -2, self.width, 24}, main.buildPath, self.subPath, function(newSubPath)
@@ -25,7 +26,7 @@ end)
 
 function FolderListClass:SortList()
 	if not self.list then return end
-	local sortMode = main.buildSortMode or "NAME"
+	local sortMode = self.sortMode
 
 	table.sort(self.list, function(a, b)
 		if sortMode == "EDITED" then

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -68,6 +68,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild, importLin
 	if not buildName then
 		main:SetMode("LIST")
 	end
+	self.saveAsSortMode = "NAME"
 
 	-- Load build file
 	self.xmlSectionList = { }
@@ -1310,10 +1311,14 @@ function buildMode:OpenSaveAsPopup()
 			end
 		end)
 	end)
-	controls.folder = new("FolderListControl", nil, {0, 115, 450, 100}, self.dbFileSubPath, function(subPath)
+
+	controls.folder = new("FolderListControl", nil, {0, 115, 450, 400}, self.dbFileSubPath, function(subPath)
 		updateBuildName()
 	end)
-	controls.save = new("ButtonControl", nil, {-45, 225, 80, 20}, "Save", function()
+	controls.folder.sortMode = self.saveAsSortMode
+	controls.folder:SortList()
+
+	controls.save = new("ButtonControl", nil, {-45, 525, 80, 20}, "Save", function()
 		main:ClosePopup()
 		self.dbFileName = newFileName
 		self.buildName = newBuildName
@@ -1321,7 +1326,7 @@ function buildMode:OpenSaveAsPopup()
 		self:SaveDBFile()
 		self.spec:SetWindowTitleWithBuildClass()
 	end)
-	controls.close = new("ButtonControl", nil, {45, 225, 80, 20}, "Cancel", function()
+	controls.close = new("ButtonControl", nil, {45, 525, 80, 20}, "Cancel", function()
 		main:ClosePopup()
 		self.actionOnSave = nil
 	end)
@@ -1333,7 +1338,18 @@ function buildMode:OpenSaveAsPopup()
 		controls.save.enabled = false
 	end
 
-	main:OpenPopup(470, 255, self.dbFileName and "Save As" or "Save", controls, "save", "edit", "close")
+	controls.buildSortMode = new("DropDownControl", { "TOPRIGHT", nil, "TOPRIGHT" }, { -10, 70, 120, 18 }, {
+		{ label = "Sort By Name", mode = "NAME" },
+		{ label = "Sort By Last Edited", mode = "EDITED" },
+	}, function(index, value)
+		self.saveAsSortMode = value.mode
+		controls.folder.sortMode = value.mode
+		controls.folder:SortList()
+	end)
+	controls.buildSortMode.tooltipText = "Sort folders by name or date modified."
+	controls.buildSortMode:SelByValue(self.saveAsSortMode, "mode")
+
+	main:OpenPopup(470, 555, self.dbFileName and "Save As" or "Save", controls, "save", "edit", "close")
 end
 
 -- Open the spectre library popup


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:

Previously, it'd share what ever setting was used for the Build list, so to change that setting you had to:

- close your Save As dialog
- close your current build
- change the drop down there
- reopen the build (if you remember what it was, or if you didn't forget to save it)
- click Save As again..

Now the the Save As dialogue has its own option

(I took the opportunity to resize the Save As dialog, 10yo game, people must be insanely long lists, makes browsing more sane)

### Steps taken to verify a working solution:
- New Build
- Save As
- Change the popup
- Watch folder list sorted

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:

<img width="817" height="657" alt="image" src="https://github.com/user-attachments/assets/ace994a1-f916-4926-811a-288aa693fd27" />
