### PR TITLE
Default crafted cluster jewels to minimum passives

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -1746,7 +1746,7 @@ function ItemsTabClass:UpdateClusterJewelControls()
 
 	-- Update added node count slider
 	local countControl = self.controls.displayItemClusterJewelNodeCount
-	item.clusterJewelNodeCount = m_min(m_max(item.clusterJewelNodeCount or item.clusterJewel.maxNodes, item.clusterJewel.minNodes), item.clusterJewel.maxNodes)
+	item.clusterJewelNodeCount = m_min(m_max(item.clusterJewelNodeCount or item.clusterJewel.minNodes, item.clusterJewel.minNodes), item.clusterJewel.maxNodes)
 	countControl.divCount = item.clusterJewel.maxNodes - item.clusterJewel.minNodes
 	countControl.val = (item.clusterJewelNodeCount - item.clusterJewel.minNodes) / (item.clusterJewel.maxNodes - item.clusterJewel.minNodes)
 
@@ -1756,7 +1756,7 @@ end
 function ItemsTabClass:CraftClusterJewel()
 	local item = self.displayItem
 	wipeTable(item.enchantModLines)
-	t_insert(item.enchantModLines, { line = "Adds "..(item.clusterJewelNodeCount or item.clusterJewel.maxNodes).." Passive Skills", crafted = true })
+	t_insert(item.enchantModLines, { line = "Adds "..(item.clusterJewelNodeCount or item.clusterJewel.minNodes).." Passive Skills", crafted = true })
 	if item.clusterJewel.size == "Large" then
 		t_insert(item.enchantModLines, { line = "2 Added Passive Skills are Jewel Sockets", crafted = true })
 	elseif item.clusterJewel.size == "Medium" then


### PR DESCRIPTION
This changes crafted cluster jewels to default to their minimum added passive count instead of their maximum, based on the `requested-features` item.

Previously, creating a cluster jewel in the item crafter would initialize it at the highest legal node count for that base, while the desirable outcome is _usually_ the lowest node count.

With this change:
  - newly crafted cluster jewels start at their minimum allowed added passive count
  - the generated `Adds X Passive Skills` enchant line stays in sync with that default

Tested:
  - crafted cluster jewels in the client
  - verified large medium and small cluster jewels now start at the lower node-count default
  - verified the added passive text updates accordingly

<img width="701" height="319" alt="image" src="https://github.com/user-attachments/assets/40527fe2-b6c5-4610-97d2-9fdf6628b809" />

<img width="701" height="418" alt="image" src="https://github.com/user-attachments/assets/fffaec34-9762-4706-9200-d1d2ba0e2e38" />