### PR TITLE
Fix spectre buffs global effects applying just by existing in the spectre library

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -2032,54 +2032,66 @@ function calcs.perform(env, skipEHP)
 	local allyBuffs = env.partyMembers["Aura"]
 	local buffExports = { Aura = {}, Curse = {}, Warcry = {}, Link = {}, EnemyMods = {}, EnemyConditions = {}, PlayerMods = {} }
 	local hasActiveSpectreSkill = false
+	local activeSpectreList = { }
 	for _, activeSkill in ipairs(env.player.activeSkillList) do
 		if not activeSkill.skillFlags.disable then
 			local skillId = activeSkill.activeEffect.grantedEffect.id
 			if skillId and skillId:match("^RaiseSpectre") then
 				hasActiveSpectreSkill = true
-				break
+				if activeSkill.minion and activeSkill.minion.type then
+					t_insert(activeSpectreList, activeSkill.minion.type)
+				end
 			end
 		end
 	end
 	if hasActiveSpectreSkill then
 		for spectreId = 1, #env.spec.build.spectreList do
-			local spectreData = data.minions[env.spec.build.spectreList[spectreId]]
-			if not modDB.conditions["HaveBeastSpectre"] then
-				-- Change to grab from monster family using CorpseTypeTags.dat if other monster families are needed in the future
-				for _, tagName in ipairs(spectreData.monsterTags) do
-					if tagName == "beast" then
-						modDB.conditions["HaveBeastSpectre"] = true
-						break
-					end
+			local isThisSpectreActive = false
+			for _, spectreType in ipairs(activeSpectreList) do
+				if env.spec.build.spectreList[spectreId] == spectreType then
+					isThisSpectreActive = true
+					break
 				end
 			end
-			for modId = 1, #spectreData.modList do
-				local modData = spectreData.modList[modId]
-				if modData.name == "EnemyCurseLimit" then
-					minionCurses.limit = modData.value + 1
-					break
-				elseif modData.name == "AllyModifier" and modData.type == "LIST" then
-					buffs["Spectre"] = buffs["Spectre"] or new("ModList")
-					minionBuffs["Spectre"] = minionBuffs["Spectre"] or new("ModList")
-					for _, modValue in pairs(modData.value) do
-						local copyModValue = copyTable(modValue)
-						copyModValue.source = "Spectre:"..spectreData.name
-						t_insert(minionBuffs["Spectre"], copyModValue)
-						t_insert(buffs["Spectre"], copyModValue)
+			if isThisSpectreActive then
+				local spectreData = data.minions[env.spec.build.spectreList[spectreId]]
+				if not modDB.conditions["HaveBeastSpectre"] then
+					-- Change to grab from monster family using CorpseTypeTags.dat if other monster families are needed in the future
+					for _, tagName in ipairs(spectreData.monsterTags) do
+						if tagName == "beast" then
+							modDB.conditions["HaveBeastSpectre"] = true
+							break
+						end
 					end
-				elseif modData.name == "MinionModifier" and modData.type == "LIST" then
-					minionBuffs["Spectre"] = minionBuffs["Spectre"] or new("ModList")
-					for _, modValue in pairs(modData.value) do
-						local copyModValue = copyTable(modValue)
-						copyModValue.source = "Spectre:"..spectreData.name
-						t_insert(minionBuffs["Spectre"], copyModValue)
-					end
-				elseif modData.name == "PlayerModifier" and modData.type == "LIST" then
-					buffs["Spectre"] = buffs["Spectre"] or new("ModList")
-					for _, modValue in pairs(modData.value) do
-						local copyModValue = copyTable(modValue)
-						copyModValue.source = "Spectre:"..spectreData.name
-						t_insert(buffs["Spectre"], copyModValue)
+				end
+				for modId = 1, #spectreData.modList do
+					local modData = spectreData.modList[modId]
+					if modData.name == "EnemyCurseLimit" then
+						minionCurses.limit = modData.value + 1
+						break
+					elseif modData.name == "AllyModifier" and modData.type == "LIST" then
+						buffs["Spectre"] = buffs["Spectre"] or new("ModList")
+						minionBuffs["Spectre"] = minionBuffs["Spectre"] or new("ModList")
+						for _, modValue in pairs(modData.value) do
+							local copyModValue = copyTable(modValue)
+							copyModValue.source = "Spectre:"..spectreData.name
+							t_insert(minionBuffs["Spectre"], copyModValue)
+							t_insert(buffs["Spectre"], copyModValue)
+						end
+					elseif modData.name == "MinionModifier" and modData.type == "LIST" then
+						minionBuffs["Spectre"] = minionBuffs["Spectre"] or new("ModList")
+						for _, modValue in pairs(modData.value) do
+							local copyModValue = copyTable(modValue)
+							copyModValue.source = "Spectre:"..spectreData.name
+							t_insert(minionBuffs["Spectre"], copyModValue)
+						end
+					elseif modData.name == "PlayerModifier" and modData.type == "LIST" then
+						buffs["Spectre"] = buffs["Spectre"] or new("ModList")
+						for _, modValue in pairs(modData.value) do
+							local copyModValue = copyTable(modValue)
+							copyModValue.source = "Spectre:"..spectreData.name
+							t_insert(buffs["Spectre"], copyModValue)
+						end
 					end
 				end
 			end


### PR DESCRIPTION


Fixes #9539, #8444 .

### Description of the problem being solved:

Currently if one wants to get the benefits of normal Forest Warrior Culling Strike, it has to be an active gem slot and included in Full DPS. That is clear even from the information in the spectre libarary which says: 
>"Spectres in your Library must be assigned to an active Raise Spectre gem for their buffs and curses to activate".

But the Onslaught buff of the Perfect Forest Warrior gets applied just by being in the spectre library (and having a different spectre used in a spectre gem). Creators already add the gem setup multiple times anyway, because of the non-global skills not applying otherwise. With this pr, the same is true for global effects from spectres.

For example Ghazzy added the line in his spectre build low budget setup, because they are only used in medium budget version loadout, but are still applying the buff in the low budget loadout.
> Forest Warrior PoB bug compensation
> Minions have 20% reduced cast speed

Related to #9306.

### Steps taken to verify a working solution:
- Tested PoB from issue https://pobb.in/gIkEH3oU8iRe
- Tested PoB from Ghazzy spectre  https://pobb.in/Og2D91DozNe1
- Tested PoB from Helm Breaker https://maxroll.gg/poe/pob/8r1afp0g

### Link to a build that showcases this PR:
https://pobb.in/gIkEH3oU8iRe

### Before screenshot:
<img width="407" height="102" alt="Screenshot 2026-03-18 115417" src="https://github.com/user-attachments/assets/cdc1eee2-6b66-43c7-a57a-0ded93101db6" />

### After screenshot:
<img width="237" height="103" alt="Screenshot 2026-03-18 115245" src="https://github.com/user-attachments/assets/b49d0db2-04b7-45ff-ae1b-94e5e619a830" />

