### PR TITLE
Fix Decay not being scaled by some DoT multi mods

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -5339,7 +5339,7 @@ function calcs.offence(env, actor, activeSkill)
 		end
 		local inc = skillModList:Sum("INC", dotCfg, "Damage", "ChaosDamage")
 		local more = skillModList:More(dotCfg, "Damage", "ChaosDamage")
-		local mult = skillModList:Override(dotTypeCfg, "DotMultiplier") or skillModList:Sum("BASE", dotTypeCfg, "DotMultiplier") + skillModList:Sum("BASE", dotTypeCfg, "ChaosDotMultiplier")
+		local mult = skillModList:Override(dotCfg, "DotMultiplier") or skillModList:Sum("BASE", dotCfg, "DotMultiplier") + skillModList:Sum("BASE", dotCfg, "ChaosDotMultiplier")
 		output.DecayDPS = skillData.decay * (1 + inc/100) * more * (1 + mult/100) * effMult
 		output.DecayDuration = 8 * debuffDurationMult
 		if breakdown then


### PR DESCRIPTION
### Description of the problem being solved:
The DoT sum calc has been using a nonexistent cfg for at least 6 years

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/gyqj0fzh

### Before screenshot:
<img width="617" height="144" alt="image" src="https://github.com/user-attachments/assets/a9e40576-cb7a-446e-86bd-85c671d36749" />

### After screenshot:
<img width="611" height="234" alt="image" src="https://github.com/user-attachments/assets/49af0812-9591-4a4d-99a9-3c1f8c5dc6d7" />
