### PR TITLE
Fix PoB Trader not prioritising local weapon mods

### DIFF
--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -916,6 +916,9 @@ function TradeQueryGeneratorClass:FinishQuery()
 	
 	-- Sort by mean Stat diff rather than weight to more accurately prioritize stats that can contribute more
 	table.sort(self.modWeights, function(a, b)
+		if a.meanStatDiff == b.meanStatDiff then
+			return math.abs(a.weight) > math.abs(b.weight)
+		end
 		return a.meanStatDiff > b.meanStatDiff
 	end)
 	
@@ -967,9 +970,6 @@ function TradeQueryGeneratorClass:FinishQuery()
 	end
 
 	local effective_max = MAX_FILTERS - num_extra
-
-	-- Prioritize top mods by abs(weight)
-	table.sort(self.modWeights, function(a, b) return math.abs(a.weight) > math.abs(b.weight) end)
 
 	local prioritizedMods = {}
 	for _, entry in ipairs(self.modWeights) do


### PR DESCRIPTION
### Description of the problem being solved:
PR #9394 made a change to sort the stat list by individual mod weight instead of the meanStatDiff like we had it before. This was prioritising high weight mods that contributed a low total value to the item and was forcing the search to ignore low weight but high value mods like local weapon damage rolls


### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/tv2uip0o

### Before screenshot:
<img width="755" height="894" alt="image" src="https://github.com/user-attachments/assets/14862d77-13ce-4e1c-b3df-7c572ef94b3c" />

### After screenshot:
<img width="768" height="824" alt="image" src="https://github.com/user-attachments/assets/779da7a4-6440-40bc-bb91-d5aa11cb606f" />
