### PR TITLE
Add support for defaulting gems to level 1

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -51,7 +51,7 @@ This hides gems with a minimum level requirement above your character level, pre
 		gemLevel = "characterLevel",
 	},
 	{
-		label = "Level One",
+		label = "Level 1",
 		description = "All gems default to level 1.",
 		gemLevel = "levelOne",
 	},

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -50,6 +50,11 @@ Awakened gems default to their highest valid non-corrupted gem level.]],
 This hides gems with a minimum level requirement above your character level, preventing them from showing up in the dropdown list.]],
 		gemLevel = "characterLevel",
 	},
+	{
+		label = "Level One",
+		description = "All gems default to level 1.",
+		gemLevel = "levelOne",
+	},
 }
 
 local showSupportGemTypeList = {
@@ -1053,6 +1058,8 @@ function SkillsTabClass:ProcessGemLevel(gemData)
 		end
 	elseif self.defaultGemLevel == "normalMaximum" then
 		return naturalMaxLevel
+	elseif self.defaultGemLevel == "levelOne" then
+		return 1
 	else -- self.defaultGemLevel == "characterLevel"
 		local maxGemLevel = naturalMaxLevel
 		if not grantedEffect.levels[maxGemLevel] then


### PR DESCRIPTION
Fixes #9512

### Description of the problem being solved:
Add option to default gems to level 1. Open to different label naming.

### Steps taken to verify a working solution:
- Verify dropdown shows only level one actives/supports

### After screenshot:
<img width="548" height="230" alt="image" src="https://github.com/user-attachments/assets/ca7486ef-8243-4bc2-a633-38247f196820" />
<img width="990" height="467" alt="image" src="https://github.com/user-attachments/assets/9db2098f-85db-47c5-8d4e-1147264bba2c" />
<img width="1165" height="836" alt="image" src="https://github.com/user-attachments/assets/20e9f046-60a8-4e4f-b87a-ef7d18b7bd37" />
