### PR TITLE
Fix Holy Strike Minion missing Lightning damage conversion from skill gem

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -6174,6 +6174,12 @@ skills["HolyStrike"] = {
 		["Staff"] = true,
 		["Two Handed Mace"] = true,
 	},
+	statMap = {
+		["skill_physical_damage_%_to_convert_to_lightning"] = {
+			mod("SkillPhysicalDamageConvertToLightning", "BASE", nil),
+			mod("MinionModifier", "LIST", { mod = mod("SkillPhysicalDamageConvertToLightning", "BASE", nil, 0, 0) })
+		},
+	},
 	statDescriptionScope = "minion_attack_skill_stat_descriptions",
 	castTime = 1,
 	minionList = {

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -1061,6 +1061,12 @@ local skills, mod, flag, skill = ...
 	minionUses = {
 		["Weapon 1"] = true,
 	},
+	statMap = {
+		["skill_physical_damage_%_to_convert_to_lightning"] = {
+			mod("SkillPhysicalDamageConvertToLightning", "BASE", nil),
+			mod("MinionModifier", "LIST", { mod = mod("SkillPhysicalDamageConvertToLightning", "BASE", nil, 0, 0) })
+		},
+	},
 #mods
 
 #skill Sweep


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:
Holy strike on the current release build does not convert 50% of the minion damage to lightning damage (as shown in the calcs tab when showing minion stats).

### Steps taken to verify a working solution:
- Add statMap to ensure the modifier is respected
- Use build exhibiting the issue on release version to confirm it is fixed on branch version

### Link to a build that showcases this PR:
https://pobb.in/iFpLVAuWKm87

### Before screenshot:
<img width="1016" height="807" alt="image" src="https://github.com/user-attachments/assets/0145feb7-79ae-4a49-b440-3ebcdb3bfe44" />

### After screenshot:
<img width="788" height="625" alt="image" src="https://github.com/user-attachments/assets/434d20b9-26f5-41c6-a311-e43994844f68" />
