### PR TITLE
Fix Searing Bond of Detonation using Power charges instead of Max Power Charges

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -9514,7 +9514,7 @@ skills["SearingBondAltX"] = {
 			mod("Damage", "MORE", nil, ModFlag.Dot, 0,  { type = "PerStat", stat = "TotemsSummoned" }, { type = "SkillPart", skillPart = 2 }),
 		},
 		["number_of_additional_totems_allowed_per_maximum_power_charge"] = {
-			mod("ActiveTotemLimit", "BASE", nil, 0, 0, { type = "Multiplier", var = "PowerCharge" }),
+			mod("ActiveTotemLimit", "BASE", nil, 0, 0, { type = "PerStat", stat = "PowerChargesMax" }),
 		},
 	},
 	baseFlags = {

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -1860,7 +1860,7 @@ local skills, mod, flag, skill = ...
 			mod("Damage", "MORE", nil, ModFlag.Dot, 0,  { type = "PerStat", stat = "TotemsSummoned" }, { type = "SkillPart", skillPart = 2 }),
 		},
 		["number_of_additional_totems_allowed_per_maximum_power_charge"] = {
-			mod("ActiveTotemLimit", "BASE", nil, 0, 0, { type = "Multiplier", var = "PowerCharge" }),
+			mod("ActiveTotemLimit", "BASE", nil, 0, 0, { type = "PerStat", stat = "PowerChargesMax" }),
 		},
 	},
 #mods


### PR DESCRIPTION
### Description of the problem being solved:
Searing Bond of Detonation scales the number of totems based on a player's maximum number of power charges, not the current amount of power charges
### Steps taken to verify a working solution:
- Observe the number of totems and the multiplier remaining the same regardless of power charges toggled turned on or off

