### PR TITLE
Add Conjuror of Rot Spectre

### DIFF
--- a/src/Classes/MinionSearchListControl.lua
+++ b/src/Classes/MinionSearchListControl.lua
@@ -13,7 +13,7 @@ local MinionSearchListClass = newClass("MinionSearchListControl", "MinionListCon
 	self.unfilteredList = copyTable(list)
 	self.isMutable = false
 
-	self.controls.searchText = new("EditControl", {"BOTTOMLEFT",self,"TOPLEFT"}, {0, -2, 128, 18}, "", "Search", "%c", 100, function(buf)
+	self.controls.searchText = new("EditControl", {"BOTTOMLEFT",self,"TOPLEFT"}, {0, -2, 203, 18}, "", "Search", "%c", 100, function(buf)
 		self:ListFilterChanged(buf, self.controls.searchModeDropDown.selIndex)
 	end, nil, nil, true)	
 	

--- a/src/Data/Skills/spectre.lua
+++ b/src/Data/Skills/spectre.lua
@@ -11593,10 +11593,6 @@ skills["FaridunCasterUndeadDamageOverTimeAura"] = {
 		area = true,
 		aura = true,
 	},
-	baseMods = {
-		skill("buffAllies", true),
-		skill("buffMinions", true),
-	},
 	constantStats = {
 		{ "active_skill_area_of_effect_radius_+%_final", 50 },
 	},

--- a/src/Data/Skills/spectre.lua
+++ b/src/Data/Skills/spectre.lua
@@ -11507,3 +11507,106 @@ skills["CrucibleVendigoFlickerStrike"] = {
 		[1] = { cooldown = 3, levelRequirement = 1, storedUses = 1, },
 	},
 }
+skills["MPSFaridunWarlockBloodSpray"] = {
+	name = "Blood Spray",
+	hidden = true,
+	color = 4,
+	baseEffectiveness = 1.1000000238419,
+	incrementalEffectiveness = 0.03999999910593,
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Projectile] = true, [SkillType.ProjectilesFromUser] = true, [SkillType.Triggerable] = true, },
+	statDescriptionScope = "skill_stat_descriptions",
+	castTime = 1,
+	baseFlags = {
+		spell = true,
+		projectile = true,
+	},
+	constantStats = {
+		{ "monster_projectile_variation", 284 },
+		{ "projectile_maximum_range_override", 25 },
+		{ "base_number_of_projectiles", 3 },
+	},
+	stats = {
+		"spell_minimum_base_physical_damage",
+		"spell_maximum_base_physical_damage",
+		"base_is_projectile",
+		"action_attack_or_cast_time_uses_animation_length",
+		"check_for_targets_between_initiator_and_projectile_source",
+		"projectile_uses_contact_position",
+		"maintain_projectile_direction_when_using_contact_position",
+		"distribute_projectiles_over_contact_points",
+	},
+	notMinionStat = {
+		"spell_minimum_base_physical_damage",
+		"spell_maximum_base_physical_damage",
+	},
+	levels = {
+		[1] = { 0.80000001192093, 1.2000000476837, critChance = 5, levelRequirement = 0, statInterpolation = { 3, 3, }, },
+	},
+}
+skills["CGEFaridunWarlockSwarmGround"] = {
+	name = "Caustic Ground",
+	hidden = true,
+	color = 4,
+	baseEffectiveness = 2,
+	incrementalEffectiveness = 0.027499999850988,
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Damage] = true, [SkillType.Triggerable] = true, [SkillType.Duration] = true, [SkillType.AreaSpell] = true, },
+	statDescriptionScope = "skill_stat_descriptions",
+	castTime = 1,
+	baseFlags = {
+		area = true,
+		spell = true,
+		duration = true,
+	},
+	constantStats = {
+		{ "active_skill_area_of_effect_radius_+%_final", -5 },
+		{ "base_skill_effect_duration", 5000 },
+		{ "ground_caustic_art_variation", 23 },
+		{ "spell_maximum_action_distance_+%", -40 },
+	},
+	stats = {
+		"base_chaos_damage_to_deal_per_minute",
+		"action_attack_or_cast_time_uses_animation_length",
+		"is_area_damage",
+	},
+	levels = {
+		[1] = { 33.333334078391, cooldown = 15, levelRequirement = 0, storedUses = 1, statInterpolation = { 3, }, },
+	},
+}
+skills["FaridunCasterUndeadDamageOverTimeAura"] = {
+	name = "Malevolence",
+	hidden = true,
+	color = 3,
+	description = "Casts an aura that multiplies damage over time and increases skill effect duration of you and your allies.",
+	skillTypes = { [SkillType.Spell] = true, [SkillType.Area] = true, [SkillType.Buff] = true, [SkillType.HasReservation] = true, [SkillType.TotemCastsAlone] = true, [SkillType.Totemable] = true, [SkillType.Aura] = true, [SkillType.Instant] = true, [SkillType.AreaSpell] = true, [SkillType.CanHaveBlessing] = true, [SkillType.InstantNoRepeatWhenHeld] = true, [SkillType.InstantShiftAttackForLeftMouse] = true, [SkillType.Cooldown] = true, },
+	statDescriptionScope = "aura_skill_stat_descriptions",
+	castTime = 1,
+	statMap = {
+		["delirium_aura_damage_over_time_+%_final"] = {
+			mod("Damage", "MORE", nil, ModFlag.Dot, 0, { type = "GlobalEffect", effectType = "Aura" }),
+		},
+		["delirium_skill_effect_duration_+%"] = {
+			mod("Duration", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
+		},
+	},
+	baseFlags = {
+		spell = true,
+		area = true,
+		aura = true,
+	},
+	baseMods = {
+		skill("buffAllies", true),
+		skill("buffMinions", true),
+	},
+	constantStats = {
+		{ "active_skill_area_of_effect_radius_+%_final", 50 },
+	},
+	stats = {
+		"delirium_aura_damage_over_time_+%_final",
+		"delirium_skill_effect_duration_+%",
+		"base_deal_no_damage",
+	},
+	levels = {
+		[1] = { 14, 10, cooldown = 0.5, levelRequirement = 0, storedUses = 1, statInterpolation = { 2, 2, }, },
+		[2] = { 17, 14, cooldown = 0.5, levelRequirement = 80, storedUses = 1, statInterpolation = { 2, 2, }, },
+	},
+}

--- a/src/Data/Spectres.lua
+++ b/src/Data/Spectres.lua
@@ -7000,3 +7000,88 @@ minions["Metadata/Monsters/LeagueAzmeri/SpecialCorpses/SynthesisGolemHigh"] = {
 		mod("LinkEffectOnSelf", "INC", 100, 0, 0), -- AzmeriGolemLinkEffectOnSelf2 [link_buff_effect_on_self_+% = 100]
 	},
 }
