### PR TITLE
Add Stormburst calc for Exploding Orb Damage

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -17706,7 +17706,10 @@ skills["StormBurst"] = {
 		},
 		{
 			name = "Max Channelled Orbs"
-		}
+		},
+		{
+			name = "Max Duration Explode"
+		},
 	},
 	preDamageFunc = function(activeSkill, output)
 		if activeSkill.skillPart == 2 then
@@ -17715,6 +17718,10 @@ skills["StormBurst"] = {
 			local jumpPeriod = activeSkill.skillData.repeatFrequency * 10
 			-- additional 1 tick upon spawn of orb
 			activeSkill.skillData.dpsMultiplier = (activeSkill.skillData.dpsMultiplier or 1) * (1 + math.floor(duration * 10 / jumpPeriod))
+		elseif activeSkill.skillPart == 3 then
+			local remainingJumps = math.floor((activeSkill.skillData.duration * output.DurationMod + 0.001) / activeSkill.skillData.repeatFrequency)
+			-- Tested in-game and the skill grants more damage only after you have at least 0.8s duration
+			activeSkill.skillModList:NewMod("Damage", "MORE", math.max(activeSkill.skillData.remainingDurationDamage * remainingJumps - 100, 0), "Skill:StormBurst")
 		end
 	end,
 	statMap = {
@@ -17723,6 +17730,7 @@ skills["StormBurst"] = {
 			div = 1000,
 		},
 		["storm_burst_new_damage_+%_final_per_remaining_teleport_zap"] = {
+			skill("remainingDurationDamage", nil),
 		},
 	},
 	baseFlags = {

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -3832,7 +3832,10 @@ local skills, mod, flag, skill = ...
 		},
 		{
 			name = "Max Channelled Orbs"
-		}
+		},
+		{
+			name = "Max Duration Explode"
+		},
 	},
 	preDamageFunc = function(activeSkill, output)
 		if activeSkill.skillPart == 2 then
@@ -3841,6 +3844,10 @@ local skills, mod, flag, skill = ...
 			local jumpPeriod = activeSkill.skillData.repeatFrequency * 10
 			-- additional 1 tick upon spawn of orb
 			activeSkill.skillData.dpsMultiplier = (activeSkill.skillData.dpsMultiplier or 1) * (1 + math.floor(duration * 10 / jumpPeriod))
+		elseif activeSkill.skillPart == 3 then
+			local remainingJumps = math.floor((activeSkill.skillData.duration * output.DurationMod + 0.001) / activeSkill.skillData.repeatFrequency)
+			-- Tested in-game and the skill grants more damage only after you have at least 0.8s duration
+			activeSkill.skillModList:NewMod("Damage", "MORE", math.max(activeSkill.skillData.remainingDurationDamage * remainingJumps - 100, 0), "Skill:StormBurst")
 		end
 	end,
 	statMap = {
@@ -3849,6 +3856,7 @@ local skills, mod, flag, skill = ...
 			div = 1000,
 		},
 		["storm_burst_new_damage_+%_final_per_remaining_teleport_zap"] = {
+			skill("remainingDurationDamage", nil),
 		},
 	},
 #baseMod skill("radius", 16)


### PR DESCRIPTION
Fixes #3272

### Description of the problem being solved:
Adds the component of the skill that deals explosive damage in an area after you stop channeling.
Tested the mechanic in-game to make sure the damage multipliers are correct
When you have less than 0.8s duration the skill does not gain any damage

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/4pc30axb

### Before screenshot:
<img width="811" height="119" alt="image" src="https://github.com/user-attachments/assets/c03378d9-67ca-4b23-94dd-e9e3840faf33" />
<img width="306" height="217" alt="image" src="https://github.com/user-attachments/assets/6801993b-66b7-4c49-88b1-73bdad226f49" />

### After screenshot:
<img width="811" height="155" alt="image" src="https://github.com/user-attachments/assets/fccdcdc4-c389-404b-9a95-5b8340f9ac29" />
<img width="310" height="213" alt="image" src="https://github.com/user-attachments/assets/d65833d3-c49a-44f9-9227-e6f36f286906" />

