### PR TITLE
Fix Enemy damage conversion mods scaling enemy damage

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1719,10 +1719,11 @@ function calcs.buildDefenceEstimations(env, actor)
 				-- Calculate the amount converted/gained as
 				for _, damageTypeTo in ipairs(dmgTypeList) do
 					local gainAsPercent = enemyDB:Sum("BASE", enemyCfg, (damageType.."DamageGainAs"..damageTypeTo)) / 100
-					local conversionPercent = (conversions[damageTypeTo.."skill"] + conversions[damageTypeTo]) / 100
-					if conversionPercent > 0 and damageType == "Physical" and damageTypeTo ~= "Chaos" then
+					local conversionPercent = conversions[damageTypeTo] / 100
+					local skillConversionPercent = conversions[damageTypeTo.."skill"] / 100
+					if skillConversionPercent > 0 and damageType == "Physical" and damageTypeTo ~= "Chaos" then
 						local physBonus = 1 + data.monsterPhysConversionMultiTable[env.enemyLevel] / 100
-						conversionPercent = conversionPercent * physBonus
+						conversionPercent = conversionPercent + skillConversionPercent * physBonus
 					end
 					if gainAsPercent > 0 or conversionPercent > 0 then
 						enemyDamageConversion[damageTypeTo] = enemyDamageConversion[damageTypeTo] or { }


### PR DESCRIPTION
Fixes #9444

### Description of the problem being solved:
When I added the fix for scaling enemy damage values by player and enemy conversion mods (#9372), I forgot to include the fix where only enemy skill damage conversion is affected by the phys conversion multiplier
So mods like Shaper of Flames or Kaom's Binding were increasing the damage dealt by the enemy, which was no longer the case in-game.

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/vjnj30og
### Before screenshot:
<img width="708" height="155" alt="image" src="https://github.com/user-attachments/assets/81a99f6e-71e1-42a6-b00c-5d49eab88853" />

### After screenshot:
<img width="709" height="159" alt="image" src="https://github.com/user-attachments/assets/f895d67b-e25c-48ab-b113-3408ed11ed12" />
