### PR TITLE
Fix Cast while Channelling trigger interval being rounded to tick rate

### DIFF
--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -245,8 +245,8 @@ local function CWCHandler(env)
 			output.addsCastTime = processAddedCastTime(env.player.mainSkill, breakdown)
 
 			local icdr = calcLib.mod(env.player.mainSkill.skillModList, env.player.mainSkill.skillCfg, "CooldownRecovery") or 1
-			local adjTriggerInterval = m_ceil(source.skillData.triggerTime * data.misc.ServerTickRate) / data.misc.ServerTickRate
-			local triggerRateOfTrigger = 1/adjTriggerInterval
+			local triggerInterval = source.skillData.triggerTime
+			local triggerRateOfTrigger = 1 / triggerInterval
 			local triggeredCD = env.player.mainSkill.skillData.cooldown
 			local cooldownOverride = env.player.mainSkill.skillModList:Override(env.player.mainSkill.skillCfg, "CooldownRecovery")
 
@@ -269,8 +269,7 @@ local function CWCHandler(env)
 			if breakdown then
 				if triggeredCD or cooldownOverride then
 					breakdown.TriggerRateCap = {
-						s_format("Cast While Channeling triggers %s every %.2fs while channeling %s ", triggeredName, source.skillData.triggerTime, source.activeEffect.grantedEffect.name),
-						s_format("%.3f ^8(adjusted for server tick rate)", adjTriggerInterval),
+						s_format("Cast While Channeling triggers %s every %.2fs while channeling %s ", triggeredName, triggerInterval, source.activeEffect.grantedEffect.name),
 						"",
 						s_format("%.2f ^8(base cooldown of triggered skill)", triggeredCD),
 						s_format("/ %.2f ^8(increased/reduced cooldown recovery)", icdr),
@@ -284,8 +283,7 @@ local function CWCHandler(env)
 					end
 				else
 					breakdown.TriggerRateCap = {
-						s_format("Cast While Channeling triggers %s every %.2fs while channeling %s ", triggeredName, source.skillData.triggerTime, source.activeEffect.grantedEffect.name),
-						s_format("%.3f ^8(adjusted for server tick rate)", adjTriggerInterval),
+						s_format("Cast While Channeling triggers %s every %.2fs while channeling %s ", triggeredName, triggerInterval, source.activeEffect.grantedEffect.name),
 						"",
 						triggeredName .. " has no base cooldown or cooldown override",
 						"",
@@ -294,7 +292,7 @@ local function CWCHandler(env)
 
 				local function extraIncreaseNeeded(affectedCD)
 					if not cooldownOverride then
-						local nextBreakpoint = effCDTriggeredSkill - adjTriggerInterval
+						local nextBreakpoint = effCDTriggeredSkill - triggerInterval
 						local timeOverBreakpoint = triggeredTotalCooldown - nextBreakpoint
 						local alreadyReducedTime = triggeredTotalCooldown * icdr - triggeredTotalCooldown
 						if timeOverBreakpoint < affectedCD then
@@ -377,7 +375,7 @@ local function CWCHandler(env)
 
 			-- Account for Trigger-related INC/MORE modifiers
 			addTriggerIncMoreMods(env.player.mainSkill, env.player.mainSkill)
-			env.player.output.ChannelTimeToTrigger = source.skillData.triggerTime
+			env.player.output.ChannelTimeToTrigger = triggerInterval
 			env.player.mainSkill.skillData.triggered = true
 			env.player.mainSkill.skillFlags.globalTrigger = true
 			env.player.mainSkill.skillData.triggerRate = output.SkillTriggerRate


### PR DESCRIPTION
Closes #8692

### Description of the problem being solved:
Makes it so that the raw CwC interval is used instead of it being rounded to tick rate.

### Steps taken to verify a working solution:
- Test build from issue
- Test with [Lightning Conduit](https://www.poewiki.net/wiki/Lightning_Conduit)