+-- Conjuror of Rot
+minions["Metadata/Monsters/FaridunLeague/FaridunWarlock/FaridunWarlockLow"] = {
+	name = "Imperfect Conjuror of Rot",
+	monsterTags = { "caster", "human", "humanoid", "not_dex", "not_str", "ranged", "red_blood", "slow_movement", },
+	baseDamageIgnoresAttackSpeed = true,
+	life = 2.04,
+	energyShield = 0.16,
+	fireResist = 0,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 40,
+	damage = 2.04,
+	damageSpread = 0,
+	attackTime = 1.5,
+	attackRange = 60,
+	accuracy = 1,
+	skillList = {
+		"SSMFaridunWarlockBloodLocust",
+		"SOFaridunWarlockPustule",
+		"GSFaridunWarlockPustuleExplosion",
+		"GTFaridunWarlockPustules",
+		"MPSFaridunWarlockBloodSpray",
+	},
+	modList = {
+		-- set_additional_life_scaling_index [set_additional_life_scaling_index = 25]
+		-- map_related_item_drop_chance_+%_final_from_league [map_related_item_drop_chance_+%_final_from_league = -50]
+	},
+}
+minions["Metadata/Monsters/FaridunLeague/FaridunWarlock/FaridunWarlockMid_"] = {
+	name = "Conjuror of Rot",
+	monsterTags = { "caster", "human", "humanoid", "not_dex", "not_str", "ranged", "red_blood", "slow_movement", },
+	baseDamageIgnoresAttackSpeed = true,
+	life = 2.04,
+	energyShield = 0.16,
+	fireResist = 0,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 40,
+	damage = 2.04,
+	damageSpread = 0,
+	attackTime = 1.5,
+	attackRange = 60,
+	accuracy = 1,
+	skillList = {
+		"SSMFaridunWarlockBloodLocust",
+		"SOFaridunWarlockPustule",
+		"GSFaridunWarlockPustuleExplosion",
+		"GTFaridunWarlockPustules",
+		"CGEFaridunWarlockSwarmGround",
+		"MPSFaridunWarlockBloodSpray",
+	},
+	modList = {
+		-- set_additional_life_scaling_index [set_additional_life_scaling_index = 25]
+		-- map_related_item_drop_chance_+%_final_from_league [map_related_item_drop_chance_+%_final_from_league = -50]
+	},
+}
+minions["Metadata/Monsters/FaridunLeague/FaridunWarlock/FaridunWarlockHigh"] = {
+	name = "Perfect Conjuror of Rot",
+	monsterTags = { "caster", "human", "humanoid", "not_dex", "not_str", "ranged", "red_blood", "slow_movement", },
+	baseDamageIgnoresAttackSpeed = true,
+	life = 2.04,
+	energyShield = 0.16,
+	fireResist = 0,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 40,
+	damage = 2.04,
+	damageSpread = 0,
+	attackTime = 1.5,
+	attackRange = 60,
+	accuracy = 1,
+	skillList = {
+		"SSMFaridunWarlockBloodLocust",
+		"SOFaridunWarlockPustule",
+		"GSFaridunWarlockPustuleExplosion",
+		"GTFaridunWarlockPustules",
+		"CGEFaridunWarlockSwarmGround",
+		"MPSFaridunWarlockBloodSpray",
+		"FaridunCasterUndeadDamageOverTimeAura",
+	},
+	modList = {
+		-- set_additional_life_scaling_index [set_additional_life_scaling_index = 25]
+		-- map_related_item_drop_chance_+%_final_from_league [map_related_item_drop_chance_+%_final_from_league = -50]
+	},
+}

