### PR TITLE
Fix Heroic Tragedy trade search using wrong Keystone for Uhtred / Medved

### DIFF
--- a/src/Classes/TimelessJewelListControl.lua
+++ b/src/Classes/TimelessJewelListControl.lua
@@ -99,8 +99,8 @@ Timeless Jewel
 League: Legion
 Limited to: 1 Historic
 Variant: Vorana (Black Scythe Training)
-Variant: Uhtred (The Unbreaking Circle)
-Variant: Medved (Celestial Mathematics)
+Variant: Uhtred (Celestial Mathematics)
+Variant: Medved (The Unbreaking Circle)
 Selected Variant:  ]] .. variant .. "\n" .. [[
 Radius: Large
 Implicits: 0

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -1217,8 +1217,8 @@ function TreeTabClass:FindTimelessJewel()
 		[6] = {
 			{ label = "Any", id = 1 },
 			{ label = "Vorana (Black Scythe Training)", id = 2 },
-			{ label = "Uhtred (The Unbreaking Circle)", id = 3 },
-			{ label = "Medved (Celestial Mathematics)", id = 4 }
+			{ label = "Uhtred (Celestial Mathematics)", id = 3 },
+			{ label = "Medved (The Unbreaking Circle)", id = 4 }
 		}
 	}
 	-- rebuild `timelessData.conquerorType` as we only store the minimum amount of `conquerorType` data in build XML

--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -1881,8 +1881,8 @@ League: Legion
 Source: Drops from Legion in Mirage
 Limited to: 1 Historic
 Variant: Vorana (Black Scythe Training)
-Variant: Uhtred (The Unbreaking Circle)
-Variant: Medved (Celestial Mathematics)
+Variant: Uhtred (Celestial Mathematics)
+Variant: Medved (The Unbreaking Circle)
 Radius: Large
 Implicits: 0
 {variant:1}Remembrancing (100-8000) songworthy deeds by the line of Vorana


### PR DESCRIPTION
I accidently put the wrong keystone name onto the wrong conqueror