### PR TITLE
Fix filtering Support gems in SkillsTab

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -115,7 +115,7 @@ function GemSelectClass:PopulateGemList()
 		if (self.sortGemsBy and gemData.tags[self.sortGemsBy] == true or not self.sortGemsBy) then
 			local levelRequirement = gemData.grantedEffect.levels[1].levelRequirement or 1
 			if characterLevel >= levelRequirement or not matchLevel then
-				if (showExceptional or showAll) and gemData.grantedEffect.plusVersionOf then
+				if (showExceptional or showAll) and (gemData.grantedEffect.plusVersionOf or gemData.tagString:match("Exceptional")) then
 					if self.skillsTab.showLegacyGems or not gemData.grantedEffect.legacy then
 						self.gems["Default:" .. gemId] = gemData
 					end

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -144,8 +144,8 @@ function GemSelectClass:FilterSupport(gemId, gemData)
 	end
 	return (not gemData.grantedEffect.support
 		or showSupportTypes == "ALL"
-		or (showSupportTypes == "NORMAL" and not gemData.grantedEffect.plusVersionOf)
-		or (showSupportTypes == "EXCEPTIONAL" and gemData.grantedEffect.plusVersionOf))
+		or (showSupportTypes == "NORMAL" and not (gemData.grantedEffect.plusVersionOf or gemData.tagString:match("Exceptional")))
+		or (showSupportTypes == "EXCEPTIONAL" and (gemData.grantedEffect.plusVersionOf or gemData.tagString:match("Exceptional"))))
 		and (self.skillsTab.showAltQualityGems or (not self.skillsTab.showAltQualityGems and self:GetQualityType(gemId) == "Default"))
 end
 

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -139,13 +139,14 @@ end
 
 function GemSelectClass:FilterSupport(gemId, gemData)
 	local showSupportTypes = self.skillsTab.showSupportGemTypes
+	local isLegacyAwakened = (gemData.grantedEffect.legacy and gemData.grantedEffect.plusVersionOf)
 	if gemData.grantedEffect.legacy and not self.skillsTab.showLegacyGems then
 		return false
 	end
 	return (not gemData.grantedEffect.support
 		or showSupportTypes == "ALL"
-		or (showSupportTypes == "NORMAL" and not (gemData.grantedEffect.plusVersionOf or gemData.tagString:match("Exceptional")))
-		or (showSupportTypes == "EXCEPTIONAL" and (gemData.grantedEffect.plusVersionOf or gemData.tagString:match("Exceptional"))))
+		or (showSupportTypes == "NORMAL" and not (isLegacyAwakened or gemData.tagString:match("Exceptional")))
+		or (showSupportTypes == "EXCEPTIONAL" and (isLegacyAwakened or gemData.tagString:match("Exceptional"))))
 		and (self.skillsTab.showAltQualityGems or (not self.skillsTab.showAltQualityGems and self:GetQualityType(gemId) == "Default"))
 end
 

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -115,7 +115,7 @@ function GemSelectClass:PopulateGemList()
 		if (self.sortGemsBy and gemData.tags[self.sortGemsBy] == true or not self.sortGemsBy) then
 			local levelRequirement = gemData.grantedEffect.levels[1].levelRequirement or 1
 			if characterLevel >= levelRequirement or not matchLevel then
-				if (showExceptional or showAll) and (gemData.grantedEffect.plusVersionOf or gemData.tagString:match("Exceptional")) then
+				if (showExceptional or showAll) and ((gemData.grantedEffect.legacy and gemData.grantedEffect.plusVersionOf) or gemData.tagString:match("Exceptional")) then
 					if self.skillsTab.showLegacyGems or not gemData.grantedEffect.legacy then
 						self.gems["Default:" .. gemId] = gemData
 					end


### PR DESCRIPTION
Fixes #9689 

### Description of the problem being solved:
The Show support gems filter in SkillsTab is still showing exceptional gems like "Invert the Rules" when Non-Exceptional is selected. This PR updates the filtering to also check for tagString "Exceptional". Also when filtering Exceptional Supports, it was only showing the ones with a "plusVersionOf", which hides most of the new gems. 

### Steps taken to verify a working solution:
- Check populated support gems for non-exceptional, exceptional, and the same combos with legacy on and off to check old awakened are showing properly

### Before screenshot:
<img width="1090" height="650" alt="image" src="https://github.com/user-attachments/assets/06028659-afb4-46a9-b8ea-df7ab9129fdd" />
<img width="992" height="690" alt="image" src="https://github.com/user-attachments/assets/3e5ae8ab-de7a-46e1-bf0d-7f160730fbbf" />


### After screenshot:
<img width="1066" height="696" alt="image" src="https://github.com/user-attachments/assets/9f1adbd5-8923-45bb-90e7-4b9d801e6f74" />
<img width="1120" height="709" alt="image" src="https://github.com/user-attachments/assets/d93fb2c0-dadd-40bc-bf31-e36ae59c630e" />