### PR TITLE
Timeless Jewel trade search should default to "instant buyout only"

### DIFF
--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -2137,7 +2137,7 @@ function TreeTabClass:FindTimelessJewel()
 		local search = {
 			query = {
 				status = {
-					option = "available"
+					option = "securable"
 				},
 				stats = {
 					{


### PR DESCRIPTION
### Description of the problem being solved:
When searching for timeless jewels via the "Find Timeless Jewel" button, the trade site URLs default to "instant buyout and in person."

This behavior is not desirable because many sellers of timeless jewels purposely list the jewels in a dump tab for a cheap price that they're not actually willing to sell at, because they want to use the community to give them a free price check.

This is especially a problem during league start, or when you're searching for an unpopular or non-meta jewel. The vast majority of the listings will be from sellers who are just looking to get a zero-effort price check, and if you DM them asking to buy the jewel, they will just ignore you and relist it for a higher price.


### Steps taken to verify a working solution:
Ran the code locally and confirmed that the generated trade URLs work as expected, and are set to "instant buyout only."

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
