### PR TITLE
Fix Melee damage not scaling Hammers from Holy Hammers

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -6079,11 +6079,9 @@ skills["HolyHammers"] = {
 		},
 		{
 			name = "First Hammer",
-			melee = false,
 		},
 		{
 			name = "Other Hammers",
-			melee = false,
 		},
 	},
 	statMap = {

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -1036,11 +1036,9 @@ local skills, mod, flag, skill = ...
 		},
 		{
 			name = "First Hammer",
-			melee = false,
 		},
 		{
 			name = "Other Hammers",
-			melee = false,
 		},
 	},
 	statMap = {


### PR DESCRIPTION
Fixes #9624

### Description of the problem being solved:
I thought the hammers wouldn't have the melee tag but that does not appear to be the case