### PR TITLE
Disable coverage report

### DIFF
--- a/.busted
+++ b/.busted
@@ -1,6 +1,6 @@
 return {
     _all = {
-        coverage = true,
+        coverage = false,
         verbose = true,
     },
     default = {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Run tests
-        run: busted --lua=luajit --no-coverage
+        run: busted --lua=luajit
   check_modcache:
     runs-on: ubuntu-latest
     container: ghcr.io/pathofbuildingcommunity/pathofbuilding-tests:latest


### PR DESCRIPTION
### Description of the problem being solved:

Currently the coverage report is disabled only for github tests action through a cli switch. This pr sets the coverage setting in the `.busted` file so that coverage reporting is also disabled for tests ran locally with the docker container.