### PR TITLE
Add support for listing all active Tattoos

### DIFF
--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -907,8 +907,8 @@ function TreeTabClass:ModifyNodePopup(selectedNode)
 	end
 
 	buildMods(selectedNode)
-	controls.modSelectLabel = new("LabelControl", {"TOPRIGHT",nil,"TOPLEFT"}, {150, 25, 0, 16}, "^7Modifier:")
-	controls.modSelect = new("DropDownControl", {"TOPLEFT",nil,"TOPLEFT"}, {155, 25, 250, 18}, modGroups, function(idx) constructUI(modGroups[idx]) end)
+	controls.modSelectLabel = new("LabelControl", {"TOPRIGHT",nil,"TOPLEFT"}, {170, 25, 0, 16}, "^7Modifier:")
+	controls.modSelect = new("DropDownControl", {"TOPLEFT",nil,"TOPLEFT"}, {175, 25, 250, 18}, modGroups, function(idx) constructUI(modGroups[idx]) end)
 	controls.modSelect.selIndex = self.defaultTattoo[nodeName] or 1
 	controls.modSelect.tooltipFunc = function(tooltip, mode, index, value)
 		tooltip:Clear()
@@ -938,24 +938,46 @@ function TreeTabClass:ModifyNodePopup(selectedNode)
 		main:ClosePopup()
 	end)
 
-	local function getTattooCount()
+	local function getTattooCount(tooltip)
+		if tooltip then
+			tooltip:Clear()
+		end
 		local count = 0
+		local tattooSdMap = { }
+
 		for _, node in pairs(self.build.spec.hashOverrides) do
 			if node.isTattoo and not node.dn:find("Runegraft") then
+				if tooltip then
+					local combined = ""
+					for _, line in ipairs(node.sd) do
+						if not (line:match("Limited") or line:match("Requires")) then -- clean up some legacy tattoo lines
+							combined = combined.." "..line
+						end
+					end
+					if tattooSdMap[combined] then
+						tattooSdMap[combined] = tattooSdMap[combined] + 1
+					else
+						tattooSdMap[combined] = 1
+					end
+				end
 				count = count + 1
 			end
+		end
+		for line, mult in pairs(tattooSdMap) do
+			tooltip:AddLine(16, colorCodes.COLD.."("..mult..") ^7"..line)
 		end
 		if count > 50 then
 			count = colorCodes.NEGATIVE..count
 		end
 		return count
 	end
-	controls.totalTattoos = new("LabelControl", nil, { 0, 95, 0, 16 }, "^7Tattoo Count: ".. getTattooCount() .."/50" )
+	controls.totalTattoos = new("ButtonControl", nil, { 0, 95, 145, 20 }, "^7Tattoo Count: ".. getTattooCount() .."/50", function() return end)
+	controls.totalTattoos.tooltipFunc = function(tooltip, mode, index, value) getTattooCount(tooltip) end
 	main:OpenPopup(600, 105, "Replace Modifier of Node", controls, "save")
 	constructUI(modGroups[self.defaultTattoo[nodeName] or 1])
 	
 	-- Show Legacy Tattoos
