### PR TITLE
Fix calculation error with theoretical maximum Poison stacks

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -4430,13 +4430,9 @@ function calcs.offence(env, actor, activeSkill)
 				
 				-- If stack limit exists, avg. poison stack is more complicated
 				if poisonStackLimit and poisonStackLimit > 0 and PoisonStacks > poisonStackLimit then
-					-- Calc number of avg. poisons applied per hit (without hit rate multipliers)
-					local singleHitPoisonChance = output.HitChance / 100 * poisonChance
-					local singleHitPoisonStacks = singleHitPoisonChance * additionalPoisonStacks
-
 					-- Calc how many hits will poison before limit is reached and theoretical max poison stacks, which is different from `poisonStackLimit` due to "additional" poison mechanics 
-					local numPoisoningHits = m_ceil(poisonStackLimit / singleHitPoisonStacks)
-					local maxPoisonStacks = numPoisoningHits * singleHitPoisonStacks
+					local numPoisoningHits = m_ceil(poisonStackLimit / additionalPoisonStacks)
+					local maxPoisonStacks = numPoisoningHits * additionalPoisonStacks
 
 					-- Only use `maxPoisonStacks` if original value exceeds it
 					uncappedPoisonStacks = m_max(PoisonStacks, maxPoisonStacks)


### PR DESCRIPTION
### Description of the problem being solved:
My previous calculation of the theoretical maximum poison stacks used a value for `singleHitPoisonStacks` that also took into account hit chance and poison chance. However, that incorrectly assumed that a fraction of the `additionalPoisonStacks` could be applied, leading to higher theoretical maximums.

As a result, lowering your hit chance or poison chance could lead to higher actual poison DPS which is obviously not true. (except  the edge cases when lowering hit/poison chance puts you below the threshold for "non-Poisoned Enemy")

### Steps taken to verify a working solution:
- Tested with lower poison chance and now value does not exceed actual theoretical maximum

### Link to a build that showcases this PR:
[Test Build](https://pobb.in/5PdTxn7yCalf)
_(see config mods for easy reproduction of wrong value in current version)_

### Before screenshot:
<img width="1001" height="345" alt="image" src="https://github.com/user-attachments/assets/9a5410cd-3191-4407-9868-65212905a55e" />

95% poison chance leads to 13.44 poison stacks

### After screenshot:
<img width="769" height="278" alt="image" src="https://github.com/user-attachments/assets/d70dc629-c523-44ba-88f8-19cf072d2a11" />

Poison stacks correctly limited to 12