--- a/src/Export/Minions/Spectres.txt
+++ b/src/Export/Minions/Spectres.txt
@@ -433,3 +433,7 @@ local minions, mod, flag = ...
 #spectre Metadata/Monsters/LeagueAzmeri/SpecialCorpses/SynthesisGolemLow
 #spectre Metadata/Monsters/LeagueAzmeri/SpecialCorpses/SynthesisGolemMid
 #spectre Metadata/Monsters/LeagueAzmeri/SpecialCorpses/SynthesisGolemHigh
+-- Conjuror of Rot
+#spectre Metadata/Monsters/FaridunLeague/FaridunWarlock/FaridunWarlockLow
+#spectre Metadata/Monsters/FaridunLeague/FaridunWarlock/FaridunWarlockMid_
+#spectre Metadata/Monsters/FaridunLeague/FaridunWarlock/FaridunWarlockHigh

--- a/src/Export/Skills/spectre.txt
+++ b/src/Export/Skills/spectre.txt
@@ -2241,3 +2241,25 @@ skills["LegionKaruiMeleeCombo2"] = {
 #skill CrucibleVendigoFlickerStrike Flicker Strike
 #flags attack melee movement
 #mods
+
+#skill MPSFaridunWarlockBloodSpray Blood Spray
+#flags spell projectile
+#mods
+
+#skill CGEFaridunWarlockSwarmGround Caustic Ground
+#flags area spell duration
+#mods
+
+#skill FaridunCasterUndeadDamageOverTimeAura Malevolence
+#flags spell area aura
+	statMap = {
+		["delirium_aura_damage_over_time_+%_final"] = {
+			mod("Damage", "MORE", nil, ModFlag.Dot, 0, { type = "GlobalEffect", effectType = "Aura" }),
+		},
+		["delirium_skill_effect_duration_+%"] = {
+			mod("Duration", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
+		},
+	},
+#baseMod skill("buffAllies", true)
+#baseMod skill("buffMinions", true)
+#mods

--- a/src/Export/Skills/spectre.txt
+++ b/src/Export/Skills/spectre.txt
@@ -2260,6 +2260,4 @@ skills["LegionKaruiMeleeCombo2"] = {
 			mod("Duration", "INC", nil, 0, 0, { type = "GlobalEffect", effectType = "Aura" }),
 		},
 	},
-#baseMod skill("buffAllies", true)
-#baseMod skill("buffMinions", true)
 #mods

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1367,8 +1367,8 @@ function buildMode:OpenSpectreLibrary()
 		end
 	end)
 	local controls = { }
