### PR TITLE
Fix Animate Weapon of Self Reflection not granting weapon mods to minion

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1182,6 +1182,9 @@ function calcs.perform(env, skipEHP)
 				env.minion.modDB:AddList(env.player.itemList["Gloves"].modList)
 			end
 		end
+		if env.player.mainSkill.skillData.minionUseMainHandWeapon then
+			env.minion.modDB:AddList(env.player.itemList["Weapon 1"].slotModList[1])
+		end
 		if env.minion.itemSet or env.minion.uses then
 			for slotName, slot in pairs(env.build.itemsTab.slots) do
 				if env.minion.uses[slotName] then


### PR DESCRIPTION
### Description of the problem being solved:
When I removed the minion from having an item set and instead have it copy the main hand weapon stats, I forgot to also have it copy the mods on the item too so that mods on weapon like the stat-stacking mod on Grey Wind would still work

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/7fc3m0eg

### Before screenshot:
<img width="714" height="216" alt="image" src="https://github.com/user-attachments/assets/35319fcb-f5f8-4a70-b274-e87a176c4703" />

### After screenshot:
<img width="931" height="209" alt="image" src="https://github.com/user-attachments/assets/bcffaa69-d86b-4c71-adc3-55ddb86588a8" />
