### PR TITLE
Fix Acceleration Shrine config tooltip

### DIFF
--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1642,7 +1642,7 @@ Huge sets the radius to 11.
 	{ var = "multiplierPvpDamage", type = "count", label = "Custom PvP Damage multiplier percent:", ifFlag = "isPvP", tooltip = "This multiplies the damage of a given skill in pvp, for instance any with damage multiplier specific to pvp (from skill or support or item like sire of shards)", apply = function(val, modList, enemyModList)
 		modList:NewMod("PvpDamageMultiplier", "MORE", val - 100, "Config")
 	end },
-	{ var = "buffAccelerationShrine", type = "check", label = "Have Acceleration Shrine?", ifFlag = "Condition:CanHaveRegularShrines", tooltip = "This will enable the Acceleration Shrine buff.\n\t15% increased Action Speed\n\t80% increased Projectile Speed", apply = function(val, modList, enemyModList)
+	{ var = "buffAccelerationShrine", type = "check", label = "Have Acceleration Shrine?", ifFlag = "Condition:CanHaveRegularShrines", tooltip = "This will enable the Acceleration Shrine buff.\n\t50% increased Action Speed\n\t80% increased Projectile Speed", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:AccelerationShrine", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 	end },
 	{ var = "buffBrutalShrine", type = "check", label = "Have Brutal Shrine?", ifFlag = "Condition:CanHaveRegularShrines", tooltip = "This will enable the Brutal Shrine buff.\n\t50% increased Damage\n\tKnocks Enemies Back on Hit\n\t30% increased Stun Duration on Enemies", apply = function(val, modList, enemyModList)


### PR DESCRIPTION
### Description of the problem being solved:
The tooltip for Acceleration Shrine is showing the wrong action speed. The mod is correct, this is a typo fix.

<img width="1456" height="147" alt="image" src="https://github.com/user-attachments/assets/84fd4b84-a28d-4f50-ba51-16be282e5b4c" />


### Before screenshot:
<img width="565" height="122" alt="image" src="https://github.com/user-attachments/assets/e228ca5a-96a0-4972-961c-2d5df8334a0a" />
<img width="330" height="73" alt="image" src="https://github.com/user-attachments/assets/838f31a2-6c1c-4d40-ac05-3f3d3c57215c" />


### After screenshot:
<img width="548" height="112" alt="image" src="https://github.com/user-attachments/assets/1f3a3d49-fdcd-496f-b2af-8c20cc05354e" />
