### PR TITLE
Fix Holy Strike not scaling with Melee damage

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -6187,6 +6187,7 @@ skills["HolyStrike"] = {
 	},
 	baseFlags = {
 		attack = true,
+		melee = true,
 		minion = true,
 		duration = true,
 	},

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -1052,7 +1052,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill HolyStrike
-#flags attack minion duration
+#flags attack melee minion duration
 	minionList = {
 		"HolyStrikeMinion",
 	},


### PR DESCRIPTION
Fixes #9633

### Description of the problem being solved:
Holy Strike was not scaling with melee damage mods

### Link to a build that showcases this PR:
https://pobb.in/HFiXZd81hrCd

### Before screenshot:
<img width="388" height="214" alt="image" src="https://github.com/user-attachments/assets/4d07506d-3e64-415c-b450-90e503a2be64" />

### After screenshot:
<img width="389" height="264" alt="image" src="https://github.com/user-attachments/assets/400a3150-e771-453a-83f1-c9723b0bc2cf" />
