### PR TITLE
Fix casing of D in "Screams of the Desiccated"

### DIFF
--- a/src/Data/Uniques/Special/New.lua
+++ b/src/Data/Uniques/Special/New.lua
@@ -5,7 +5,7 @@
 data.uniques.new = {
 -- New
 [[
-Screams of the desiccated
+Screams of the Desiccated
 Leather Belt
 LevelReq: 56
 Implicits: 1


### PR DESCRIPTION
- Uppercase D in "Screams of the Desiccated" 
- Drive-by: add empty newline at the end of file.

~Fixes # .~ Not linked to a reported issue.

### Description of the problem being solved:
- Name of new unique belt "Screams of the Desiccated" spelled with lowercase D.
- Drive-by: missing newline at end of file.

### Steps taken to verify a working solution:
- n/a, just fixing spelling

### Link to a build that showcases this PR:
n/a, no local build set up

### Before screenshot:
<img width="472" height="285" alt="Screenshot 2026-03-13 at 17 33 57" src="https://github.com/user-attachments/assets/ae25eb58-723e-4cbe-b967-01e420eea6c9" />


### After screenshot:
n/a, no local build but it would be exactly the same except a capital D.