### PR TITLE
Fix Ynda's Stand and Olroth Bloodline not working correctly

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -839,7 +839,18 @@ function calcs.defence(env, actor)
 			local armourData = actor.itemList[slot] and actor.itemList[slot].armourData
 			if armourData then
 				slotCfg.slotName = slot
+				energyShieldBase = not modDB:Flag(nil, "GainNoEnergyShieldFrom" .. slot) and armourData.EnergyShield or 0
+				armourBase = not modDB:Flag(nil, "GainNoArmourFrom" .. slot) and armourData.Armour or 0
+				evasionBase = not modDB:Flag(nil, "GainNoEvasionFrom" .. slot) and armourData.Evasion or 0
 				wardBase = not modDB:Flag(nil, "GainNoWardFrom" .. slot) and armourData.Ward or 0
+				if slot == "Body Armour" and modDB:Flag(nil, "ConvertBodyArmourArmourEvasionToWard") then
+					local conversion = m_min(modDB:Sum("BASE", nil, "BodyArmourArmourEvasionToWardPercent") / 100, 1)
+					local convertedArmour = armourBase *  conversion
+					local convertedEvasion = evasionBase *  conversion
+					armourBase = armourBase - convertedArmour
+					evasionBase = evasionBase - convertedEvasion
+					wardBase = wardBase + (convertedEvasion + convertedArmour)
+				end
 				if wardBase > 0 then
 					if modDB:Flag(nil, "EnergyShieldToWard") then
 						local inc = modDB:Sum("INC", slotCfg, "Ward", "Defences", "EnergyShield")
@@ -864,7 +875,6 @@ function calcs.defence(env, actor)
 						end
 					end
 				end
-				energyShieldBase = not modDB:Flag(nil, "GainNoEnergyShieldFrom" .. slot) and armourData.EnergyShield or 0
 				if energyShieldBase > 0 then
 					if modDB:Flag(nil, "EnergyShieldToWard") then
 						local more = modDB:More(slotCfg, "EnergyShield", "Defences")
@@ -887,22 +897,14 @@ function calcs.defence(env, actor)
 						end
 					end
 				end
-				armourBase = not modDB:Flag(nil, "GainNoArmourFrom" .. slot) and armourData.Armour or 0
 				if armourBase > 0 then
-					if slot == "Body Armour" and modDB:Flag(nil, "ConvertBodyArmourArmourEvasionToWard")then
-						armourBase = armourBase * (1 - ((m_min(modDB:Sum("BASE", nil, "BodyArmourArmourEvasionToWardPercent"), 100) or 0) / 100))
-					end
 					armour = armour + armourBase * calcLib.mod(modDB, slotCfg, "Armour", "ArmourAndEvasion", "Defences", slot.."ESAndArmour")
 					gearArmour = gearArmour + armourBase
 					if breakdown then
 						breakdown.slot(slot, nil, slotCfg, armourBase, nil, "Armour", "ArmourAndEvasion", "Defences", slot.."ESAndArmour")
 					end
 				end
-				evasionBase = not modDB:Flag(nil, "GainNoEvasionFrom" .. slot) and armourData.Evasion or 0
 				if evasionBase > 0 then
-					if slot == "Body Armour" and modDB:Flag(nil, "ConvertBodyArmourArmourEvasionToWard")then
-						evasionBase = evasionBase * (1 - ((m_min(modDB:Sum("BASE", nil, "BodyArmourArmourEvasionToWardPercent"), 100) or 0) / 100))
-					end
 					gearEvasion = gearEvasion + evasionBase
 					if breakdown then
 						breakdown.slot(slot, nil, slotCfg, evasionBase, nil, "Evasion", "ArmourAndEvasion", "Defences")

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1409,7 +1409,7 @@ function calcs.perform(env, skipEHP)
 		local armourData = env.player.itemList["Body Armour"] and env.player.itemList["Body Armour"].armourData
 		local wardMult = ((modDB:Sum("BASE", nil,"BodyArmourArmourEvasionToWardPercent") or 0) / 100)
 		if armourData then
-			armourData.Ward = armourData.Ward + m_floor((armourData.Evasion + armourData.Armour) * wardMult)
+			armourData.Ward = m_floor((armourData.Evasion + armourData.Armour) * wardMult)
 		end
 	end
 

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1406,14 +1406,10 @@ function calcs.perform(env, skipEHP)
 	end
 
 	if modDB:Flag(nil, "ConvertBodyArmourArmourEvasionToWard") then
-		local ward
 		local armourData = env.player.itemList["Body Armour"] and env.player.itemList["Body Armour"].armourData
+		local wardMult = ((modDB:Sum("BASE", nil,"BodyArmourArmourEvasionToWardPercent") or 0) / 100)
 		if armourData then
-			ward = armourData.Evasion + armourData.Armour
-			if ward > 0 then
-				local wardMult = ((modDB:Sum("BASE", nil,"BodyArmourArmourEvasionToWardPercent") or 0) / 100)
-				modDB:NewMod("Ward", "BASE", ward * wardMult , "Body Armour Armour And Evasion Rating to Ward Conversion")
-			end
+			armourData.Ward = armourData.Ward + m_floor((armourData.Evasion + armourData.Armour) * wardMult)
 		end
 	end
 

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1405,14 +1405,6 @@ function calcs.perform(env, skipEHP)
 		end
 	end
 
-	if modDB:Flag(nil, "ConvertBodyArmourArmourEvasionToWard") then
-		local armourData = env.player.itemList["Body Armour"] and env.player.itemList["Body Armour"].armourData
-		local wardMult = ((modDB:Sum("BASE", nil,"BodyArmourArmourEvasionToWardPercent") or 0) / 100)
-		if armourData then
-			armourData.Ward = m_floor((armourData.Evasion + armourData.Armour) * wardMult)
-		end
-	end
-
 	-- Special handling of Mageblood
 	local maxLeftActiveMagicUtilityCount = modDB:Sum("BASE", nil, "LeftActiveMagicUtilityFlasks")
 	local maxRightActiveMagicUtilityCount = modDB:Sum("BASE", nil, "RightActiveMagicUtilityFlasks")


### PR DESCRIPTION
Fixes #9538

### Description of the problem being solved:
The Ynda's stand belt is meant to convert the armour and evasion on the body armour to war which can then be scaled by mods like increased Defences / Ward from Body Armour

### Steps taken to verify a working solution:
- Test taking armour on and off
-No Ward Body armours yet so replacing the valu of the armour isn't an issue

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/97a4r0ct
### Before screenshot:
<img width="487" height="153" alt="image" src="https://github.com/user-attachments/assets/88f5da14-e472-4faa-8830-9b4c0a37add3" />

### After screenshot:
<img width="550" height="153" alt="image" src="https://github.com/user-attachments/assets/c5dc93ce-0bef-4dbf-a8c6-c9ad3f414434" />
