### PR TITLE
Update Runegraft of Refraction and add Fury parsing

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -8783,6 +8783,7 @@ c["Gain 3 Mana per Taunted Enemy Hit Gain 2 Power Charges on Using a Warcry"]={{
 c["Gain 3 Power Charge on use"]={{}," Power Charge on use "}
 c["Gain 3 Rage on Melee Weapon Hit"]={{[1]={flags=0,keywordFlags=0,name="Condition:CanGainRage",type="FLAG",value=true}},nil}
 c["Gain 3 Rage when Hit by an Enemy"]={{[1]={flags=0,keywordFlags=0,name="Condition:CanGainRage",type="FLAG",value=true}},nil}
+c["Gain 3 Rage when you use a Life Flask"]={{[1]={flags=0,keywordFlags=0,name="Condition:CanGainRage",type="FLAG",value=true}},nil}
 c["Gain 3% of Maximum Life as Extra Maximum Energy Shield"]={{[1]={flags=0,keywordFlags=0,name="LifeGainAsEnergyShield",type="BASE",value=3}},nil}
 c["Gain 3% of Missing Unreserved Life before being Hit by an Enemy Per Defiance"]={{[1]={[1]={type="Multiplier",var="Defiance"},flags=0,keywordFlags=0,name="Life",type="BASE",value=3}}," Missing Unreserved  before being Hit by an Enemy  "}
 c["Gain 30 Energy Shield per Enemy Hit while affected by Discipline"]={{[1]={[1]={type="Condition",var="AffectedByDiscipline"},flags=4,keywordFlags=0,name="EnergyShieldOnHit",type="BASE",value=30}},nil}
@@ -10293,6 +10294,7 @@ c["Projectile Attack Skills have 50% increased Critical Strike Chance"]={{[1]={[
 c["Projectile Attack Skills have 60% increased Critical Strike Chance"]={{[1]={[1]={skillType=47,type="SkillType"},flags=0,keywordFlags=0,name="CritChance",type="INC",value=60}},nil}
 c["Projectile Barrages have no spread"]={nil,"Projectile Barrages have no spread "}
 c["Projectile Barrages have no spread You take no Extra Damage from Critical Strikes while Elusive"]={nil,"Projectile Barrages have no spread You take no Extra Damage from Critical Strikes while Elusive "}
+c["Projectiles Chain +1 times"]={{[1]={flags=1024,keywordFlags=0,name="ChainCountMax",type="BASE",value=1}},nil}
 c["Projectiles Chain +1 times while you have Phasing"]={{[1]={[1]={type="Condition",var="Phasing"},flags=1024,keywordFlags=0,name="ChainCountMax",type="BASE",value=1}},nil}
 c["Projectiles Fork"]={{[1]={flags=1024,keywordFlags=0,name="ForkOnce",type="FLAG",value=true},[2]={flags=1024,keywordFlags=0,name="ForkCountMax",type="BASE",value=1}},nil}
 c["Projectiles Pierce 2 additional Targets"]={{[1]={flags=0,keywordFlags=0,name="PierceCount",type="BASE",value=2}},nil}

--- a/src/Data/TattooPassives.lua
+++ b/src/Data/TattooPassives.lua
@@ -2053,7 +2053,7 @@ return {
 			["overrideType"] = "AlternateMastery", 
 			["sd"] = {
 				[1] = "Fire at most 1 Projectile", 
-				[2] = "Projectiles Chain +1 times",
+				[2] = "Skills Chain +1 times", 
 				[3] = "Projectiles Fork", 
 				[4] = "Limited to 1 Runegraft of Refraction", 
 			}, 

--- a/src/Data/TattooPassives.lua
+++ b/src/Data/TattooPassives.lua
@@ -2053,7 +2053,7 @@ return {
 			["overrideType"] = "AlternateMastery", 
 			["sd"] = {
 				[1] = "Fire at most 1 Projectile", 
-				[2] = "Skills Chain +1 times", 
+				[2] = "Projectiles Chain +1 times",
 				[3] = "Projectiles Fork", 
 				[4] = "Limited to 1 Runegraft of Refraction", 
 			}, 

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2405,6 +2405,9 @@ local specialModList = {
 	["gain %d+ rage on hit with retaliation skills"] = {
 		flag("Condition:CanGainRage"),
 	},
+	["gain %d+ rage when you use a life flask"] = {
+		flag("Condition:CanGainRage"),
+	},
 	["while a unique enemy is in your presence, gain %d+ rage on hit with attacks, no more than once every [%d%.]+ seconds"] = {
 		flag("Condition:CanGainRage", { type = "ActorCondition", actor = "enemy", var = "RareOrUnique" }),
 	},
@@ -4254,6 +4257,7 @@ local specialModList = {
 	["your blink and mirror arrow clones use your gloves"] = { flag("BlinkAndMirrorUseGloves") },
 	-- Projectiles
 	["skills chain %+(%d) times"] = function(num) return { mod("ChainCountMax", "BASE", num) } end,
+	["projectiles chain %+(%d) times"] = function(num) return { mod("ChainCountMax", "BASE", num, nil, ModFlag.Projectile) } end,
 	["arrows chain %+(%d) times"] = function(num) return { mod("ChainCountMax", "BASE", num, nil, 0, KeywordFlag.Arrow) } end,
 	["skills chain an additional time while at maximum frenzy charges"] = { mod("ChainCountMax", "BASE", 1, { type = "StatThreshold", stat = "FrenzyCharges", thresholdStat = "FrenzyChargesMax" }) },
 	["attacks chain an additional time when in main hand"] = { mod("ChainCountMax", "BASE", 1, nil, ModFlag.Attack, { type = "SlotNumber", num = 1 }) },


### PR DESCRIPTION
### Description of the problem being solved:

Runegraft of Refraction was changed in 3.28 from "Skills Chain +1 times" to "Projectiles Chain +1 times". Updated the display text and added a parser entry for the new projectile-specific wording.

Also added parsing for Runegraft of Fury's "Gain 3 Rage when you use a Life Flask" so the rage config shows up when it's allocated.

### Steps taken to verify a working solution:
- Full test suite passes (195/0/0/0)
- Parser entries follow existing patterns for projectile chain and rage gain mods
- ModCache entries match the format of neighboring entries

### Link to a build that showcases this PR:

N/A — Runegraft tree data for these hasn't been exported yet, but the parsing is ready for when it is.