### PR TITLE
Fix per Minion Limit calculation when using Congregation Support

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1317,7 +1317,7 @@ function calcs.perform(env, skipEHP)
 			end
 		end
 		if activeSkill.minion and activeSkill.minion.minionData and activeSkill.minion.minionData.limit then
-			local limit = m_floor(modDB:Override(nil, activeSkill.minion.minionData.limit) or (calcLib.val(activeSkill.skillModList, activeSkill.minion.minionData.limit) * (1 + activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "ActiveMinionLimit") / 100)))
+			local limit = m_floor(modDB:Override(nil, activeSkill.minion.minionData.limit) or (calcLib.val(activeSkill.skillModList, activeSkill.minion.minionData.limit) * activeSkill.skillModList:More(activeSkill.skillCfg, "ActiveMinionLimit")))
 			output[activeSkill.minion.minionData.limit] = m_max(limit, output[activeSkill.minion.minionData.limit] or 0)
 		end
 		if activeSkill.skillTypes[SkillType.CreatesMinion] and not activeSkill.skillTypes[SkillType.MinionsAreUndamagable] then


### PR DESCRIPTION
Fixes #9638

### Description of the problem being solved:
Congregation Support was not scaling the minion limit stat for the use in per Void Spawn or other per minion limit mods

Original PR has it applied as a INC mod, I switched it to use MORE but forgot to update one of the cases that was still looking for an INC mod

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/ab3zws0o

### Before screenshot:
<img width="645" height="143" alt="image" src="https://github.com/user-attachments/assets/baf1e1a8-e8cd-48f3-96d0-898000407bf8" />

### After screenshot:
<img width="838" height="225" alt="image" src="https://github.com/user-attachments/assets/c982333b-14bb-40d0-9f5c-1b3396f46a07" />
