### PR TITLE
Add Life Recharge to sidebar when using Eternal Youth

### DIFF
--- a/src/Modules/BuildDisplayStats.lua
+++ b/src/Modules/BuildDisplayStats.lua
@@ -118,6 +118,7 @@ local displayStats = {
 	{ stat = "LifeUnreservedPercent", label = "Unreserved Life", fmt = "d%%", color = colorCodes.LIFE, condFunc = function(v,o) return v < 100 end },
 	{ stat = "LifeRegenRecovery", label = "Life Regen", fmt = ".1f", color = colorCodes.LIFE, condFunc = function(v,o) return o.LifeRecovery <= 0 and o.LifeRegenRecovery ~= 0 end },
 	{ stat = "LifeRegenRecovery", label = "Life Recovery", fmt = ".1f", color = colorCodes.LIFE, condFunc = function(v,o) return o.LifeRecovery > 0 and o.LifeRegenRecovery ~= 0 end },
+	{ stat = "LifeRecharge", label = "Life Recharge", fmt = ".1f", color = colorCodes.LIFE, condFunc = function(v,o) return v > 0 end },
 	{ stat = "LifeLeechGainRate", label = "Life Leech/On Hit Rate", fmt = ".1f", color = colorCodes.LIFE, compPercent = true },
 	{ stat = "LifeLeechGainPerHit", label = "Life Leech/Gain per Hit", fmt = ".1f", color = colorCodes.LIFE, compPercent = true },
 	{ },


### PR DESCRIPTION
Fixes #8583

### Description of the problem being solved:
If people are using the Keystone I'm pretty sure they'd like to see the value in the sidebar

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/14aod0wb

### Before screenshot:
<img width="200" height="74" alt="image" src="https://github.com/user-attachments/assets/7cb90719-a1bb-4571-b212-87a9267e59d8" />


### After screenshot:
<img width="204" height="94" alt="image" src="https://github.com/user-attachments/assets/ccd913cd-bd45-4a23-80ce-d7267b96b387" />
