### PR TITLE
Fix Reliquarian Widowhail Ascendancy not working

### DIFF
--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1083,7 +1083,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 						end
 					end
 				elseif item.type == "Quiver" and items["Weapon 1"] and items["Weapon 1"].name:match("Widowhail") then
-					local widowHailMod=(1 + (items["Weapon 1"].baseModList:Sum("INC", nil, "EffectOfBonusesFromQuiver") or 100) / 100)
+					local widowHailMod=(1 + (items["Weapon 1"].baseModList:Sum("INC", nil, "EffectOfBonusesFromQuiver") + env.initialNodeModDB:Sum("INC", nil, "EffectOfBonusesFromQuiver") or 100) / 100)
 					scale = scale * widowHailMod
 					env.modDB:NewMod("WidowHailMultiplier", "BASE", widowHailMod, "Widowhail")
 					local combinedList = new("ModList")


### PR DESCRIPTION
Fixes #9563

### Description of the problem being solved:
We were not grabbing the mod from the tree so it wasn't working at all

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/0a5qx0cv

### Before screenshot:
<img width="381" height="202" alt="image" src="https://github.com/user-attachments/assets/7380d8f8-420a-4f9e-8a58-e18821512b66" />

### After screenshot:
<img width="381" height="414" alt="image" src="https://github.com/user-attachments/assets/7024bf43-3dfc-4977-83fb-99fb83449b2e" />
