### PR TITLE
Redirect user to build list menu on initial build load crash

### DIFF
--- a/src/Launch.lua
+++ b/src/Launch.lua
@@ -111,7 +111,7 @@ function launch:OnFrame()
 			local errMsg = PCall(self.main.OnFrame, self.main)
 			if errMsg then
 				-- Send user to build list menu if a build crashes on initial load
-				if self.main.modes.BUILD.outputRevision == 1 and self.main.modes.BUILD.buildFlag then
+				if self.main.modes.BUILD.outputRevision == 1 and self.main.modes.BUILD.buildFlag and not self.devMode then
 					main:SetMode("LIST")
 				end
 				self:ShowErrMsg("In 'OnFrame': %s", errMsg)

--- a/src/Launch.lua
+++ b/src/Launch.lua
@@ -110,6 +110,10 @@ function launch:OnFrame()
 		if self.main.OnFrame then
 			local errMsg = PCall(self.main.OnFrame, self.main)
 			if errMsg then
+				-- Send user to build list menu if a build crashes on initial load
+				if self.main.modes.BUILD.outputRevision == 1 and self.main.modes.BUILD.buildFlag then
+					main:SetMode("LIST")
+				end
 				self:ShowErrMsg("In 'OnFrame': %s", errMsg)
 			end
 		end


### PR DESCRIPTION
### Description of the problem being solved:
Currently if a build crashes on initial load the user will be stuck in the OnError screen. This is especially problematic if the build is set to default load on startup essentially locking the user out of POB. This PR redirect the user to the build list menu if a build crashes on initial load allowing the user to dismiss the error and load a different build.

The main caveat with the suggested approach is that I'm not sure whether global state won't get wonky. It doesn't appear to from testing.

### Steps taken to verify a working solution:
- Test with build that crashes on startup
  - The user is redirected to build list screen.
- Test with build that crashes on hover (dismiss-able error)
  - Since the user can partially continue working on the build the user is not redirected.

### Link to a build that showcases this PR:
- None. I've tested by applying asserts.
### Before video:

https://github.com/user-attachments/assets/a571bbad-a618-4488-8333-58764c3b7ec0


### After video:

https://github.com/user-attachments/assets/9e3032f9-c70d-44fe-be24-91cc8715e69e

