### PR TITLE
Fix prevent kinetic fusilade style skills from multiplying trigger source rate

### DIFF
--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -455,7 +455,7 @@ local function defaultTriggerHandler(env, config)
 			end
 
 			--Account for skills that can hit multiple times per use
-			if source and GlobalCache.cachedData[env.mode][uuid] and source.skillPartName and source.skillPartName:match("(.*)All(.*)Projectiles(.*)") and source.skillFlags.projectile then
+			if source and GlobalCache.cachedData[env.mode][uuid] and source.skillPartName and source.skillPartName:match("(.*)All(.*)Projectiles(.*)") and source.skillFlags.projectile and not (source.skillTypes[SkillType.Duration] and source.skillTypes[SkillType.Area]) then
 				local multiHitDpsMult = GlobalCache.cachedData[env.mode][uuid].Env.player.output.ProjectileCount or 1
 				trigRate = trigRate * multiHitDpsMult
 				if breakdown then


### PR DESCRIPTION
Fixes #9708

### Description of the problem being solved:
According to the linked issue kinetic fusilade projectiles do not increase the trigger source rate. This pr excludes such skills from the source rate multiplication logic.

### Steps taken to verify a working solution:
- Test build from issue.

### Link to a build that showcases this PR:

See issue