### PR TITLE
Fix for Chieftain resist nodes applying effects twice due to Foulborn Choir of the Storm

### DIFF
--- a/spec/System/TestDefence_spec.lua
+++ b/spec/System/TestDefence_spec.lua
@@ -358,6 +358,26 @@ describe("TestDefence", function()
 		build.skillsTab.socketGroupList = {}
 	end)
 
+	it("foulborn resistance conversion remains stable across recalculation", function()
+		build.configTab.input.enemyIsBoss = "None"
+		build.configTab.input.customMods = "\z
+		+300 to fire resistance\n\z
+		modifiers to fire resistance also apply to cold and lightning resistances at 50% of their value\n\z
+		mana is increased by 100% of overcapped lightning resistance\n\z
+		"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(90, build.calcsTab.calcsOutput.LightningResistTotal)
+		assert.are.equals(15, build.calcsTab.calcsOutput.LightningResistOverCap)
+
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(90, build.calcsTab.calcsOutput.LightningResistTotal)
+		assert.are.equals(15, build.calcsTab.calcsOutput.LightningResistOverCap)
+	end)
+
 	-- fun part
 	it("armoured max hits", function()
 		build.configTab.input.enemyIsBoss = "None"

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -513,47 +513,50 @@ function calcs.resistances(actor)
 	output["PhysicalResist"] = 0
 	
 	-- Process Resistance conversion mods
-	for _, resFrom in ipairs(resistTypeList) do
-		local maxRes
-		for _, resTo in ipairs(resistTypeList) do
-			local conversionRate = modDB:Sum("BASE", nil, resFrom.."MaxResConvertTo"..resTo) / 100
-			if conversionRate ~= 0 then
-				if not maxRes then
-					maxRes = 0
-					for _, mod in ipairs(modDB:Tabulate("BASE", nil, resFrom.."ResistMax")) do
-						if mod.mod.source ~= "Base" then
-							maxRes = maxRes + mod.value
+	if not actor.resistConversionApplied then
+		actor.resistConversionApplied = true
+		for _, resFrom in ipairs(resistTypeList) do
+			local maxRes
+			for _, resTo in ipairs(resistTypeList) do
+				local conversionRate = modDB:Sum("BASE", nil, resFrom.."MaxResConvertTo"..resTo) / 100
+				if conversionRate ~= 0 then
+					if not maxRes then
+						maxRes = 0
+						for _, mod in ipairs(modDB:Tabulate("BASE", nil, resFrom.."ResistMax")) do
+							if mod.mod.source ~= "Base" then
+								maxRes = maxRes + mod.value
+							end
 						end
 					end
-				end
-				if maxRes ~= 0 then
-					modDB:NewMod(resTo.."ResistMax", "BASE", maxRes * conversionRate, resFrom.." To "..resTo.." Max Resistance Conversion")
+					if maxRes ~= 0 then
+						modDB:NewMod(resTo.."ResistMax", "BASE", maxRes * conversionRate, resFrom.." To "..resTo.." Max Resistance Conversion")
+					end
 				end
 			end
 		end
-	end
-	
-	for _, resFrom in ipairs(resistTypeList) do
-		local res
-		for _, resTo in ipairs(resistTypeList) do
-			local conversionRate = modDB:Sum("BASE", nil, resFrom.."ResConvertTo"..resTo) / 100
-			if conversionRate ~= 0 then
-				if not res then
-					res = 0
-					for _, mod in ipairs(modDB:Tabulate("BASE", nil, resFrom.."Resist")) do
-						if mod.mod.source ~= "Base" then
-							res = res + mod.value
+
+		for _, resFrom in ipairs(resistTypeList) do
+			local res
+			for _, resTo in ipairs(resistTypeList) do
+				local conversionRate = modDB:Sum("BASE", nil, resFrom.."ResConvertTo"..resTo) / 100
+				if conversionRate ~= 0 then
+					if not res then
+						res = 0
+						for _, mod in ipairs(modDB:Tabulate("BASE", nil, resFrom.."Resist")) do
+							if mod.mod.source ~= "Base" then
+								res = res + mod.value
+							end
 						end
 					end
-				end
-				if res ~= 0 then
-					modDB:NewMod(resTo.."Resist", "BASE", res * conversionRate, resFrom.." To "..resTo.." Resistance Conversion")
-				end
-				for _, mod in ipairs(modDB:Tabulate("INC", nil, resFrom.."Resist")) do
-					modDB:NewMod(resTo.."Resist", "INC", mod.value * conversionRate, mod.mod.source)
-				end
-				for _, mod in ipairs(modDB:Tabulate("MORE", nil, resFrom.."Resist")) do
-					modDB:NewMod(resTo.."Resist", "MORE", mod.value * conversionRate, mod.mod.source)
+					if res ~= 0 then
+						modDB:NewMod(resTo.."Resist", "BASE", res * conversionRate, resFrom.." To "..resTo.." Resistance Conversion")
+					end
+					for _, mod in ipairs(modDB:Tabulate("INC", nil, resFrom.."Resist")) do
+						modDB:NewMod(resTo.."Resist", "INC", mod.value * conversionRate, mod.mod.source)
+					end
+					for _, mod in ipairs(modDB:Tabulate("MORE", nil, resFrom.."Resist")) do
+						modDB:NewMod(resTo.."Resist", "MORE", mod.value * conversionRate, mod.mod.source)
+					end
 				end
 			end
 		end

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -513,50 +513,47 @@ function calcs.resistances(actor)
 	output["PhysicalResist"] = 0
 	
 	-- Process Resistance conversion mods
-	if not actor.resistConversionApplied then
-		actor.resistConversionApplied = true
-		for _, resFrom in ipairs(resistTypeList) do
-			local maxRes
-			for _, resTo in ipairs(resistTypeList) do
-				local conversionRate = modDB:Sum("BASE", nil, resFrom.."MaxResConvertTo"..resTo) / 100
-				if conversionRate ~= 0 then
-					if not maxRes then
-						maxRes = 0
-						for _, mod in ipairs(modDB:Tabulate("BASE", nil, resFrom.."ResistMax")) do
-							if mod.mod.source ~= "Base" then
-								maxRes = maxRes + mod.value
-							end
+	for _, resFrom in ipairs(resistTypeList) do
+		local maxRes
+		for _, resTo in ipairs(resistTypeList) do
+			local conversionRate = modDB:Sum("BASE", nil, resFrom.."MaxResConvertTo"..resTo) / 100
+			if conversionRate ~= 0 then
+				if not maxRes then
+					maxRes = 0
+					for _, mod in ipairs(modDB:Tabulate("BASE", nil, resFrom.."ResistMax")) do
+						if mod.mod.source ~= "Base" then
+							maxRes = maxRes + mod.value
 						end
 					end
-					if maxRes ~= 0 then
-						modDB:NewMod(resTo.."ResistMax", "BASE", maxRes * conversionRate, resFrom.." To "..resTo.." Max Resistance Conversion")
-					end
+				end
+				if maxRes ~= 0 then
+					modDB:NewMod(resTo.."ResistMax", "BASE", maxRes * conversionRate, resFrom.." To "..resTo.." Max Resistance Conversion")
 				end
 			end
 		end
+	end
 
-		for _, resFrom in ipairs(resistTypeList) do
-			local res
-			for _, resTo in ipairs(resistTypeList) do
-				local conversionRate = modDB:Sum("BASE", nil, resFrom.."ResConvertTo"..resTo) / 100
-				if conversionRate ~= 0 then
-					if not res then
-						res = 0
-						for _, mod in ipairs(modDB:Tabulate("BASE", nil, resFrom.."Resist")) do
-							if mod.mod.source ~= "Base" then
-								res = res + mod.value
-							end
+	for _, resFrom in ipairs(resistTypeList) do
+		local res
+		for _, resTo in ipairs(resistTypeList) do
+			local conversionRate = modDB:Sum("BASE", nil, resFrom.."ResConvertTo"..resTo) / 100
+			if conversionRate ~= 0 then
+				if not res then
+					res = 0
+					for _, mod in ipairs(modDB:Tabulate("BASE", nil, resFrom.."Resist")) do
+						if mod.mod.source ~= "Base" then
+							res = res + mod.value
 						end
 					end
-					if res ~= 0 then
-						modDB:NewMod(resTo.."Resist", "BASE", res * conversionRate, resFrom.." To "..resTo.." Resistance Conversion")
-					end
-					for _, mod in ipairs(modDB:Tabulate("INC", nil, resFrom.."Resist")) do
-						modDB:NewMod(resTo.."Resist", "INC", mod.value * conversionRate, mod.mod.source)
-					end
-					for _, mod in ipairs(modDB:Tabulate("MORE", nil, resFrom.."Resist")) do
-						modDB:NewMod(resTo.."Resist", "MORE", mod.value * conversionRate, mod.mod.source)
-					end
+				end
+				if res ~= 0 then
+					modDB:NewMod(resTo.."Resist", "BASE", res * conversionRate, resFrom.." To "..resTo.." Resistance Conversion")
+				end
+				for _, mod in ipairs(modDB:Tabulate("INC", nil, resFrom.."Resist")) do
+					modDB:NewMod(resTo.."Resist", "INC", mod.value * conversionRate, mod.mod.source)
+				end
+				for _, mod in ipairs(modDB:Tabulate("MORE", nil, resFrom.."Resist")) do
+					modDB:NewMod(resTo.."Resist", "MORE", mod.value * conversionRate, mod.mod.source)
 				end
 			end
 		end

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3189,8 +3189,16 @@ function calcs.perform(env, skipEHP)
 
 	-- Foulborn Choir of the Storm, needs to be after main auras (incase purity of lightning/elements auras) but before extra auras (Radiant Faith)
 	if modDB:Flag(nil, "ManaIncreasedByOvercappedLightningRes") then
-		-- Calclate resistances for ManaIncreasedByOvercappedLightningRes
-		calcs.resistances(env.player)
+		-- Calculate resistances for ManaIncreasedByOvercappedLightningRes without mutating conversion mods on the player ModDB.
+		local tempResistActor = {
+			modDB = new("ModDB", modDB),
+			output = output,
+			activeSkillList = env.player.activeSkillList,
+			enemy = env.player.enemy,
+		}
+		tempResistActor.player = tempResistActor
+		tempResistActor.modDB.actor = tempResistActor
+		calcs.resistances(tempResistActor)
 		-- Set the life/mana reservations again as we now have increased mana from overcapped lightning resistance
 		doActorLifeMana(env.player)
 		doActorLifeManaReservation(env.player, true)


### PR DESCRIPTION
Fixes #9481 .

### Description of the problem being solved:
Foulborn Choir of the Storm's increased mana by overcapped lightning resist mod causes resistance conversion mods, such as Taslio, Cleansing Water, to apply twice in calculations.

This is due to [how Foulborn Choir of the Storm is handled in the calculations](https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/9a1a8706/src/Modules/CalcPerform.lua#L3190). Since it calls the resistance, mana and reservation calculations again, it adds resistance conversion mods twice as well.

Fix just adds a flag so resistance conversion mods aren't processed twice on accident.

### Steps taken to verify a working solution:
- Check resists are accurate: ~25,000 fire resistance with ~12,500 lightning and cold resistance
- Check Max res granted by Valako, Storm's Embrace is not double applying to cold/lightning resist
- Check Mana to Energy Shield no longer double applying and matches with user report
- Check Transfiguration of Mind applies half the increased damage (in config)
- Check if non-Foulborn Choir builds have resist/max res from Chieftain nodes works properly 

### Link to a build that showcases this PR:
https://pobb.in/5cSHvaw15MUI (Screenshots based off this PoB)

https://pobb.in/V41O4IvnojAr (extra case, ES aligns with user report but I'm uncertain mana is accurate as they're saying the in-game UI is bugged. The increased mana aligns with what they're reporting.) 

### Before screenshot:
<img width="528" height="709" alt="fix-tasalio-choir-before" src="https://github.com/user-attachments/assets/33d0ed65-ff43-4cb3-b4da-3786ca66b72f" />

### After screenshot:
<img width="530" height="712" alt="fix-tasalio-choir-after" src="https://github.com/user-attachments/assets/5b58a569-4d60-4d5c-a7e1-e26ee8913b8a" />
