### PR TITLE
Fix Transfusion Support disabling Offering buffs

### DIFF
--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -5203,8 +5203,8 @@ skills["SupportTransfusion"] = {
 	statDescriptionScope = "gem_stat_descriptions",
 	statMap = {
 		["random_nearby_minion_gain_a_soul_eater_soul_on_X_life_spent"] = {
-			flag("Condition:MinionCanHaveSoulEater", { type = "GlobalEffect", effectType = "Buff" }),
-			mod("MinionModifier", "LIST", { mod = mod("Condition:CanHaveSoulEater", "FLAG", true) }, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+			flag("Condition:MinionCanHaveSoulEater", { type = "GlobalEffect", effectType = "Buff", effectName = "Transfusion" }),
+			mod("MinionModifier", "LIST", { mod = mod("Condition:CanHaveSoulEater", "FLAG", true) }, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Transfusion" }),
 		},
 	},
 	qualityStats = {

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -740,8 +740,8 @@ local skills, mod, flag, skill = ...
 #skill SupportTransfusion
 	statMap = {
 		["random_nearby_minion_gain_a_soul_eater_soul_on_X_life_spent"] = {
-			flag("Condition:MinionCanHaveSoulEater", { type = "GlobalEffect", effectType = "Buff" }),
-			mod("MinionModifier", "LIST", { mod = mod("Condition:CanHaveSoulEater", "FLAG", true) }, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
+			flag("Condition:MinionCanHaveSoulEater", { type = "GlobalEffect", effectType = "Buff", effectName = "Transfusion" }),
+			mod("MinionModifier", "LIST", { mod = mod("Condition:CanHaveSoulEater", "FLAG", true) }, 0, 0, { type = "GlobalEffect", effectType = "Buff", effectName = "Transfusion" }),
 		},
 	},
 #mods


### PR DESCRIPTION
Fixes #9608

### Description of the problem being solved:
The transfusion global buff for SoulEater was being picked up as the first buff on the offering skill gems so buffs on the offering skills would not inherit the `buffMinions` and `buffNotPlayer` mod as those only get inherited if the skill already has no buff mods
Giving the mods an effect name forces them to not be included in the buff parsing of the offering skills

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/bo2bhl03

### Before screenshot:
<img width="823" height="261" alt="image" src="https://github.com/user-attachments/assets/6a870832-88c1-4fb7-b8e4-794c428029a5" />


### After screenshot:
<img width="788" height="134" alt="image" src="https://github.com/user-attachments/assets/9bbe3951-3fa6-45fe-bd5c-e04c7f194681" />
