### PR TITLE
Add warning for eligible items missing an anoint

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2367,6 +2367,18 @@ function ItemsTabClass:getAnoint(item)
 	return result
 end
 
+---Gets how many anoint slots are still missing on an item.
+---@param item table @The item to inspect
+---@return number @How many additional anoints can still be applied
+function ItemsTabClass:getMissingAnointCount(item)
+	if not item or not item.base or not (item.canBeAnointed or item.base.type == "Amulet") then
+		return 0
+	end
+	local maxAnoints = item.canHaveFourEnchants and 4 or item.canHaveThreeEnchants and 3 or item.canHaveTwoEnchants and 2 or 1
+	local anointCount = #self:getAnoint(item)
+	return m_max(0, maxAnoints - m_min(anointCount, maxAnoints))
+end
+
 ---Returns a copy of the currently displayed item, but anointed with a new node.
 ---Removes any existing enchantments before anointing. (Anoints are considered enchantments)
 ---@param node table @The passive tree node to anoint, or nil to just remove existing anoints.

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1701,6 +1701,9 @@ function buildMode:InsertItemWarnings()
 			InsertIfNew(self.controls.warnings.lines, "You have too many gems in your "..warning.." slot")
 		end
 	end
+	if self.calcsTab.mainEnv.itemWarnings.missingAnointWarning then
+		InsertIfNew(self.controls.warnings.lines, "You have eligible items missing an anoint: "..table.concat(self.calcsTab.mainEnv.itemWarnings.missingAnointWarning, ", "))
+	end
 end
 
 -- Build list of side bar stats

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -14,21 +14,6 @@ local m_max = math.max
 
 local tempTable1 = { }
 
-local function isAnointableItem(item)
-	return item and item.base and (item.canBeAnointed or item.base.type == "Amulet")
-end
-
-local function itemHasAnoint(item)
-	for _, modList in ipairs({ item.enchantModLines, item.scourgeModLines, item.implicitModLines, item.explicitModLines, item.crucibleModLines }) do
-		for _, mod in ipairs(modList or {}) do
-			if mod.line and mod.line:find("Allocates ", 1, true) then
-				return true
-			end
-		end
-	end
-	return false
-end
-
 -- Initialise modifier database with stats and conditions common to all actors
 function calcs.initModDB(env, modDB)
 	modDB:NewMod("FireResistMax", "BASE", data.characterConstants["base_maximum_all_resistances_%"], "Base")
@@ -895,9 +880,14 @@ function calcs.initEnv(build, mode, override, specEnv)
 
 		for _, slot in ipairs(build.itemsTab.orderedSlots) do
 			local item = items[slot.slotName]
-			if isAnointableItem(item) and not itemHasAnoint(item) then
+			local missingAnoints = build.itemsTab:getMissingAnointCount(item)
+			if missingAnoints > 0 then
+				local slotLabel = slot.label
+				if missingAnoints > 1 then
+					slotLabel = slotLabel .. " (" .. missingAnoints .. " missing)"
+				end
 				env.itemWarnings.missingAnointWarning = env.itemWarnings.missingAnointWarning or { }
-				t_insert(env.itemWarnings.missingAnointWarning, slot.label)
+				t_insert(env.itemWarnings.missingAnointWarning, slotLabel)
 			end
 		end
 

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -14,6 +14,21 @@ local m_max = math.max
 
 local tempTable1 = { }
 
+local function isAnointableItem(item)
+	return item and item.base and (item.canBeAnointed or item.base.type == "Amulet")
+end
+
+local function itemHasAnoint(item)
+	for _, modList in ipairs({ item.enchantModLines, item.scourgeModLines, item.implicitModLines, item.explicitModLines, item.crucibleModLines }) do
+		for _, mod in ipairs(modList or {}) do
+			if mod.line and mod.line:find("Allocates ", 1, true) then
+				return true
+			end
+		end
+	end
+	return false
+end
+
 -- Initialise modifier database with stats and conditions common to all actors
 function calcs.initModDB(env, modDB)
 	modDB:NewMod("FireResistMax", "BASE", data.characterConstants["base_maximum_all_resistances_%"], "Base")
@@ -875,6 +890,14 @@ function calcs.initEnv(build, mode, override, specEnv)
 			end
 			for slot in pairs(trueDisabled) do
 				items[slot] = nil
+			end
+		end
+
+		for _, slot in ipairs(build.itemsTab.orderedSlots) do
+			local item = items[slot.slotName]
+			if isAnointableItem(item) and not itemHasAnoint(item) then
+				env.itemWarnings.missingAnointWarning = env.itemWarnings.missingAnointWarning or { }
+				t_insert(env.itemWarnings.missingAnointWarning, slot.label)
 			end
 		end
 


### PR DESCRIPTION
This adds a sidebar warning for equipped items that can be anointed but currently are not.

The warning is shown for eligible anointable bases such as:
  - amulets
  - Cord Belts
  - anointable blight uniques

When triggered, the warning lists the affected equipment slots so the player can see at a glance which items are missing an anoint. To remain concise, items supporting multiple anoints only generate the warning when they have no anoint.

Tested:
  - equipped anointable items without an anoint and verified the warning appears
  - verified the warning does not appear once an anoint is present
  - verified the warning wording stays readable when multiple eligible items are missing an anoint

<img width="1484" height="900" alt="image" src="https://github.com/user-attachments/assets/c79f6168-466c-4354-bc73-ec3951556a27" />
