### PR TITLE
Fix Charged Dash of Projection release states not appearing on Calcs tab

### DIFF
--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -4166,7 +4166,7 @@ skills["ChargedDashAltX"] = {
 	preDamageFunc = function(activeSkill, output)
 		   if activeSkill.skillPart == 3 then
 			   local finalWaveDamageModifier = activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "chargedDashFinalDamageModifier")
-			   activeSkill.skillModList:NewMod("Damage", "MORE", finalWaveDamageModifier, "Skill:ChargedDash", ModFlag.Attack, { type = "Release Damage", skillPart = 3 })
+			   activeSkill.skillModList:NewMod("Damage", "MORE", finalWaveDamageModifier, "Skill:ChargedDashofProjection", ModFlag.Attack, { type = "Release Damage", skillPart = 3 })
 		   end
 	end,
 	statMap = {
@@ -4176,7 +4176,7 @@ skills["ChargedDashAltX"] = {
 			mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, { type = "SkillPart", skillPart = 3 }),
 		},
 		["charged_dash_damage_+%_final_per_stack"] = {
-			mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, { type = "Multiplier", var = "ChargedDashStage" }, { type = "SkillPart", skillPart = 3 }),
+			mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, { type = "Multiplier", var = "ChargedDashofProjectionStage" }, { type = "SkillPart", skillPart = 3 }),
 		},
 		["charged_dash_channelling_damage_at_full_stacks_+%_final"] = {
 			mod("Damage", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
@@ -4193,7 +4193,7 @@ skills["ChargedDashAltX"] = {
 		skill("radiusSecondary", 26),
 		skill("radiusSecondaryLabel", "End of Dash:"),
 		skill("hitTimeMultiplier", 2, { type = "Skill", skillPartList = { 1, 2 } }),
-		mod("Multiplier:ChargedDashMaxStages", "BASE", 15),
+		mod("Multiplier:ChargedDashofProjectionMaxStages", "BASE", 15),
 		skill("showAverage", true, { type = "SkillPart", skillPart = 3 }),
 	},
 	qualityStats = {

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -731,7 +731,7 @@ local skills, mod, flag, skill = ...
 	preDamageFunc = function(activeSkill, output)
 		   if activeSkill.skillPart == 3 then
 			   local finalWaveDamageModifier = activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "chargedDashFinalDamageModifier")
-			   activeSkill.skillModList:NewMod("Damage", "MORE", finalWaveDamageModifier, "Skill:ChargedDash", ModFlag.Attack, { type = "Release Damage", skillPart = 3 })
+			   activeSkill.skillModList:NewMod("Damage", "MORE", finalWaveDamageModifier, "Skill:ChargedDashofProjection", ModFlag.Attack, { type = "Release Damage", skillPart = 3 })
 		   end
 	end,
 	statMap = {
@@ -741,7 +741,7 @@ local skills, mod, flag, skill = ...
 			mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, { type = "SkillPart", skillPart = 3 }),
 		},
 		["charged_dash_damage_+%_final_per_stack"] = {
-			mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, { type = "Multiplier", var = "ChargedDashStage" }, { type = "SkillPart", skillPart = 3 }),
+			mod("chargedDashFinalDamageModifier", "INC", nil, 0, 0, { type = "Multiplier", var = "ChargedDashofProjectionStage" }, { type = "SkillPart", skillPart = 3 }),
 		},
 		["charged_dash_channelling_damage_at_full_stacks_+%_final"] = {
 			mod("Damage", "MORE", nil, 0, 0, { type = "SkillPart", skillPart = 2 }),
@@ -752,7 +752,7 @@ local skills, mod, flag, skill = ...
 #baseMod skill("radiusSecondary", 26)
 #baseMod skill("radiusSecondaryLabel", "End of Dash:")
 #baseMod skill("hitTimeMultiplier", 2, { type = "Skill", skillPartList = { 1, 2 } })
-#baseMod mod("Multiplier:ChargedDashMaxStages", "BASE", 15)
+#baseMod mod("Multiplier:ChargedDashofProjectionMaxStages", "BASE", 15)
 #baseMod skill("showAverage", true, { type = "SkillPart", skillPart = 3 })
 #mods
 


### PR DESCRIPTION
Fixes #9599

### Description of the problem being solved:
I forgot to change the names on the new charged dash so that it used the skills name so it was never showing the stages box on the calcs tab
