### PR TITLE
Allow Crab Barriers to be set to 0

### DIFF
--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -265,11 +265,11 @@ return {
 		modList:NewMod("Condition:CatsAgilityActive", "FLAG", true, "Config")
 	end },
 	{ label = "Aspect of the Crab:", ifSkill = "Aspect of the Crab" },
-	{ var = "overrideCrabBarriers", type = "count", label = "# of Crab Barriers (if not maximum):", ifSkill = "Aspect of the Crab", apply = function(val, modList, enemyModList)
+	{ var = "overrideCrabBarriers", type = "countAllowZero", label = "# of Crab Barriers (if not maximum):", ifSkill = "Aspect of the Crab", apply = function(val, modList, enemyModList)
 		modList:NewMod("CrabBarriers", "OVERRIDE", val, "Config", { type = "Condition", var = "Combat" })
 	end },
 	{ label = "Aspect of the Spider:", ifSkill = "Aspect of the Spider" },
-	{ var = "aspectOfTheSpiderWebStacks", type = "count", label = "# of Spider's Web Stacks:", ifSkill = "Aspect of the Spider", apply = function(val, modList, enemyModList)
+	{ var = "aspectOfTheSpiderWebStacks", type = "countAllowZero", label = "# of Spider's Web Stacks:", ifSkill = "Aspect of the Spider", apply = function(val, modList, enemyModList)
 		modList:NewMod("ExtraSkillMod", "LIST", { mod = modLib.createMod("Multiplier:SpiderWebApplyStack", "BASE", val) }, "Config", { type = "SkillName", skillName = "Aspect of the Spider" })
 		if val > 0 then
 			modList:NewMod("Condition:AspectOfTheSpiderActive", "FLAG", true, "Config")


### PR DESCRIPTION
### Description of the problem being solved:
When I have aspect of the crab, I cannot set the number of barriers to 0. This means I cannot see my physical max hit on 0 barriers which seems odd.

Spider webs do work, but I think its type should also be countAllowZero to be consistent (works because it looks like we just added a `if val > 0 then` check to the apply function)

### Steps taken to verify a working solution:
Set them to 0, saw that it properly calculated the max hit.

### Before screenshot:
<img width="383" height="160" alt="image" src="https://github.com/user-attachments/assets/90884ecd-53c1-41ce-b2d8-8ff889a9f371" />
<img width="682" height="39" alt="image" src="https://github.com/user-attachments/assets/c2cc6dee-6aa4-4316-9e18-61fedd491d79" />

### After screenshot:
<img width="339" height="106" alt="image" src="https://github.com/user-attachments/assets/5150fb49-a2bb-4dd6-b1af-bfdf418f641c" />
<img width="689" height="37" alt="image" src="https://github.com/user-attachments/assets/f657cadf-2a00-4b9e-9b32-8142389bdb94" />
