### PR TITLE
Cancel power report calcs through toast message

### DIFF
--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -207,7 +207,7 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 		self.controls.treeHeatMapStatSelect.shown = state
 
 		if state == false then
-			self.controls.powerReportList.shown = false 
+			self.controls.powerReportList.shown = false
 		end
 	end)
 
@@ -302,12 +302,17 @@ local TreeTabClass = newClass("TreeTab", "ControlHost", function(self, build)
 
 		self.controls.powerReportList.label = message
 		self.lastProgressToastUpdate = now
-		local toastIndex = findToastIndex("^Building Power Report")
+		local toastIndex = findToastIndex("^Cancelling")
 		if toastIndex then
-			main.toastMessages[toastIndex] = message
+			self.viewer.showHeatMap = false
 		else
-			t_insert(main.toastMessages, message)
-			self.powerBuilderToastActive = true
+			toastIndex = findToastIndex("^Building Power Report")
+			if toastIndex then
+				main.toastMessages[toastIndex] = message
+			else
+				t_insert(main.toastMessages, message)
+				self.powerBuilderToastActive = true
+			end
 		end
 	end
 	-- Completion callback from the CalcsTab power builder coroutine

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -236,6 +236,9 @@ function main:Init()
 	self.controls.dismissToast = new("ButtonControl", {"BOTTOMLEFT",self.anchorMain,"BOTTOMLEFT"}, {0, function() return -self.mainBarHeight + self.toastHeight end, 80, 20}, "Dismiss", function()
 		self.toastMode = "HIDING"
 		self.toastStart = GetTime()
+		if self.toastMessages[1]:match("^Building Power Report") then
+			self.toastMessages[1] = "Cancelling"
+		end
 	end)
 	self.controls.dismissToast.shown = function()
 		return self.toastMode == "SHOWN"
@@ -386,6 +389,9 @@ function main:OnFrame()
 
 	-- Run toasts
 	if self.toastMessages[1] then
+		if self.toastMessages[1]:match("^Building Power Report") then
+			self.controls.dismissToast.label = "Cancel"
+		end
 		if not self.toastMode then
 			self.toastMode = "SHOWING"
 			self.toastStart = GetTime()


### PR DESCRIPTION
### Description of the problem being solved:
Currently the dismiss button on the power report toast message doesn't really do anything. It hides the message for a few frames, but it instantly shown again with the new percentage.

I figured changing the button to be "Cancel" for the power report makes sense. Clicking Cancel will toggle the node power box on the tree tab.

Currently, enabling the node power calcs, then switching to a different tab (like Items) will stop the power report. Clicking Cancel then will not stop the power report when returning to the Tree tab. So maybe there is a better way of doing this, but making this PR for now.

### After screenshot:
<img width="327" height="84" alt="image" src="https://github.com/user-attachments/assets/c9b1617a-c368-4547-a936-59664a52535d" />
