### PR TITLE
Fix General's Cry DPS not scaling properly with increased Warcry Cooldown

### DIFF
--- a/src/Modules/CalcMirages.lua
+++ b/src/Modules/CalcMirages.lua
@@ -394,6 +394,7 @@ function calcs.mirages(env)
 			mirageSpawnTime = mirageSpawnTime + 1
 		else
 			mirageSpawnTime = mirageSpawnTime + (mainSkillOutputCache.HitTime or mainSkillOutputCache.Time)
+			env.player.mainSkill.skillData.timeOverride = 1
 		end
 
 		-- This is so that it's consistent with the info message but removing this could make it more accurate numbers wise

--- a/src/Modules/CalcMirages.lua
+++ b/src/Modules/CalcMirages.lua
@@ -394,12 +394,10 @@ function calcs.mirages(env)
 			mirageSpawnTime = mirageSpawnTime + 1
 		else
 			mirageSpawnTime = mirageSpawnTime + (mainSkillOutputCache.HitTime or mainSkillOutputCache.Time)
-			env.player.mainSkill.skillData.timeOverride = 1
 		end
 
 		-- This is so that it's consistent with the info message but removing this could make it more accurate numbers wise
 		mirageSpawnTime = round(mirageSpawnTime, 2)
-		cooldown = m_max(cooldown, mirageSpawnTime)
 
 		-- Scale dps with GC's cooldown
 		env.player.mainSkill.skillData.dpsMultiplier = (env.player.mainSkill.skillData.dpsMultiplier or 1) * (1 / cooldown)


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:

3.27.0g: `General's Cry spawned clones are now not yet considered to be active, and thus counting against your maximum allowed, until they have activated. Previously, these would count against your maximum at the point where the number of clones to create from a use was calculated, which could cause clones created by a previous warcry to be replaced before they had enough time to act.`


So cooldown is no needed anymore since mirages will now only get replaced after finishing their action

### Steps taken to verify a working solution:
- 
-
-

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
