### PR TITLE
Fix Ahuana's Bite and Bonechill's "inc damage taken" mods stacking

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -3283,11 +3283,10 @@ function calcs.perform(env, skipEHP)
 			condition = "Chilled",
 			mods = function(num)
 				local mods = { modLib.createMod("ActionSpeed", "INC", -num, "Chill", { type = "Condition", var = "Chilled" }) }
-				if output.HasBonechill and (hasGuaranteedBonechill or enemyDB:Sum("BASE", nil, "ChillVal") > 0) then
-					t_insert(mods, modLib.createMod("ColdDamageTaken", "INC", num, "Bonechill", { type = "Condition", var = "Chilled" }))
-				end
 				if modDB:Flag(nil, "ChillEffectIncDamageTaken") then
 					t_insert(mods, modLib.createMod("DamageTaken", "INC", num, "Ahuana's Bite", { type = "Condition", var = "Chilled" }))
+				elseif output.HasBonechill and (hasGuaranteedBonechill or enemyDB:Sum("BASE", nil, "ChillVal") > 0) then
+					t_insert(mods, modLib.createMod("ColdDamageTaken", "INC", num, "Bonechill", { type = "Condition", var = "Chilled" }))
 				end
 				if modDB:Flag(nil, "ChillEffectLessDamageDealt") then
 					t_insert(mods, modLib.createMod("Damage", "MORE", -num / 2, "Shaper of Winter", { type = "Condition", var = "Chilled" }))


### PR DESCRIPTION
Fixes #8581

### Description of the problem being solved:
The mods are not meant to stack with each other so I just use Ahuana's if it exists then fall back to Bonechill

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/8fazk0e1

### Before screenshot:
<img width="441" height="173" alt="image" src="https://github.com/user-attachments/assets/91c30c64-2c70-424b-a581-725eec6e7b3e" />

### After screenshot:
<img width="420" height="160" alt="image" src="https://github.com/user-attachments/assets/cebeaefe-aa94-417c-87a5-4459d24ecf4f" />
