### PR TITLE
Fix Earthbreaker Totems Slam skills benefiting from Exert bonuses

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2505,7 +2505,8 @@ function calcs.offence(env, actor, activeSkill)
 
 		if env.mode_buffs then
 			-- Iterative over all the active skills to account for exerted attacks provided by warcries
-			if not activeSkill.skillTypes[SkillType.NeverExertable] and not activeSkill.skillTypes[SkillType.Triggered] and not activeSkill.skillTypes[SkillType.Channel] and not activeSkill.skillTypes[SkillType.OtherThingUsesSkill] and not activeSkill.skillTypes[SkillType.Retaliation] then
+			if not activeSkill.skillTypes[SkillType.NeverExertable] and not activeSkill.skillTypes[SkillType.Triggered] and not activeSkill.skillTypes[SkillType.Channel] and not activeSkill.skillTypes[SkillType.OtherThingUsesSkill]
+				and not activeSkill.skillTypes[SkillType.Retaliation] and not activeSkill.skillTypes[SkillType.SummonsTotem] then
 				for index, value in ipairs(actor.activeSkillList) do
 					if value.activeEffect.grantedEffect.name == "Ancestral Cry" and activeSkill.skillTypes[SkillType.MeleeSingleTarget] and not globalOutput.AncestralCryCalculated and not value.skillFlags.disable then
 						globalOutput.AncestralCryDuration = calcSkillDuration(value.skillModList, value.skillCfg, value.skillData, env, enemyDB)


### PR DESCRIPTION
Fixes #9506

### Description of the problem being solved:
Totem skills were not being excluded from the Exert logic

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/rs8bg0e5

### Before screenshot:
<img width="811" height="133" alt="image" src="https://github.com/user-attachments/assets/798b5e99-01dd-4252-a71e-2cb98f4f32e6" />

### After screenshot:
<img width="785" height="79" alt="image" src="https://github.com/user-attachments/assets/91ab2ec9-fd11-42b8-b43f-1b8523db49b3" />
