### PR TITLE
Hide graft slots if not 3.27 tree

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -30,7 +30,7 @@ local socketDropList = {
 	{ label = colorCodes.SCION.."W", color = "W" }
 }
 
-local baseSlots = { "Weapon 1", "Weapon 2", "Helmet", "Body Armour", "Gloves", "Boots", "Amulet", "Ring 1", "Ring 2", "Ring 3", "Belt", "Flask 1", "Flask 2", "Flask 3", "Flask 4", "Flask 5", "Graft 1", "Graft 2" }
+local baseSlots = { "Weapon 1", "Weapon 2", "Helmet", "Body Armour", "Gloves", "Boots", "Amulet", "Ring 1", "Ring 2", "Ring 3", "Belt", "Graft 1", "Graft 2", "Flask 1", "Flask 2", "Flask 3", "Flask 4", "Flask 5" }
 
 local influenceInfo = itemLib.influenceInfo.all
 
@@ -141,6 +141,10 @@ local ItemsTabClass = newClass("ItemsTab", "UndoHandler", "ControlHost", "Contro
 					return not abyssal.inactive and self.activeItemSet.useSecondWeaponSet
 				end
 				swapSlot.abyssalSocketList[i] = abyssal
+			end
+		elseif slotName == "Graft 1" or slotName == "Graft 2" then
+			slot.shown = function()
+				return self.build.spec.treeVersion:find("3_27")
 			end
 		elseif slotName == "Ring 3" then
 			slot.shown = function()

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -671,6 +671,11 @@ function calcs.initEnv(build, mode, override, specEnv)
 		local jewelLimits = {}
 		for _, slot in pairs(build.itemsTab.orderedSlots) do
 			local slotName = slot.slotName
+			if slotName == "Graft 1" or slotName == "Graft 2" then
+				if not build.spec.treeVersion:find("3_27") then
+					goto continue
+				end
+			end
 			local item
 			if slotName == override.repSlotName then
 				item = override.repItem


### PR DESCRIPTION
### Description of the problem being solved:
Grafts are removed in 3.28. This PR keeps the grafts equipped in the slot for legacy builds, but does not calc the slot if the tree is not 3.27. If we instead remove the item from the slot, switching back to the 3.27 tree for comparison will always have the grafts missing. I'm not 100% decided on what's better here. Keeping it hidden is better for legacy stuff, but how important is that really?
