### PR TITLE
Add Gem tooltip for Legacy Gems

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -12,11 +12,6 @@ local m_max = math.max
 local m_floor = math.floor
 
 local toolTipText = "Prefix tag searches with a colon and exclude tags with a dash. e.g. :fire:lightning:-cold:area"
-local nonLegacyAwakened = {
-	["SupportAwakenedEmpower"] = true,
-	["SupportAwakenedEnlighten"] = true,
-	["SupportAwakenedEnhance"] = true,
-}
 local altQualMap = {
 	["Default"] = "",
 	["Alternate1"] = "Anomalous ",
@@ -121,7 +116,7 @@ function GemSelectClass:PopulateGemList()
 			local levelRequirement = gemData.grantedEffect.levels[1].levelRequirement or 1
 			if characterLevel >= levelRequirement or not matchLevel then
 				if (showExceptional or showAll) and gemData.grantedEffect.plusVersionOf then
-					if self.skillsTab.showLegacyGems or nonLegacyAwakened[gemData.grantedEffectId] or not gemData.name:match("^Awakened") then
+					if self.skillsTab.showLegacyGems or not gemData.grantedEffect.legacy then
 						self.gems["Default:" .. gemId] = gemData
 					end
 				elseif showNormal or showAll then
@@ -144,7 +139,7 @@ end
 
 function GemSelectClass:FilterSupport(gemId, gemData)
 	local showSupportTypes = self.skillsTab.showSupportGemTypes
-	if gemData.name:match("^Awakened") and not self.skillsTab.showLegacyGems and not nonLegacyAwakened[gemData.grantedEffectId] then
+	if gemData.grantedEffect.legacy and not self.skillsTab.showLegacyGems then
 		return false
 	end
 	return (not gemData.grantedEffect.support
@@ -615,6 +610,11 @@ function GemSelectClass:AddGemTooltip(gemInstance)
 		local grantedEffect = gemInstance.gemData.grantedEffect
 		self.tooltip:AddLine(fontSizeTitle, colorCodes.GEM .. altQualMap[gemInstance.qualityId]..grantedEffect.name, "FONTIN SC")
 		self.tooltip:AddSeparator(10)
+		if grantedEffect.legacy then
+			self.tooltip:AddLine(fontSizeTitle, colorCodes.WARNING .. "Legacy Gem", "FONTIN SC")
+			self.tooltip:AddLine(fontSizeBig, colorCodes.WARNING .. "Gem only exists in Standard League", "FONTIN SC")
+			self.tooltip:AddSeparator(10)
+		end
 		self.tooltip:AddLine(fontSizeBig, "^x7F7F7F" .. gemInstance.gemData.tagString, "FONTIN SC")
 		self:AddCommonGemInfo(gemInstance, grantedEffect, true, secondary and secondary.support and secondary)
 	end

--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -81,6 +81,7 @@ skills["SupportAwakenedAddedColdDamage"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportAddedColdDamage",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	qualityStats = {
 		Default = {
 			{ "cold_damage_+%", 0.5 },
@@ -267,6 +268,7 @@ skills["SupportAwakenedArrowNova"] = {
 		["Bow"] = true,
 	},
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["support_rain_projectile_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, ModFlag.Projectile),
@@ -679,6 +681,7 @@ skills["SupportAwakenedCastOnCriticalStrike"] = {
 	ignoreMinionTypes = true,
 	plusVersionOf = "SupportCastOnCriticalStrike",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["support_cast_on_crit_spell_damage_+%_final"] = {
 		},
@@ -975,6 +978,7 @@ skills["SupportAwakenedChain"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportChain",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["support_chain_hit_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, ModFlag.Hit),
@@ -1417,6 +1421,7 @@ skills["SupportAwakenedColdPenetration"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportColdPenetration",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	qualityStats = {
 		Default = {
 			{ "cold_damage_+%", 0.5 },
@@ -1725,6 +1730,7 @@ skills["SupportAwakenedDeadlyAilments"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportDeadlyAilments",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["support_better_ailments_hit_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, ModFlag.Hit),
@@ -2118,6 +2124,7 @@ skills["SupportAwakenedFork"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportFork",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["support_fork_projectile_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, ModFlag.Projectile),
@@ -2281,6 +2288,7 @@ skills["SupportAwakenedGreaterMultipleProjectiles"] = {
 	excludeSkillTypes = { SkillType.ProjectilesNumberModifiersNotApplied, },
 	plusVersionOf = "SupportGreaterMultipleProjectiles",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["support_multiple_projectile_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, ModFlag.Projectile),
@@ -4079,6 +4087,7 @@ skills["SupportAwakenedSwiftAffliction"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportSwiftAffliction",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["support_rapid_decay_damage_over_time_+%_final"] = {
 			mod("Damage", "MORE", nil, ModFlag.Dot),
@@ -4549,6 +4558,7 @@ skills["SupportAwakenedViciousProjectiles"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportViciousProjectiles",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["support_projectile_attack_speed_+%_final"] = {
 			mod("Speed", "MORE", nil, bit.bor(ModFlag.Attack, ModFlag.Projectile)),
@@ -4750,6 +4760,7 @@ skills["SupportAwakenedVoidManipulation"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportVoidManipulation",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["support_void_manipulation_chaos_damage_+%_final"] = {
 			mod("ChaosDamage", "MORE", nil),

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -81,6 +81,7 @@ skills["SupportAwakenedAddedChaosDamage"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportAddedChaosDamage",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	qualityStats = {
 		Default = {
 			{ "chaos_damage_+%", 0.5 },
@@ -189,6 +190,7 @@ skills["SupportAwakenedAddedLightningDamage"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportAddedLightningDamage",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	qualityStats = {
 		Default = {
 			{ "lightning_damage_+%", 0.5 },
@@ -456,6 +458,7 @@ skills["SupportAwakenedBlasphemy"] = {
 	ignoreMinionTypes = true,
 	plusVersionOf = "SupportBlasphemy",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["curse_apply_as_aura"] = {
 		},
@@ -845,6 +848,7 @@ skills["SupportAwakenedCastWhileChannelling"] = {
 	excludeSkillTypes = { SkillType.SummonsTotem, SkillType.DisallowTriggerSupports, },
 	plusVersionOf = "SupportCastWhileChannelling",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["cast_while_channelling_time_ms"] = {
 			skill("triggerTime", nil, { type = "SkillType", skillType = SkillType.Channel } ),
@@ -1270,6 +1274,7 @@ skills["SupportAwakenedControlledDestruction"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportControlledDestruction",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["support_controlled_destruction_spell_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, ModFlag.Spell),
@@ -1577,6 +1582,7 @@ skills["SupportAwakenedHextouch"] = {
 	ignoreMinionTypes = true,
 	plusVersionOf = "SupportHextouch",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["apply_linked_curses_on_hit_%"] = {
 			--Display only. Handled by SupportCurseOnHitCursePlus
@@ -2137,6 +2143,7 @@ skills["SupportAwakenedElementalFocus"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportElementalFocus",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["support_gem_elemental_damage_+%_final"] = {
 			mod("ElementalDamage", "MORE", nil),
@@ -3712,6 +3719,7 @@ skills["SupportAwakenedIncreasedAreaofEffect"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportIncreasedAreaOfEffect",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["inc_aoe_plus_more_area_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, ModFlag.Area),
@@ -4713,6 +4721,7 @@ skills["SupportAwakenedLightningPenetration"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportLightningPenetration",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	qualityStats = {
 		Default = {
 			{ "lightning_damage_+%", 0.5 },
@@ -4971,6 +4980,7 @@ skills["SupportAwakenedMinionDamage"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportMinionDamage",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["support_minion_damage_+%_final"] = {
 			mod("MinionModifier", "LIST", { mod = mod("Damage", "MORE", nil) }),
@@ -6278,6 +6288,7 @@ skills["SupportAwakenedSpellCascade"] = {
 	ignoreMinionTypes = true,
 	plusVersionOf = "SupportSpellCascade",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["support_spell_cascade_area_of_effect_+%_final"] = {
 			mod("AreaOfEffect", "MORE", nil),
@@ -6515,6 +6526,7 @@ skills["SupportAwakenedSpellEcho"] = {
 	excludeSkillTypes = { SkillType.SummonsTotem, SkillType.Trapped, SkillType.RemoteMined, SkillType.Triggered, SkillType.HasReservation, SkillType.Vaal, SkillType.Instant, SkillType.NonRepeatable, SkillType.CreatesMinion, SkillType.NOT, SkillType.AND, },
 	plusVersionOf = "SupportSpellEcho",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["support_echo_damage_+%_final"] = {
 			mod("Damage", "MORE", nil),
@@ -6873,6 +6885,7 @@ skills["SupportAwakenedUnboundAilments"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportUnboundAilments",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["support_unbound_ailments_ailment_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Bleed, KeywordFlag.Poison, KeywordFlag.Ignite)),
@@ -7003,6 +7016,7 @@ skills["SupportAwakenedUnleash"] = {
 	excludeSkillTypes = { SkillType.SummonsTotem, SkillType.Trapped, SkillType.RemoteMined, SkillType.Triggered, SkillType.HasReservation, SkillType.Vaal, SkillType.Instant, SkillType.Channel, SkillType.Cooldown, },
 	plusVersionOf = "SupportUnleash",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["support_anticipation_rapid_fire_count"] = {
 			mod("SealCount", "BASE", nil),

--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -77,6 +77,7 @@ skills["SupportAwakenedAddedFireDamage"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportAddedFireDamage",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	qualityStats = {
 		Default = {
 			{ "fire_damage_+%", 0.5 },
@@ -232,6 +233,7 @@ skills["SupportAwakenedAncestralCall"] = {
 	ignoreMinionTypes = true,
 	plusVersionOf = "SupportAncestralCall",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["support_spirit_strike_damage_+%_final"] = {
 			mod("Damage", "MORE", nil),
@@ -885,6 +887,7 @@ skills["SupportAwakenedBrutality"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportBrutality",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["support_brutality_physical_damage_+%_final"] = {
 			mod("PhysicalDamage", "MORE", nil),
@@ -999,6 +1002,7 @@ skills["SupportAwakenedBurningDamage"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportBurningDamage",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["support_burning_damage_+%_final"] = {
 			mod("FireDamage", "MORE", nil, 0, KeywordFlag.FireDot),
@@ -1824,6 +1828,7 @@ skills["SupportAwakenedElementalDamageWithAttacks"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportElementalDamageWithAttacks",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["support_attack_skills_elemental_damage_+%_final"] = {
 			mod("ElementalDamage", "MORE", nil, 0, KeywordFlag.Attack),
@@ -2216,6 +2221,7 @@ skills["SupportAwakenedFirePenetration"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportFirePenetration",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	qualityStats = {
 		Default = {
 			{ "fire_damage_+%", 0.5 },
@@ -2731,6 +2737,7 @@ skills["SupportAwakenedGenerosity"] = {
 	ignoreMinionTypes = true,
 	plusVersionOf = "SupportGenerosity",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["aura_cannot_affect_self"] = {
 			skill("auraCannotAffectSelf", true),
@@ -3175,6 +3182,7 @@ skills["SupportItemQuantity"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { },
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	qualityStats = {
 		Default = {
 			{ "base_killed_monster_dropped_item_quantity_+%", 0.35 },
@@ -3714,6 +3722,7 @@ skills["SupportAwakenedMeleePhysicalDamage"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportMeleePhysicalDamage",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["support_melee_physical_damage_+%_final"] = {
 			mod("PhysicalDamage", "MORE", nil, ModFlag.Melee),
@@ -3836,6 +3845,7 @@ skills["SupportAwakenedMeleeSplash"] = {
 	excludeSkillTypes = { },
 	plusVersionOf = "SupportMeleeSplash",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	qualityStats = {
 		Default = {
 			{ "base_skill_area_of_effect_+%", 0.5 },
@@ -4034,6 +4044,7 @@ skills["SupportAwakenedMultistrike"] = {
 	excludeSkillTypes = { SkillType.Vaal, SkillType.NonRepeatable, SkillType.CreatesMinion, SkillType.NOT, SkillType.AND, },
 	plusVersionOf = "SupportMultistrike",
 	statDescriptionScope = "gem_stat_descriptions",
+	legacy = true,
 	statMap = {
 		["multistrike_damage_+%_final_on_first_repeat"] = {
 			mod("RepeatOneDamage", "MORE", nil, nil, nil, { type = "ModFlagOr", modFlags = bit.bor(ModFlag.WeaponMelee, ModFlag.Unarmed) }, { type = "Condition", varList = {"averageRepeat", "alwaysFinalRepeat"} }),

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -9,6 +9,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedAddedColdDamage
+	legacy = true,
 #mods
 
 #skill SupportAdditionalAccuracy
@@ -23,6 +24,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedArrowNova
+	legacy = true,
 	statMap = {
 		["support_rain_projectile_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, ModFlag.Projectile),
@@ -76,6 +78,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedCastOnCriticalStrike
+	legacy = true,
 	statMap = {
 		["support_cast_on_crit_spell_damage_+%_final"] = {
 		},
@@ -121,6 +124,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedChain
+	legacy = true,
 	statMap = {
 		["support_chain_hit_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, ModFlag.Hit),
@@ -171,6 +175,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedColdPenetration
+	legacy = true,
 #mods
 
 #skill SupportCompanionship
@@ -197,6 +202,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedDeadlyAilments
+	legacy = true,
 	statMap = {
 		["support_better_ailments_hit_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, ModFlag.Hit),
@@ -239,6 +245,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedFork
+	legacy = true,
 	statMap = {
 		["support_fork_projectile_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, ModFlag.Projectile),
@@ -258,6 +265,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedGreaterMultipleProjectiles
+	legacy = true,
 	statMap = {
 		["support_multiple_projectile_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, ModFlag.Projectile),
@@ -499,6 +507,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedSwiftAffliction
+	legacy = true,
 	statMap = {
 		["support_rapid_decay_damage_over_time_+%_final"] = {
 			mod("Damage", "MORE", nil, ModFlag.Dot),
@@ -570,6 +579,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedViciousProjectiles
+	legacy = true,
 	statMap = {
 		["support_projectile_attack_speed_+%_final"] = {
 			mod("Speed", "MORE", nil, bit.bor(ModFlag.Attack, ModFlag.Projectile)),
@@ -609,6 +619,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedVoidManipulation
+	legacy = true,
 	statMap = {
 		["support_void_manipulation_chaos_damage_+%_final"] = {
 			mod("ChaosDamage", "MORE", nil),

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -9,12 +9,14 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedAddedChaosDamage
+	legacy = true,
 #mods
 
 #skill SupportAddedLightningDamage
 #mods
 
 #skill SupportAwakenedAddedLightningDamage
+	legacy = true,
 #mods
 
 #skill SupportArcaneSurge
@@ -54,6 +56,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedBlasphemy
+	legacy = true,
 	statMap = {
 		["curse_apply_as_aura"] = {
 		},
@@ -112,6 +115,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedCastWhileChannelling
+	legacy = true,
 	statMap = {
 		["cast_while_channelling_time_ms"] = {
 			skill("triggerTime", nil, { type = "SkillType", skillType = SkillType.Channel } ),
@@ -175,6 +179,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedControlledDestruction
+	legacy = true,
 	statMap = {
 		["support_controlled_destruction_spell_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, ModFlag.Spell),
@@ -219,6 +224,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedHextouch
+	legacy = true,
 	statMap = {
 		["apply_linked_curses_on_hit_%"] = {
 			--Display only. Handled by SupportCurseOnHitCursePlus
@@ -309,6 +315,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedElementalFocus
+	legacy = true,
 	statMap = {
 		["support_gem_elemental_damage_+%_final"] = {
 			mod("ElementalDamage", "MORE", nil),
@@ -503,6 +510,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedIncreasedAreaofEffect
+	legacy = true,
 	statMap = {
 		["inc_aoe_plus_more_area_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, ModFlag.Area),
@@ -604,6 +612,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedLightningPenetration
+	legacy = true,
 #mods
 
 #skill SupportMeatShield
@@ -637,6 +646,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedMinionDamage
+	legacy = true,
 	statMap = {
 		["support_minion_damage_+%_final"] = {
 			mod("MinionModifier", "LIST", { mod = mod("Damage", "MORE", nil) }),
@@ -839,6 +849,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedSpellCascade
+	legacy = true,
 	statMap = {
 		["support_spell_cascade_area_of_effect_+%_final"] = {
 			mod("AreaOfEffect", "MORE", nil),
@@ -887,6 +898,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedSpellEcho
+	legacy = true,
 	statMap = {
 		["support_echo_damage_+%_final"] = {
 			mod("Damage", "MORE", nil),
@@ -951,6 +963,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedUnboundAilments
+	legacy = true,
 	statMap = {
 		["support_unbound_ailments_ailment_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Bleed, KeywordFlag.Poison, KeywordFlag.Ignite)),
@@ -975,6 +988,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedUnleash
+	legacy = true,
 	statMap = {
 		["support_anticipation_rapid_fire_count"] = {
 			mod("SealCount", "BASE", nil),

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -9,6 +9,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedAddedFireDamage
+	legacy = true,
 #mods
 
 #skill SupportAncestralCall
@@ -23,6 +24,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedAncestralCall
+	legacy = true,
 	statMap = {
 		["support_spirit_strike_damage_+%_final"] = {
 			mod("Damage", "MORE", nil),
@@ -109,6 +111,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedBrutality
+	legacy = true,
 	statMap = {
 		["support_brutality_physical_damage_+%_final"] = {
 			mod("PhysicalDamage", "MORE", nil),
@@ -125,6 +128,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedBurningDamage
+	legacy = true,
 	statMap = {
 		["support_burning_damage_+%_final"] = {
 			mod("FireDamage", "MORE", nil, 0, KeywordFlag.FireDot),
@@ -254,6 +258,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedElementalDamageWithAttacks
+	legacy = true,
 	statMap = {
 		["support_attack_skills_elemental_damage_+%_final"] = {
 			mod("ElementalDamage", "MORE", nil, 0, KeywordFlag.Attack),
@@ -298,6 +303,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedFirePenetration
+	legacy = true,
 #mods
 
 #skill SupportFissure
@@ -382,6 +388,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedGenerosity
+	legacy = true,
 	statMap = {
 		["aura_cannot_affect_self"] = {
 			skill("auraCannotAffectSelf", true),
@@ -430,6 +437,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportItemQuantity
+	legacy = true,
 #mods
 
 #skill SupportKnockback
@@ -486,6 +494,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedMeleePhysicalDamage
+	legacy = true,
 	statMap = {
 		["support_melee_physical_damage_+%_final"] = {
 			mod("PhysicalDamage", "MORE", nil, ModFlag.Melee),
@@ -503,6 +512,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedMeleeSplash
+	legacy = true,
 #mods
 
 #skill SupportMultipleTotems
@@ -534,6 +544,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportAwakenedMultistrike
+	legacy = true,
 	statMap = {
 		["multistrike_damage_+%_final_on_first_repeat"] = {
 			mod("RepeatOneDamage", "MORE", nil, nil, nil, { type = "ModFlagOr", modFlags = bit.bor(ModFlag.WeaponMelee, ModFlag.Unarmed) }, { type = "Condition", varList = {"averageRepeat", "alwaysFinalRepeat"} }),


### PR DESCRIPTION
### Description of the problem being solved:
Adds a tooltip to legacy gems so players know when hovering over them
Adding `(legacy)` to the end of the gem names caused a bunch of issues so dropped it
We now manually tag legacy gems instead of relying on a exclusion filter for awakened variants


### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/t52qgy03

### Before screenshot:
<img width="866" height="252" alt="image" src="https://github.com/user-attachments/assets/0346d2d0-48e0-412d-bb3a-756c6a8bfc8c" />

### After screenshot:
<img width="867" height="314" alt="image" src="https://github.com/user-attachments/assets/026983d0-ff94-439d-b5c6-6137586ecb29" />
