### PR TITLE
Add support for Lethal Dose support

### DIFF
--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -2671,6 +2671,9 @@ skills["SupportLethalDose"] = {
 		["support_lethal_dose_poison_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, 0, KeywordFlag.Poison),
 		},
+		["additional_poisons_+_to_apply_vs_non_poisoned_enemies"] = {
+			mod("AdditionalPoisonStacks", "BASE", nil, 0, 0, {type = "Condition", var = "NonPoisonedOnly"}),
+		},
 	},
 	qualityStats = {
 		Default = {

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -323,6 +323,9 @@ local skills, mod, flag, skill = ...
 		["support_lethal_dose_poison_damage_+%_final"] = {
 			mod("Damage", "MORE", nil, 0, KeywordFlag.Poison),
 		},
+		["additional_poisons_+_to_apply_vs_non_poisoned_enemies"] = {
+			mod("AdditionalPoisonStacks", "BASE", nil, 0, 0, {type = "Condition", var = "NonPoisonedOnly"}),
+		},
 	},
 #mods
 


### PR DESCRIPTION
### Description of the problem being solved:
Mod parsing for `"additional_poisons_+_to_apply_vs_non_poisoned_enemies"` on Lethal Dose support was still missing and is now added

### Steps taken to verify a working solution:
- Works with standard Viper Strike
- Only applies if `NonPoisonedOnly` is true (e.g. via config)
- Does not work with/benefit Viper Strike of the Mamba (because it can't apply multiple poisons)
- Also works with spells

### Link to a build that showcases this PR:
[Lethal Dose Test](https://pobb.in/pFPXRg0ubTur)

### After screenshot:

Mod parsing
<img width="1595" height="232" alt="image" src="https://github.com/user-attachments/assets/d917bf24-60a5-4256-9340-bfe1d08aa3d2" />

Working with standard Viper Strike
<img width="692" height="262" alt="image" src="https://github.com/user-attachments/assets/4c02a3bf-d436-4185-98d8-6966f248decf" />

"Not working" with Mamba
<img width="711" height="293" alt="image" src="https://github.com/user-attachments/assets/7829673b-b12a-4a46-84c5-0351b28ba42a" />
