### PR TITLE
Fix Bleed chance over 100% scaling Vicious Skewering Impale effect

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -5295,7 +5295,7 @@ function calcs.offence(env, actor, activeSkill)
 			local impaleStacks = m_min(maxStacks, configStacks)
 
 			local baseStoredDamage = data.misc.ImpaleStoredDamageBase
-			local storedExpectedDamageIncOnBleed = skillModList:Sum("INC", cfg, "ImpaleEffectOnBleed")*skillModList:Sum("BASE", cfg, "BleedChance")/100
+			local storedExpectedDamageIncOnBleed = skillModList:Sum("INC", cfg, "ImpaleEffectOnBleed") * m_min(skillModList:Sum("BASE", cfg, "BleedChance") / 100, 1)
 			local storedExpectedDamageInc = (skillModList:Sum("INC", cfg, "ImpaleEffect") + storedExpectedDamageIncOnBleed)/100
 			local storedExpectedDamageMore = round(skillModList:More(cfg, "ImpaleEffect"), 2)
 			local storedExpectedDamageModifier = (1 + storedExpectedDamageInc) * storedExpectedDamageMore


### PR DESCRIPTION
Fixes #9475

### Description of the problem being solved:
The calc was not capping the effect at 100% Bleed chance so it would continue to scale the Impale effect

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/7yan40wo

### Before screenshot:
<img width="440" height="58" alt="image" src="https://github.com/user-attachments/assets/9efcf3ba-3487-47c6-ae99-20eb397cd800" />

### After screenshot:
<img width="442" height="75" alt="image" src="https://github.com/user-attachments/assets/10c6c3c2-2ca2-4837-aeb2-dc8ddb0034a0" />
