### PR TITLE
Default staged skills to their maximum stages

### DIFF
--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -1498,7 +1498,7 @@ function buildMode:RefreshSkillSelectControls(controls, mainGroup, suffix)
 					controls.mainSkillPart.selIndex = activeEffect.srcInstance["skillPart"..suffix] or 1
 					if activeEffect.grantedEffect.parts[controls.mainSkillPart.selIndex].stages then
 						controls.mainSkillStageCount.shown = true
-						controls.mainSkillStageCount.buf = tostring(activeEffect.srcInstance["skillStageCount"..suffix] or activeEffect.grantedEffect.parts[controls.mainSkillPart.selIndex].stagesMin or 1)
+						controls.mainSkillStageCount.buf = tostring(activeEffect.srcInstance["skillStageCount"..suffix] or activeSkill.skillData.stagesMax or activeEffect.grantedEffect.parts[controls.mainSkillPart.selIndex].stagesMin or 1)
 					end
 				end
 				if activeSkill.skillFlags.mine then
@@ -1507,7 +1507,7 @@ function buildMode:RefreshSkillSelectControls(controls, mainGroup, suffix)
 				end
 				if activeSkill.skillFlags.multiStage and not (activeEffect.grantedEffect.parts and #activeEffect.grantedEffect.parts > 1) then
 					controls.mainSkillStageCount.shown = true
-					controls.mainSkillStageCount.buf = tostring(activeEffect.srcInstance["skillStageCount"..suffix] or activeSkill.skillData.stagesMin or 1)
+					controls.mainSkillStageCount.buf = tostring(activeEffect.srcInstance["skillStageCount"..suffix] or activeSkill.skillData.stagesMax or activeSkill.skillData.stagesMin or 1)
 				end
 				if not activeSkill.skillFlags.disable and (activeEffect.grantedEffect.minionList or activeSkill.minionList[1]) then
 					wipeTable(controls.mainSkillMinion.list)

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -615,16 +615,15 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 		end
 	end
 
-	if skillModList:Sum("BASE", activeSkill.skillCfg, "Multiplier:"..activeGrantedEffect.name:gsub("%s+", "").."MaxStages") > 0 then
+	local limit = skillModList:Sum("BASE", activeSkill.skillCfg, "Multiplier:"..activeGrantedEffect.name:gsub("%s+", "").."MaxStages")
+	activeSkill.skillData.stagesMax = limit > 0 and limit or nil
+	if limit > 0 then
 		skillFlags.multiStage = true
-		activeSkill.activeStageCount = m_max((env.mode == "CALCS" and activeEffect.srcInstance.skillStageCountCalcs) or (env.mode ~= "CALCS" and activeEffect.srcInstance.skillStageCount) or 1, 1 + skillModList:Sum("BASE", activeSkill.skillCfg, "Multiplier:"..activeGrantedEffect.name:gsub("%s+", "").."MinimumStage"))
-		local limit = skillModList:Sum("BASE", activeSkill.skillCfg, "Multiplier:"..activeGrantedEffect.name:gsub("%s+", "").."MaxStages")
-		if limit > 0 then
-			if activeSkill.activeStageCount and activeSkill.activeStageCount > 0 then
-				skillModList:NewMod("Multiplier:"..activeGrantedEffect.name:gsub("%s+", "").."Stage", "BASE", m_min(limit, activeSkill.activeStageCount), "Base")
-				activeSkill.activeStageCount = (activeSkill.activeStageCount or 0) - 1
-				skillModList:NewMod("Multiplier:"..activeGrantedEffect.name:gsub("%s+", "").."StageAfterFirst", "BASE", m_min(limit - 1, activeSkill.activeStageCount), "Base")
-			end
+		activeSkill.activeStageCount = m_max((env.mode == "CALCS" and activeEffect.srcInstance.skillStageCountCalcs) or (env.mode ~= "CALCS" and activeEffect.srcInstance.skillStageCount) or activeSkill.skillData.stagesMax or 1, 1 + skillModList:Sum("BASE", activeSkill.skillCfg, "Multiplier:"..activeGrantedEffect.name:gsub("%s+", "").."MinimumStage"))
+		if activeSkill.activeStageCount and activeSkill.activeStageCount > 0 then
+			skillModList:NewMod("Multiplier:"..activeGrantedEffect.name:gsub("%s+", "").."Stage", "BASE", m_min(limit, activeSkill.activeStageCount), "Base")
+			activeSkill.activeStageCount = (activeSkill.activeStageCount or 0) - 1
+			skillModList:NewMod("Multiplier:"..activeGrantedEffect.name:gsub("%s+", "").."StageAfterFirst", "BASE", m_min(limit - 1, activeSkill.activeStageCount), "Base")
 		end
 	elseif noPotentialStage and activeEffect.srcInstance and not (activeEffect.gemData and activeEffect.gemData.secondaryGrantedEffect) then
 		activeEffect.srcInstance.skillStageCountCalcs = nil

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1778,6 +1778,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 			activeSkill.skillData.soulPreventionDuration = activeSkill.soulPreventionDuration
 			activeSkill.skillData.totemLevel = skillData.totemLevel
 			activeSkill.skillData.damageEffectiveness = skillData.damageEffectiveness
+			activeSkill.skillData.stagesMax = skillData.stagesMax
 			activeSkill.skillData.manaReservationPercent = skillData.manaReservationPercent
 		end
 	end


### PR DESCRIPTION
Fixes: requested feature backlog - Max stages of skills by default.

### Description of the problem being solved:

Stage-based skills default to 1 stage unless the user changes them manually. This makes staged skills show a lower-than-expected default state in both the Skills UI and calculations.

This change stores each active skill's resolved maximum stage count and uses that as the default when no explicit stage count has been set.

**Note**: this applies when the skill is usable. Skills that are currently unusable because of weapon requirements still behave as they do today until a valid weapon is equipped.


### Steps taken to verify a working solution:
- Verified 40ish skills including Flameblast of Celerity, Incinerate of Venting, Blade Blast, Blight and Blight of Contagion, Reave and Vaal Reave, Scorching Ray, Penance Brand of Dissipation, Wintertide Brand, Scourge Arrow, Tornado of Elemental Turbulence...
- Verified Blade Flurry and Thunderstorm update to their max stages once a valid weapon is equipped.

### Implementation TLDR

While querying the skill details to set the `multiStage` flag, the max stage value is now parsed and stored in a new `stagesMax` skillData variable and used in the UI where relevant.

### Skills UI
<img width="1061" height="465" alt="image" src="https://github.com/user-attachments/assets/ab4c68cf-b927-4200-a35d-4b604ed7e063" />

<img width="1111" height="318" alt="image" src="https://github.com/user-attachments/assets/03903b7c-9413-439d-8aad-6025b9795c6f" />

### Calcs Tab
<img width="812" height="318" alt="image" src="https://github.com/user-attachments/assets/b3ff05fa-09c8-4dd9-bc1a-1f7ed89ac5a1" />

### Behaviour without / with usable weapon
<img width="884" height="318" alt="image" src="https://github.com/user-attachments/assets/0af84d59-b80b-4b0c-87b8-c364f9f6af9e" />

<img width="734" height="318" alt="image" src="https://github.com/user-attachments/assets/42708f40-277e-40ee-8725-6210ca790312" />
