### PR TITLE
Fix Generals Cry damage calculation with some skills

### DIFF
--- a/src/Modules/CalcMirages.lua
+++ b/src/Modules/CalcMirages.lua
@@ -393,7 +393,7 @@ function calcs.mirages(env)
 		if env.player.mainSkill.skillTypes[SkillType.Channel] then
 			mirageSpawnTime = mirageSpawnTime + 1
 		else
-			mirageSpawnTime = mirageSpawnTime + (mainSkillOutputCache.HitTime or mainSkillOutputCache.Time)
+			mirageSpawnTime = mirageSpawnTime
 			env.player.mainSkill.skillData.timeOverride = 1
 		end
 
@@ -401,7 +401,7 @@ function calcs.mirages(env)
 		mirageSpawnTime = round(mirageSpawnTime, 2)
 
 		-- Scale dps with GC's cooldown
-		env.player.mainSkill.skillData.dpsMultiplier = (env.player.mainSkill.skillData.dpsMultiplier or 1) * (1 / cooldown)
+		env.player.mainSkill.skillModList:NewMod("DPS", "MORE", (1 / cooldown - 1) * 100, "General's Cry Cooldown")
 
 		-- Does not use player resources
 		env.player.mainSkill.skillModList:NewMod("HasNoCost", "FLAG", true, "Used by mirage")


### PR DESCRIPTION
### Description of the problem being solved:
he dpsMultiplier from General Cry was overwriting the dpsMultiplier from other skills like Lacerate so selecting double slash with lacerate and GC would not include the 2x dps multi from both slashes hitting

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/upd5z0e5

### Before screenshot:
<img width="394" height="91" alt="image" src="https://github.com/user-attachments/assets/8c79b23b-211a-4889-b583-88bbba4882ee" />

### After screenshot:
<img width="397" height="89" alt="image" src="https://github.com/user-attachments/assets/1fec367e-88f9-46e3-91c2-7344c983c5d4" />
