### PR TITLE
Add gem color indicators to socket group labels

### DIFF
--- a/src/Classes/SkillListControl.lua
+++ b/src/Classes/SkillListControl.lua
@@ -84,6 +84,27 @@ function SkillListClass:GetRowValue(column, index, socketGroup)
 		if socketGroup.includeInFullDPS then 
 			label = label .. colorCodes.CUSTOM .. " (FullDPS)"
 		end
+		
+		if not socketGroup.source then
+			local colorStr = ""
+			for _, gem in ipairs(socketGroup.gemList) do
+				if gem.gemData or gem.grantedEffect then
+					local grantedEffect = gem.grantedEffect or (gem.gemData and gem.gemData.grantedEffect)
+					if grantedEffect then
+						local char = grantedEffect.color == 1 and "R" or grantedEffect.color == 2 and "G" or grantedEffect.color == 3 and "B" or "W"
+						local colorCode = gem.color or ""
+						if colorStr:len() > 0 then
+							colorStr = colorStr .. "^7-"
+						end
+						colorStr = colorStr .. colorCode .. char
+					end
+				end
+			end
+			if colorStr:len() > 0 then
+				label = label .. " ^7" .. colorStr
+			end
+		end
+
 		return label
 	end
 end


### PR DESCRIPTION
Feature# .

### Description of the problem being solved:
This commit adds the feature requested in [#9547](https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/9547) by appending text to the end of the skill group label that indicates the colors of the skills.

### Before screenshot:
<img width="1364" height="880" alt="before" src="https://github.com/user-attachments/assets/e3d0ac66-881f-4881-8290-b9709a43e90e" />

### After screenshot:
<img width="1362" height="868" alt="after" src="https://github.com/user-attachments/assets/a7e08279-ba4e-4ba4-a050-d1eb4de2dc18" />