### PR TITLE
Fix Resistance Shrine not granting max Chaos Resistance

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -330,6 +330,7 @@ local function doActorAttribsConditions(env, actor)
 		if modDB:Flag(nil, "ResistanceShrine") then
 			modDB:NewMod("ElementalResist", "BASE", m_floor(50 * shrineEffectMod), "Resistance Shrine")
 			modDB:NewMod("ElementalResistMax", "BASE", m_floor(10 * shrineEffectMod), "Resistance Shrine")
+			modDB:NewMod("ChaosResistMax", "BASE", m_floor(10 * shrineEffectMod), "Resistance Shrine")
 		end
 		if modDB:Flag(nil, "ResonatingShrine") then
 			modDB:NewMod("PowerChargesMax", "BASE", m_floor(1 * shrineEffectMod), "Resonating Shrine")
@@ -361,6 +362,7 @@ local function doActorAttribsConditions(env, actor)
 		if modDB:Flag(nil, "LesserResistanceShrine") then
 			modDB:NewMod("ElementalResist", "BASE", m_floor(25 * shrineEffectMod), "Lesser Resistance Shrine")
 			modDB:NewMod("ElementalResistMax", "BASE", m_floor(2 * shrineEffectMod), "Lesser Resistance Shrine")
+			modDB:NewMod("ChaosResistMax", "BASE", m_floor(2 * shrineEffectMod), "Lesser Resistance Shrine")
 		end
 	end
 	if env.mode_effective then


### PR DESCRIPTION
### Description of the problem being solved:
The Resistance Shrine grants max Chaos Res but it was missing from the stat list for both the regular and lesser version

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/hcc3g0e1

### Before screenshot:
<img width="644" height="218" alt="image" src="https://github.com/user-attachments/assets/572b4bbb-9482-4e0b-94f1-e408dd721c83" />

### After screenshot:
<img width="687" height="233" alt="image" src="https://github.com/user-attachments/assets/fc057d1a-7547-481e-9a70-e5ebd8d4792d" />
