### PR TITLE
Fix crash caused by phantasm support being copied with mirage skills that take over mainSKill

### DIFF
--- a/src/Modules/CalcMirages.lua
+++ b/src/Modules/CalcMirages.lua
@@ -37,6 +37,8 @@ local function calculateMirage(env, config)
 	if mirageSkill then
 		local newSkill, newEnv = calcs.copyActiveSkill(env, "CALCULATOR", mirageSkill)
 		newSkill.skillCfg.skillCond["usedByMirage"] = true
+		newSkill.skillFlags.multiPart = nil
+		newSkill.skillFlags.haveMinion = nil
 		newEnv.limitedSkills = newEnv.limitedSkills or {}
 		newEnv.limitedSkills[cacheSkillUUID(newSkill, newEnv)] = true
 		newSkill.skillData.mirageUses = env.player.mainSkill.skillData.storedUses
@@ -150,21 +152,8 @@ function calcs.mirages(env)
 			postCalcFunc = function(env, newSkill, newEnv)
 				env.player.mainSkill = newSkill
 				env.player.mainSkill.infoMessage = tostring(maxMirageWarriors) .. " Mirage Warriors using " .. newSkill.activeEffect.grantedEffect.name
-
-				-- Re-link over the output
 				env.player.output = newEnv.player.output
-				if newSkill.minion then
-					env.minion = newEnv.player.mainSkill.minion
-					env.minion.output = newEnv.minion.output
-				end
-
-				-- Re-link over the breakdown (if present)
-				if newEnv.player.breakdown then
-					env.player.breakdown = newEnv.player.breakdown
-					if newSkill.minion then
-						env.minion.breakdown = newEnv.minion.breakdown
-					end
-				end
+				env.player.breakdown = newEnv.player.breakdown or env.player.breakdown
 			end,
 			mirageSkillNotFoundFunc = function(env, config)
 				env.player.mainSkill.disableReason = "No Saviour active skill found"


### PR DESCRIPTION
Fixes #9706

### Description of the problem being solved:
Currently `Reflection` from `The Saviour` sort of allowed for handling of phantasms on mirages that copy mainSkill. This caused issues with breakdown as the `CALCULATOR` env mode does not generate breakdown and the `CALCS` mode expect the breakdown to be present. This pr fixes the issue by disabling minion handling on `Reflection`. The summon phantasm dps can still be seen on the main skill.

### Steps taken to verify a working solution:
- Test build from issue