-	controls.showLegacyTattoo = new("CheckBoxControl", { "LEFT", controls.totalTattoos, "RIGHT" }, { 205, 0, 20 }, "Show Legacy Tattoos:", function(state)
+	controls.showLegacyTattoo = new("CheckBoxControl", { "LEFT", controls.totalTattoos, "RIGHT" }, { 195, 0, 20 }, "Show Legacy Tattoos:", function(state)
 		self.showLegacyTattoo = state
 		buildMods(selectedNode)
 	end)


### PR DESCRIPTION
### Description of the problem being solved:
Allow users to quickly view all tattoos in a tree. List all active tattoos in a tooltip when hovering the tattoo count in the add modifier popup. Haven't tested with 50 distinct tattoos so it might not show well but I feel like it's rare for a build to not use the same tattoos multiple times and this will combine those. Also added a little parsing to skip certain lines in Legacy tattoos.

Also slight UI spacing adjustments.

### Steps taken to verify a working solution:
- tested against Legacy tattoos
- verify tattoo counts

### Link to a build that showcases this PR:
<pre>eNrtXFlz2zgSfs78CpSq5mkVSzx0TTmzJVu-Knaisexk52kKIiEJY4jQkKAcza_fBsBLsg5Q1GZTtZsHh6S6G40Pje5GE-D5P7_NGVqSMKI8-FCzzpo1RAKP-zSYfqg9P12_79b--etP50MsZp8nFzFl8pdff3p3rq4RI0vCPtTsXg15DEfRJzwnH2ojD6TVEI48EviX-fNPPCA1JHA4JeJL2qbzB7S5wIGYER484D95eMP9lDZ7ToO1594Mh9gTJLyXCvRjwR-4Dy2IMIZfxzjwqUhpl5S86l_vHoafH59qaI5pMOLeCxE3IY8X0O8adOnd-ZDhFQlHAgu0xCwGDlAtgtsPtT5ghKfklopaw5D2Ig4jMcBzuNzNc9a0bLfXbvbcXqfp2HYqY7QgxN_JZp21UsLLkIqHmAm6YJSEuzmamXrQh8sZDjxyuCdPXGA2GI5MKbkBOl-pmF0w6J2RXEl9Nw2oIMbkQ04jHpTS2oj4MmYMjN-I9pFEJFxiQQ0VueTzMQ32Y9IFY7Hzceec-fw1OCz7AQf4kkfCjHJIQpi1ohTDiHgcJnrZNkpy3tMJMacs1Y-Eoaw2x_XjamRKV1rwcQo9gocyoxzxmO2lbOWkYp8zysx4QL7tJHMyYXeBgXIDsuRywu2ktLu9M6vXcbtux2r31nzA1e1wJ5trWSntcLaKqIfZA_5G5_EcPOkTfiF7WsybuafTmQjAfxjzdrOeXdOQHNHkJXgIY7ZWJ2ObYR6Z8hXAkTPCwIQWxPtFkt4FnqnU5yBU_nRPRNzgeATzl1F4zIhJSFxvJJlFu7HKo69ua0qCpMGVmeO4J8Sb3UAW8ojFbgVt2yl6TUNsJek-bDekGmBbAGqd4xBQzlmvyFgSKMliBlTuAQMSTlejGSXML0edqnWJF4Y4F7n34b2juVJQFFlLQvIVh75ZCNideBSpzDTPE9mrJY72OmV3HVVNbgToA4E0Ehh8YprPDkP-J_EEZeXY-uGcx6FpFzS1UQ_SeKJXCY_Ej729ESzzcVeTiezHklwwWMeY9iPjAj0ZK8XaFwJ7LwPuT41RU42U4ljXbxQvFuBppDkcEPDedYuhEpJvapLN5LSfwZj3zfz3rWYxqJo2kNOWaCBLFExb2WA42FS7uRbpjTuTEx9q4q2ZPoC7mEOoUMtaWIwbDA6stoyWTorQcAk35K-g-UwWIKLdUWsbNeRDBqqEJPh7ZSx_jdyogavAj0M5FYzb2OTIm3mgAcys9Th_ZrU2ihhr9Yu3LM2zTmtbyaIKZeesbeXr3I0SxBbBO0oQhwRvqUOYsGwWI0x4NisSBp0wIn5TkdhDu7UicUj5t2WJLVazJf_fo8eujPkAy7asZw_LlkTQkLqkbocysyc6hywligZYYBSpmuM1ZYKEA_Cjcl5qWQSH3uweHl1jxsYQaT_Uik_lnZ8sb7_gkOJAWAr5jYe2fCgbPm-o-qy8egoJ-ULJK_qb8_m9rte2a-rud4gGnaZzZtvd5F9P__AvmcHZZ00LCKMZf5VdH1Bw5uCxPBKldVatIKz0QT_V6t18wUOByDf53xCHYvWhNsEs0mgoVRBOI7yX1V3lTbFafOcrVOY4AqBWOohEGhFZ1cDhqr9OHFCWFKAT1oD7Uk3bgaV-3Wp27V69ZTudut1zWk695Ta7dduxbLveduyuXXfbrU633ur17G7dday2Xbe7jtOst22r6dSdZrtn1W23Z7l1x3WbzbrVttod-Nty3XqrC6RA04G_rXarq1py6pbbAwFOGyhgRkmJ0KgDrXahzY7t1EEctGm5zVa77vQ6HWABHpAKzbh124aBAV2cDqQ2Qg5hXi-3uwq2d-fPj_fq4t1MiEX0S6Px-vp6tsBixifkGyS5Zx6fNxaACgD-PnqhjL2Xohp9-Hcx7ffvvsTLjy_NZ_9fHxfXowv8vPRWYnL_181Hisd_hSvmTP78_cvHm98H3eC3jxfuwG9-ur69aj9P3W6n2SJXr4P4_edl_-bPMZ9bzaj9HN59_fh-MQbZSsFGquG5LrdHDX0nE4iQwhBp9bP7xDj0iN_JyCOTb9GwB_Lv8516FDXughs8h25IWxQhZk9g_Kwx1B2VRvaEheA8anykAi8x_Dwmya8XN2eLYKoNRNqKGn-YRwCsZkJ8gsSMIM2KHsmYgG1RT0KfqzKSYN7BwyjFN2pAPs19W4nX3XpnNX-WbypATSQ46i859ZEKOeC0dccbac__w0A8xS98BqF8LxTSTDUU93yFmVihHJL-Czzai8NaE-p5EQp4Op2SUL8wQhYaxfM5D9BoQUMqsgaQ4kOvMxKgFY9RSLA3Q0ktCsnlJ_wGhq1lYvQc0L9igsAJz1eIRogqthANZYUCQNF093QOIduXY2Ch9a5951HAEWaU7xsE6TC2mWPCCuYD61ZfmlRoZpUjFWVGc4grSZPFYdHLugjN8JKgVtFaHzCdIxihWyq-L0ifpmBEs3j_pO3IItZblBJe9BXDGjyYmmI0gYWgrxLdIjZrcOi074dDQoWjfUjINe4rZi-mUORr4k_QRBGOf7R_lkBIAqQpcDrDvhsih_25CvB7_Lly0mgQ0sAYEgbp5xSyugUJ9avrIirNMzAT6b7UREJ6uYRUJggeB0dIJq_fF6R-yGdg_DHdh5PKXbbhlHGjkcdjYQZRXujYtJptIXBMIP6hS3DkjPiHyK5D_jcJfrxoqdK3rZ46YUYj-Tcwt7GFrqZveCG1HoGluCCoeeYoW5MmhYA6SYd_PGxUMvw_iI2Bw1ariL2hC_yTh8OlqXcSXBCA0h-H8EdCtRHCaOBBFhWBM3qSlP8Ff2RiMWoZtNdiIKSHlJtGMVh-0slq0xmpFwYyo4lkGgmZ5UjEwZbcJ2H_vjB9wQy_7M0N5bpyG0aaE-kixBjW5Ma5oeJISvtv8p9_WD-jywwT9bZgPcz9cMmzWnP_b2fPhzMkVeXYkyGVcc3qWeTxSEColp4l2JhxuxHycByR_9Jq2MRPy_rL_5cYMtHRNagfL2Llt6qMdN6QZURV-5Q9lBfaPFUF8x5SeG91Q-ZRWpFEEXh5-eBiNRiOspIm0PaZ-C0GfyHW6ZPCpZQ5IkIXvosirqUzXa-ZI59McMwkTVJ5DXg4z_YPFX9PWtTlYFlyjRcLLf1ptZC1zP79fVItTTRA1E8rqMlDtbG1n6t5iZkXKUU3flDPAGcWwxgHyau2AjBxKAvTEsZfkqoQw2OpvtwdLDfV-AleiXmClhs_pDuDrZTjhvExZnbeiNQjKaxnKhVJrWxIcsqkQ5ldq6KR_gkMFkxel5W3F5fWJO0SsqlWDiGshoJk1JVR-xIgVdTSzRFfS-Rh0tpfekQl4UAPc_ZMjnJSCtVTJDHgZGSVEWvjVVV1mAURAnepN_V9JXgB2kkTTLHcXaLXRislJDarWkru98lcMy7GwdqAZzh-fryXVhCo_dyaC9lo9IoXqD9eRRBmkS71IkjnJIsuyDf2C4IRB8-wKaFVQsI1w9FLKY415Y_l21TZOUbQhgy3hIwL7q-Q3nBSBb1bwubAUr0zVlk0LwgTVQDYOxqtUkhy8cYC7VNpYlfVxKo8m9zSs8mtbEHtE0wHqyp0R5lxBRnbTPoIQyrT7_48ZkSUHq4jRuc431TaeMuOeQn6R1lVtMoy2GUZylrMCYzUOoGMdkVDP0UAbJ-gH63TBNFTdMep7EatE2hhnwYQq3QUsY_NIqr0YHsIPIVhldIixJNT6O2cZuzsE5hR-ZzcOlUO5VZ0TVbleVg9IWpVtgW7IgrtqulU1QjROpU_cE4lyK0KSXW7qLw-OBmqJxNUfcVSPtaczCTap3Ja1mlct1s66pyo4VOEzLfKnzeSCpTeIxtin4zUXtKvRB5miPQWVlX3kleqCKcLV8EiFklzqgz3RxDPx7LyrP9P97-uU85p5P0xjicT-RkAuXM3VJ83uLq-vrp8uvtylbCMiDp9gzzOGF5EspaZFtjicaR__FCTe2lVbW5ABKYs0qWypHTHgKqUNMV3S9PvBChZ-W0ZSVffSChfw3wFHENKEr2yu9JKaRXkNmi5h1lLy3fXmwnSr38ucSTUlmiNVGHzv5kU-YmDpDvyshTv3XyBWdJycl0aCSEL8Avi0Qn1ZJm1OOSyOK-flcLF8-IQe6tsvNcOOJnJUK_OtAB9WYZZn0jQ3Ml1KVTVq6oEVX1dhn1APJz0XV-WYc522fNAfo1DScmelZL0iQfKyGHS9CmTx5OSkb1iJHtQRuBnMSNhsl1dS3oAz5M-KDlxQjqORTqNC_elsJJHMjRC-eEMM1Z14lj3IT97bOiJiocvNKBvj2OYiVKnV1NHVo5V70dL8Fs75GY4BGnlyt84AGoIQnLuVfd_7RCs4SRR_ldthVO-QU-XjYflHAaE4-pi1InO6mI2j3hWl6hSwGS8k-ud7MmbxQL3s6DyzVw1IXKWVZMgJ1s1CU808EQckqMFPGaJyOPeHOQtZ3oqUYfqtSOKRvzZYcWjJegjlUezqxOfhty7_P-ATNQb2DwAZE9KWbPag0Y9dWKvoiy5zW0AyJYV9RYg1cMNn1RNlo6zJwJNuw_9xZKCPyl-wqSEIMgLbrPM81hJ2RHoW4KZPArKWTWBm19mMRe2ZaoTj8cLHPiptM_r6f6x6HERgVB1BHEg9-hGlbRUx3v2yTlvpCvEc3XoEOHFggS5biO5qcdfSpN9AvzzLT0-kTvXcBLwGdPSPnGhtxRJyenN-SUPJnSabKjQN8UtFdkTJKhgpLDno7iTYsiwR2ac-SRM1qZEdq7w1YJsIdvK1ts7mIqn9zMu5xBXlpdkC-am5Tq7meTxVZIeVi1wtQ60s_5pi5zRtl3rAKtEY0gKKjomSGw21O21d7OBRXgvI7U38U3pYCsK2Rf25HluEhJfMV_KPUGw6p-UAEb2rhwoI4-rY7bG2mpQwryqYGwd2bckSuGv9rYVkHd303t6msBqWu1LpFMSKhALdn-gMV0_yMg7zT19iuiUss8TFdZH8vRACfw2v8NhPjEzziNsP111pCxtq9ftmdjlLWaMv0KjkPDNiTaWRzLnS-JfrMC1rUpYDjw5QnVpcEkdw2Qwc9WVf1_X30jZRfY1n7f-yT00SMkndyDuPOKg2NNO0wCe8s4anmybUxC60sChA5m6-_Wn88bmJ1f_DYUAnB4=</pre>

### After screenshot:
<img width="1230" height="516" alt="image" src="https://github.com/user-attachments/assets/d093e847-6104-40e8-8f7d-66e71990a1b5" />
