### PR TITLE
Fix headless path helpers for relative data loads

### DIFF
--- a/src/HeadlessWrapper.lua
+++ b/src/HeadlessWrapper.lua
@@ -99,14 +99,25 @@ end
 function GetTime()
 	return 0
 end
+local function getCwd()
+	local handle = io.popen("pwd")
+	if not handle then
+		return "."
+	end
+	local cwd = handle:read("*l")
+	handle:close()
+	return cwd or "."
+end
+local HEADLESS_SCRIPT_PATH = getCwd()
+local HEADLESS_RUNTIME_PATH = HEADLESS_SCRIPT_PATH .. "/../runtime"
 function GetScriptPath()
-	return ""
+	return HEADLESS_SCRIPT_PATH
 end
 function GetRuntimePath()
-	return ""
+	return HEADLESS_RUNTIME_PATH
 end
 function GetUserPath()
-	return ""
+	return HEADLESS_SCRIPT_PATH
 end
 function MakeDir(path) end
 function RemoveDir(path) end


### PR DESCRIPTION
## Summary
- make `GetScriptPath()` return the actual headless working directory instead of an empty string
- derive `GetRuntimePath()` and `GetUserPath()` from that resolved path
- fix headless imports that load data files relative to the script root

## Repro
- run headless PoB with `loadBuildFromJSON(...)` on a character that has a timeless jewel allocated
- `Modules/DataLegionLookUpTableHelper.lua` builds lookup-table paths from `GetScriptPath()`
- in headless mode the wrapper currently returns `""`, so those paths resolve to `/Data/TimelessJewelData/...` instead of the mounted PoB checkout
- this causes timeless-jewel imports to fail even though the data files are present

## Result
- headless JSON imports can now resolve timeless jewel data from `src/Data/TimelessJewelData`
- this unblocks headless stat extraction for builds that allocate timeless jewels