### Link to a build that showcases this PR:
```bash
eNqtHFt32jjzufsrfHgmARvbwB6ye0jIbb-kYSFtd596hC1AW2GxtpyU_fXfSPKVcJExfWiNPDfNTaOR3MHvP1fUeMNhRFhw1TAv2w0DBx7zSbC4anx5vbvoNX7_7ZfBGPHly_w6JlS8-e2XTwP5bKxRwJeYBc8kYOE9868an1mAG4a3RCHyOA6f8Bumw5izZ-bjqwYPY3g7Q4FPeApLBchVw-o2jBUiwZR5PzC_D1m8BoGAFEVR9BmtAHvqgZQN443gd0Xu8Xn8MnltGCjycODf5JCKMkfhAvOv6ew632F2mcTon6LEMKVPgzFFGxxOOeJGBH9dNYagGbTAD4QDV0RjoNxutA7CXsdhxEdoBY_HcaZrjP0MzNwH9so4XsGoh1c44K9kVSB96e7DugkJf44pJ2tKcJhzuXT2YcA8b5Yo8HLyZrt9QChER-Pp8VkqSJbr0Ha7zqXl7pXjG-FLgC8S10G5pqBNLYkE9OMiIBxrg48ZiVhQab5V5L-JKYXI0qI_wREO3xAnmvLcsNWMBGXVHJNnGGL0Mr-dz7HHJ8gncfSMeYijjIB1ae_DfUYBumFRbm_HPAQ6xiFELy9htI8gTLHHIOCLKD1Hg8lu1L3cnsgc60NWmkiCUFWa0-ZxO9WFq0z4NIEmkB71IKcsppqQvJDkrAPR828Rst_bBzjCPzOozl5yjwEvcHUOcC1Cuge4vjGuljmdNHP7MM5Dstu7dGzHsUynY3f3oY2Xm4h4iD6jn2QVryDnv6IfOOdnW9Z-B1wseQBpah-u5fT34d6REJ-AdsOofwraErFoL55rHwoxHU3Awu39KoAfA08vcL8EoUzbhfX-oKbneALxJGqKGcW6KDmTJCx1FnLFa4GDhOEm53Z5kNsTxt7yHkq2CeJYL3XnAWW1D-pWABd1ax1cbXYo9wCDMkYFTQnE3ZrqH0KpqKfbAIeLzXRJMPWrQadi3aC1Vu3p_VrE1nLlMrtdqtBCraiSbyj09RaVqjK9oaiYbE33sLoUuJamnjGUo4Dg462aei_GOGT_QLlFaDW0YbhicahpcAWsNYF0oVCbmQn2Y09vYVJVI3nD1xT2crrTyLBATkoroQ45R96PEfMX2kqTTCphlOWbxus1ZBDhDboExAoIpTsp1DIXrgb0C7iyVkSLtVKfQQ6tzSBb__W5bKHoz0Us4BUmk4Nrs8gM-gzJQmys5W78mWlsyO9gt6a19ZKA5Z3g_nhj7yD5UvQs8m2WowMNhc5xhLsQB_9ttum3tcCLDDr787sfhyIUtHlsY2ixGUqbyZbIE1kVOjNpxSv6IxRCc4Q4MvyknP6KQoICbsqW0tagJQcj2Xe6I5TjcAR-JOQSshsRRqG3fIKhO0TpDDLNVaM4Cr8E40FLtsTE02cQLhKyiNH0x-CGBXOyMJCUX_2YYi54S7GzEYMTTrHYCcxRTGF-xE-BPg0eg3XMjUA2ueIIl31mxhjFKEjabC2FIftGSwh2HCZ40yVMdSpSJuAE8WqGw8zXd8HjAK825dUgx7Ms-xiqyDRjUX-nOJ0jCB_yTIrotI-xCvMWVoa0H2edrbipxXM0-wAv4WA7UEzniHjpUp0iuGa_19fQXjWlr7Kmn2hc4RD70tg3LIYch-m8gsClNJyZ75gVkoqBUTpBQVHubltH6ltB4wFijb2DD9xRtML6fiol3tZXr-8ecznRhC4g2Efgk85tPrFjOimu_truLJBOCTiIgm20o0bLgq4aw4gsCH2Zy0QEbibzkIatcmuXDa3S0gSvYE32rzdDSjf6thfq0k00U49B_q6aBYsllrYVM81WSoLZ1iSTrW3aB5A8tX5Akc9DRF_JAhYGEfEfEuGglS01ctlSv8Tja4jxV4Lfjf8YW_0FHE33stezew058DeEhetcdtsQTEa0ZO9iUR4RqKKgVPBwlJ7uqJVxykOxTArEJ3XAo9bnwfQHoTSSBJ7wAnmbe7wC3DmiEVZ0h5T_GSNK-NYrFnIxcL2BcupO7CK3WttSJqjLFdzrZi1kGj49NZI1V3JOllyoAeTqCoCJeAELV1lXbItbOrUcKRFQFAhSpynt0mItB-Wh1jAXQHLfGrtB1IvkCxJ4NPbxY5CUmNnscSAaQX4qCUUzIbRi9GkAEhmesLYk8m8uXHa61s6GH_1CbfGmSiAxNgW7gZNes8AHC_yVsrynbIaolVlXyDtGIU9ktgpD8pfwRuGFGUFDUDTY3BhhzgKk9pBb01nglRDhGXPkQ9nWeoTqLmoJ_bekguCpIF7C8qjQZrkSUqRUCKT2khGgXFI8Pq6E9xj4p_hHTGmTGkD6rhQr8SbxnDoTVGKq-_0NozUL5HDBoXcHihQkoZK4zQFCiUdRllZ_14zxyBjONlGEqKFOTQ0HPIgrXbbV43j2ZfKUlKhlAoqFYVZAGULaxrwCwk4h3epCWpV4-hsjrbT0sTDl24KaVWdaAX4iIsOsimBVRejUVEEVhg-YrjCvY-1dEnROM30tW-4Qw66AD5VM9KOaz2LKKzOoa1u3Mkf7hMg1pu-iG1PTi6xTONdIjmq-VZzmPkTzam62e6adylKekvSlVeooGVbYNxzVibLdFM42mTPlDesUec6uleqWOYPY9nk0eHLSqGfRHYWHdS7fMs81JbvulDq1XcuunbFqT8I-l13s2tpwTxXlPLHi1jaGU5nCuZTvnCsonPPosm555NS2hVk3MM6WZ85RPrnnEsY8w9rknmFC9hnkcGpnnM4ZZtI5w0zOQeMcbmadJ_rPVkeew9Oq7yOscwXbEfEHraQDpY5OQ-TjqezffsOiax2pk03Z90o7xGk3Vfb4ksNL8cPgon2cX7a3eqLPGXEcbtRReyQawoWr-olMkWx4oXAzLL8KiDiQYb5omFl9s99vdrp98Xe_Z5tNp91zrWbXtm0Ydvvtpu32zXbTbdtdq-n0ep1O03S7XafZsc1up-labbtp92wLhh277TRt2-zZTbfT77pNy7W67WbH7HdMeNt2bYlkNm2zD-O23W_3mpbpmM1Op2u3myAMEOzYdrfp2hYwtdqO1WvaHbfbtLqO4Om63V7TcU2nl3zAoOaqTAfqV23bJefr6NdW6_39_XKN-JLN8U9C8aXHVq01IIGWL2Sn80KotjWEP9eL4fCh8zim9xcz5qH4YTJ9fQm9i-5oeb20v_bvR5v-H_-98_CPfxz3HuH5U-Raj1-77Pv_3mbDZbDovT_9PZ__dcH_-PP5-naMung84RwD6SvVJE2lGygHihJ_E9cqQgLGSNxGWFz6hnAJ8SC7pQZar8GGWfdzKtr5_ps4Jn1ljObNfCDEiWoGXzWGlKr-quwpq75o4ZxbquC7OsX4cFRTglyRyPs-i-dz8XkIeBYP5Xcst3d3tzevj19vE5QpljeZDI9RitYRzuUVbdikNUwBCEjEs0hBXzXE0Yh8OcIcERppUXvIj-KKtCSd_J0OpW8QliERO7siodufOARNLrK3OqTkxxgfxFGyiJtz8hMTLV2pY9AiKXUZ6wYCX97t06EizivLRMSI3lQeV2tEt5SbjGkbWxwViR59tEMpXBwjga-TOfEUjKbV02sIJd14Xhwib6NFQ37OUsZXQzrI6nOVMnYypqVV-XHMllbVmJZ_YQ9tythqSAc5uxtaJpANs0B8j6VD6ZbiIaHiateWZT-zQDo7xE0GoEPwGfJLspaVCb6IexbpGx1KECUhmcV8O5wL41q6kvfVS2oSI1pzkdexi6hyREuvpRvKpWxUfKOZ1LZIyBEd1PQcvoisxjRNkBwRldSvxrSUkJ7Pl-afDGoFiUy3wzdG_I-ZYvtlbYLyQu0Z5BJXZuuT2b5Dq0VRdru34iUZ24uujpf3YX_hRJyI1yMiIq4eBRF49Si8ksDjcYi1CEw-VCOTgzVIjpndNCyt1cngqfjZLdCTKai7qiejy7tL2vl_hOfyFH_HApC9qkfrjkFFB-WGuipRj9aUx8EI1HuYVK6gIzPUSEj6tNTKW0lpKqkkn3N9zJfqRX1CUBc86Bageyll98sfMKLiA2JG6xHc_p5NwwR7aYlPZOI1CvyU2kuVsn-_9hiPgKi8CT0Sn-JEtaSUN0ELdAatZIc4aG3_jwT_B9LcqnE=
```
### Before screenshot:
<img width="760" height="284" alt="image" src="https://github.com/user-attachments/assets/79408e93-a933-4fff-85f8-91377124b367" />

### After screenshot:
<img width="665" height="246" alt="image" src="https://github.com/user-attachments/assets/7ce15fdc-c8cd-47e8-8717-7ccdbdbeb6d0" />
