### PR TITLE
Add Unholy Aberration spectre

### DIFF
--- a/src/Data/Spectres.lua
+++ b/src/Data/Spectres.lua
@@ -2907,6 +2907,13 @@ minions["Metadata/Monsters/SpiderPlated/SpiderPlatedUnholyEmerge"] = {
 		"Melee",
 	},
 	modList = {
+		-- MonsterNoDropsOrExperience [monster_no_drops_or_experience = 1]
+		-- CannotBeAugmented [cannot_have_azmeri_dust = 1]
+		-- CannotBeAugmented [cant_possess_this = 1]
+		-- CannotBeAugmented [cant_touch_this = 1]
+		-- CannotBeAugmented [cannot_be_tagged_by_sentinel = 1]
+		-- CannotBeAugmented [cannot_be_afflicted = 1]
+		-- CannotBeAugmented [cannot_have_affliction_mods = 1]
 	},
 }
 -- Wicker Man

--- a/src/Data/Spectres.lua
+++ b/src/Data/Spectres.lua
@@ -2889,6 +2889,26 @@ minions["Metadata/Monsters/Undying/UndyingOutcastWhirlingBlades"] = {
 	modList = {
 	},
 }
+-- Unholy Aberration
+minions["Metadata/Monsters/SpiderPlated/SpiderPlatedUnholyEmerge"] = {
+	name = "Unholy Aberration",
+	monsterTags = { "animal_claw_weapon", "beast", "flesh_armour", "insect_blood", "is_unarmed", "medium_height", "medium_movement", "melee", "physical_affinity", "spider", },
+	life = 14,
+	fireResist = 0,
+	coldResist = 0,
+	lightningResist = 0,
+	chaosResist = 0,
+	damage = 1.6,
+	damageSpread = 0.2,
+	attackTime = 1.95,
+	attackRange = 18,
+	accuracy = 1,
+	skillList = {
+		"Melee",
+	},
+	modList = {
+	},
+}
 -- Wicker Man
 minions["Metadata/Monsters/WickerMan/WickerMan"] = {
 	name = "Wicker Man",

--- a/src/Export/Minions/Spectres.txt
+++ b/src/Export/Minions/Spectres.txt
@@ -162,6 +162,8 @@ local minions, mod, flag = ...
 #spectre Metadata/Monsters/Undying/CityStalkerMaleCasterArmour
 #spectre Metadata/Monsters/Undying/UndyingOutcastPuncture
 #spectre Metadata/Monsters/Undying/UndyingOutcastWhirlingBlades
+-- Unholy Aberration
+#spectre Metadata/Monsters/SpiderPlated/SpiderPlatedUnholyEmerge
 -- Wicker Man
 #spectre Metadata/Monsters/WickerMan/WickerMan
 -- Redemption Sentry


### PR DESCRIPTION
Fixes #9699

### Description of the problem being solved:

Added Unholy Aberration Spectre.

### Steps taken to verify a working solution:
- Ran PoB in Dev Mode, confirmed spectre appears and stats are correct
- Added to both `src/Export/Minions/Spectres.txt` and `src/Data/Spectres.lua`

### Link to a build that showcases this PR:

https://pobb.in/x0h84fqB9Sm2

### After screenshot:

<img width="1026" height="955" alt="image" src="https://github.com/user-attachments/assets/9bfa66b5-6715-404c-8790-5abd456b1837" />
