### PR TITLE
Remove discriminator alert when the account name field is empty

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -70,7 +70,7 @@ local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(
 	end
 	self.controls.accountNameGo.tooltipFunc = function(tooltip)
 		tooltip:Clear()
-		if not self.controls.accountName.buf:match("[#%-]%d%d%d%d$") then
+		if not self.controls.accountName.buf:match("[#%-]%d%d%d%d$") and self.controls.accountName.buf ~= "" then
 			tooltip:AddLine(16, "^7Missing discriminator e.g. " .. self.controls.accountName.buf .. "#1234")
 		end
 	end
@@ -97,7 +97,7 @@ local ImportTabClass = newClass("ImportTab", "ControlHost", "Control", function(
 
 	self.controls.accountNameMissingDiscriminator = new("LabelControl", {"TOPLEFT",self.controls.accountName,"BOTTOMLEFT"}, {0, 8, 0, 16}, "^1Missing discriminator e.g. #1234")
 	self.controls.accountNameMissingDiscriminator.shown = function()
-		return not self.controls.accountName.buf:match("[#%-]%d%d%d%d$")
+		return not self.controls.accountName.buf:match("[#%-]%d%d%d%d$") and self.controls.accountName.buf ~= ""
 	end
 
 	self.controls.accountNameUnicode = new("LabelControl", {"TOPLEFT",self.controls.accountRealm,"BOTTOMLEFT"}, {0, 34, 0, 14}, "^7Note: if the account name contains non-ASCII characters it must be pasted into the textbox,\nnot typed manually.")


### PR DESCRIPTION
### Description of the problem being solved:
Just a minor change to hide the alert when the account name field is empty

### Steps taken to verify a working solution:
- Open the import tab
- Leave the accountName field blank
- It should no show the "missing discriminator" alert
- Type anything in the field
- The alert should show as usual

### Link to a build that showcases this PR:
Not needed

### Before screenshot:
<img width="664" height="274" alt="image" src="https://github.com/user-attachments/assets/7feacee2-3bc4-4f5b-980a-439e31ca875b" />

### After screenshot:
<img width="664" height="272" alt="image" src="https://github.com/user-attachments/assets/966e8315-4e9a-49f3-85d7-2b7bae21068d" />
<img width="661" height="270" alt="image" src="https://github.com/user-attachments/assets/f62578eb-7e08-4bc3-9e57-416ae3a3af8d" />
