### PR TITLE
Fix Cryogenesis not working correctly

### DIFF
--- a/src/Classes/CalcsTab.lua
+++ b/src/Classes/CalcsTab.lua
@@ -614,7 +614,7 @@ function CalcsTabClass:PowerBuilder()
 end
 
 function CalcsTabClass:CalculatePowerStat(selection, original, modified)
-	if modified.Minion and not selection.stat == "FullDPS" then
+	if modified.Minion and selection.stat ~= "FullDPS" then
 		original = original.Minion
 		modified = modified.Minion
 	end

--- a/src/Classes/ModStore.lua
+++ b/src/Classes/ModStore.lua
@@ -300,7 +300,7 @@ function ModStoreClass:GetStat(stat, cfg)
 	if stat == "ManaUnreserved" and self.actor.output[stat] ~= self.actor.output[stat] then
 		-- 0% reserved = total mana
 		return self.actor.output["Mana"]
-	elseif stat == "ManaUnreserved" and not self.actor.output[stat] == nil and self.actor.output[stat] < 0 then
+	elseif stat == "ManaUnreserved" and self.actor.output[stat] ~= nil and self.actor.output[stat] < 0 then
 		-- This reverse engineers how much mana is unreserved before efficiency for accurate Arcane Cloak calcs
 		local reservedPercentBeforeEfficiency = (math.abs(self.actor.output["ManaUnreservedPercent"]) + 100) * ((100 + self.actor["ManaEfficiency"]) / 100)
 		return self.actor.output["Mana"] * (math.ceil(reservedPercentBeforeEfficiency) / 100);

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -173,7 +173,7 @@ function calcs.copyActiveSkill(env, mode, skill)
 		activeEffect.quality = skill.activeEffect.srcInstance.quality
 		activeEffect.qualityId = skill.activeEffect.srcInstance.qualityId
 		activeEffect.srcInstance = skill.activeEffect.srcInstance
-		activeEffect.gemData = skill.activeEffect.srcInstance.gemDat
+		activeEffect.gemData = skill.activeEffect.srcInstance.gemData
 	end
 
 	local newSkill = calcs.createActiveSkill(activeEffect, skill.supportList, skill.actor, skill.socketGroup, skill.summonSkill)

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -3067,7 +3067,7 @@ function calcs.offence(env, actor, activeSkill)
 		elseif skillModList:Flag(cfg, "AllAddedDamageAsCold") then
 			addedDamageRedirectType = "Cold"
 		end
-		if addedDamageRedirectType and not activeSkill.activeEffect.grantedEffect.name == "Elemental Hit" then
+		if addedDamageRedirectType and activeSkill.activeEffect.grantedEffect.name ~= "Elemental Hit" then
 			for _, damageType in ipairs(dmgTypeList) do
 				if damageType ~= addedDamageRedirectType then
 					for _, value in ipairs(skillModList:Tabulate("BASE", cfg, damageType.."Min")) do


### PR DESCRIPTION
I found four definite correctness bugs worth patching immediately. First, CalcActiveSkill.copyActiveSkill assigns activeEffect.gemData = skill.activeEffect.srcInstance.gemDat, which is a typo and should be gemData. That copied-skill path matters because CalcMirages uses calcs.copyActiveSkill(...) before running a recalculation for the mirage skill.

Second, ModStore.lua has a Lua precedence bug: not self.actor.output[stat] == nil is parsed as (not self.actor.output[stat]) == nil, so that branch is effectively dead. The intended condition is self.actor.output[stat] ~= nil. Because that code is in the ManaUnreserved fallback logic, it can suppress the negative-unreserved-mana recovery path.

Third, CalcsTab.lua has the same precedence bug in if modified.Minion and not selection.stat == "FullDPS" then. That should be selection.stat ~= "FullDPS". As written, the minion-switch branch is effectively never taken for normal string values.

Fourth, CalcOffence.lua has the same mistake again: if addedDamageRedirectType and not activeSkill.activeEffect.grantedEffect.name == "Elemental Hit" then. That should be activeSkill.activeEffect.grantedEffect.name ~= "Elemental Hit". In practice, that means the exclusion logic for Elemental Hit is not behaving as intended.