-	controls.list = new("MinionListControl", nil, {-100, 40, 190, 250}, self.data, destList)
-	controls.source = new("MinionSearchListControl", nil, {100, 60, 190, 230}, self.data, sourceList, controls.list)
+	controls.list = new("MinionListControl", nil, {-139, 40, 265, 250}, self.data, destList)
+	controls.source = new("MinionSearchListControl", nil, {139, 60, 265, 230}, self.data, sourceList, controls.list)
 	controls.save = new("ButtonControl", nil, {-45, 330, 80, 20}, "Save", function()
 		self.spectreList = destList
 		self.modFlag = true
@@ -1378,9 +1378,9 @@ function buildMode:OpenSpectreLibrary()
 	controls.cancel = new("ButtonControl", nil, {45, 330, 80, 20}, "Cancel", function()
 		main:ClosePopup()
 	end)
-	controls.noteLine1 = new("LabelControl", {"TOPLEFT",controls.list,"BOTTOMLEFT"}, {24, 2, 0, 16}, "^7Spectres in your Library must be assigned to an active")
-	controls.noteLine2 = new("LabelControl", {"TOPLEFT",controls.list,"BOTTOMLEFT"}, {20, 18, 0, 16}, "^7Raise Spectre gem for their buffs and curses to activate")
-	local spectrePopup = main:OpenPopup(410, 360, "Spectre Library", controls)
+	controls.noteLine1 = new("LabelControl", {"TOPLEFT",controls.list,"BOTTOMLEFT"}, {99, 2, 0, 16}, "^7Spectres in your Library must be assigned to an active")
+	controls.noteLine2 = new("LabelControl", {"TOPLEFT",controls.list,"BOTTOMLEFT"}, {95, 18, 0, 16}, "^7Raise Spectre gem for their buffs and curses to activate")
+	local spectrePopup = main:OpenPopup(575, 360, "Spectre Library", controls)
 	spectrePopup:SelectControl(spectrePopup.controls.source.controls.searchText)
 end
 


### PR DESCRIPTION
### Description of the problem being solved:
Adds all three forms of Conjuror of Rot spectre and three skills: Blood Spray, Swarm Ground, and Malevolence Aura. Also increased the size of the Spectre Popup to show the longest names.

First time adding a spectre, lemme know if I botched something.

### Steps taken to verify a working solution:
- double check Malevolence aura on Perfect Conjuror persists and can be toggled in Config

### Before screenshot:
<img width="647" height="561" alt="image" src="https://github.com/user-attachments/assets/b9386996-4222-4dd1-8454-0f8f113b251c" />

### After screenshot:
<img width="744" height="541" alt="image" src="https://github.com/user-attachments/assets/5e186cf3-cdef-4b9c-b238-1f35ba7416c7" />
<img width="672" height="440" alt="image" src="https://github.com/user-attachments/assets/8957ac1b-87cd-45a6-b41a-bc569c8fb71a" />
<img width="1195" height="176" alt="image" src="https://github.com/user-attachments/assets/bf15a6b6-20da-41a1-86e9-5b78e6e566f5" />
