### PR TITLE
Fix issues with gems socketed in Ring slot 3

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1373,7 +1373,10 @@ end
 
 -- Build list of modifiers in a given slot number while applying local modifiers and adding quality
 function ItemClass:BuildModListForSlotNum(baseList, slotNum)
-	local slotName = self:GetPrimarySlot():gsub("1", tostring(slotNum))
+	local slotName = self:GetPrimarySlot()
+	if slotNum ~= 1 then
+		slotName = slotName:gsub("1", tostring(slotNum))
+	end
 	local modList = new("ModList")
 	for _, baseMod in ipairs(baseList) do
 		local mod = copyTable(baseMod)

--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1371,12 +1371,9 @@ local function calcLocal(modList, name, type, flags)
 	return result
 end
 
--- Build list of modifiers in a given slot number (1 or 2) while applying local modifiers and adding quality
+-- Build list of modifiers in a given slot number while applying local modifiers and adding quality
 function ItemClass:BuildModListForSlotNum(baseList, slotNum)
-	local slotName = self:GetPrimarySlot()
-	if slotNum == 2 then
-		slotName = slotName:gsub("1", "2")
-	end
+	local slotName = self:GetPrimarySlot():gsub("1", tostring(slotNum))
 	local modList = new("ModList")
 	for _, baseMod in ipairs(baseList) do
 		local mod = copyTable(baseMod)


### PR DESCRIPTION
Fixes #9684

### Description of the problem being solved:
The logic for `{SlotName}` only took into consideration slot 1 and 2 which caused issues with `Unseen Hand`.

### Link to a build that showcases this PR:

See issue.