### PR TITLE
Add more specific jewel tooltip comparison sorting

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -4041,7 +4041,8 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 		-- tooltips only for affected slots" checked, we can just compare that
 		-- one slot
 		if main.slotOnlyTooltips and slot then
-			addCompareForSlot(slot)
+			slot = type(slot) ~= "string" and slot or self.slots[slot]
+			if slot then addCompareForSlot(slot) end
 			return
 		end
 

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -4094,9 +4094,9 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 		local function sortFunc(a, b)
 			if a == b then return end
 
-			local aParams = { a.compareSlot.selItemId == 0 and 1 or 0, similar(a.selItem, a.isSameUnique), a.output.FullDPS, a.output.CombinedDPS, a.output.TotalEHP, a.compareSlot.label }
+			local aParams = { a.compareSlot.selItemId == 0 and 1 or 0, similar(a.selItem, a.isSameUnique), a.output.FullDPS, a.output.CombinedDPS, a.output.TotalEHP, a.compareSlot.label, a.compareSlot.slotName }
 			local bParams = { b.compareSlot.selItemId == 0 and 1 or 0, similar(b.selItem, b.isSameUnique), b.output.FullDPS, b
-				.output.CombinedDPS, b.output.TotalEHP, b.compareSlot.label }
+				.output.CombinedDPS, b.output.TotalEHP, b.compareSlot.label, b.compareSlot.slotName }
 			for i = 1, #aParams do
 				if aParams[i] == nil or bParams[i] == nil then
 					-- continue
@@ -4106,7 +4106,7 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 					return false
 				end
 			end
-			return true
+			return false
 		end
 		table.sort(slots, sortFunc)
 		

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -4016,48 +4016,104 @@ function ItemsTabClass:AddItemTooltip(tooltip, item, slot, dbMode)
 				t_insert(compareSlots, slot)
 			end
 		end
-		table.sort(compareSlots, function(a, b)
-			if a ~= b then
-				if slot == a then
-					return true
-				end
-				if slot == b then
-					return false
-				end
-			end
-			if a.selItemId ~= b.selItemId then
-				if item == self.items[a.selItemId] then
-					return true
-				end
-				if item == self.items[b.selItemId] then
-					return false
-				end
-			end
-			local aNum = tonumber(a.slotName:match("%d+"))
-			local bNum = tonumber(b.slotName:match("%d+"))
-			if aNum and bNum then
-				return aNum < bNum
-			else
-				return a.slotName < b.slotName
-			end
-		end)
 
-		-- Add comparisons for each slot
-		for _, compareSlot in pairs(compareSlots) do
-			if not main.slotOnlyTooltips or (slot and (slot.nodeId == compareSlot.nodeId or slot.slotName == compareSlot.slotName)) or not slot or slot == compareSlot then
-				local selItem = self.items[compareSlot.selItemId]
-				local output = calcFunc({ repSlotName = compareSlot.slotName, repItem = item ~= selItem and item or nil})
-				local header
-				if item == selItem then
-					header = "^7Removing this item from "..compareSlot.label.." will give you:"
-				else
-					header = string.format("^7Equipping this item in %s will give you:%s", compareSlot.label, selItem and "\n(replacing "..colorCodes[selItem.rarity]..selItem.name.."^7)" or "")
+		tooltip:AddLine(14, colorCodes.TIP .. "Tip: Press Ctrl+D to disable the display of stat differences.")
+
+		local function getReplacedItemAndOutput(compareSlot)
+			local selItem = self.items[compareSlot.selItemId]
+			local output = calcFunc({ repSlotName = compareSlot.slotName, repItem = item ~= selItem and item or nil })
+			return selItem, output
+		end
+		local function addCompareForSlot(compareSlot, selItem, output)
+			if not selItem or not output then
+				selItem, output = getReplacedItemAndOutput(compareSlot)
+			end
+			local header
+			if item == selItem then
+				header = "^7Removing this item from "..compareSlot.label.." will give you:"
+			else
+				header = string.format("^7Equipping this item in %s will give you:%s", compareSlot.label or compareSlot.slotName, selItem and "\n(replacing "..colorCodes[selItem.rarity]..selItem.name.."^7)" or "")
+			end
+			self.build:AddStatComparesToTooltip(tooltip, calcBase, output, header)
+		end
+
+		-- if we have a specific slot to compare to, and the user has "Show
+		-- tooltips only for affected slots" checked, we can just compare that
+		-- one slot
+		if main.slotOnlyTooltips and slot then
+			addCompareForSlot(slot)
+			return
+		end
+
+		
+		local slots = {}
+		local isUnique = item.rarity == "UNIQUE" or item.rarity == "RELIC"
+		local currentSameUniqueCount = 0
+		for _, compareSlot in ipairs(compareSlots) do
+			local selItem, output = getReplacedItemAndOutput(compareSlot)
+			local isSameUnique = isUnique and selItem and item.name == selItem.name
+			if isUnique and isSameUnique and item.limit then
+				currentSameUniqueCount = currentSameUniqueCount + 1
+			end
+			table.insert(slots,
+				{ selItem = selItem, output = output, compareSlot = compareSlot, isSameUnique = isSameUnique })
+		end
+
+		-- limited uniques: only compare to slots with the same item if more don't fit
+		if currentSameUniqueCount == item.limit then
+			for _, slotEntry in ipairs(slots) do
+				if slotEntry.isSameUnique then
+					addCompareForSlot(slotEntry.compareSlot, slotEntry.selItem, slotEntry.output)
 				end
-				self.build:AddStatComparesToTooltip(tooltip, calcBase, output, header)
+			end
+			return
+		end
+
+		
+		-- either the same unique or same base type
+		local function similar(compareItem, sameUnique)
+			-- empty slot
+			if not compareItem then return 0 end
+
+			local sameBaseType = not isUnique
+				and compareItem.rarity ~= "UNIQUE" and compareItem.rarity ~= "RELIC"
+				and item.base.type == compareItem.base.type
+				and item.base.subType == compareItem.base.subType
+			if sameBaseType or sameUnique then
+				return 1
+			else
+				return 0
 			end
 		end
+		-- sort by:
+		-- 1. empty sockets
+		-- 2. same base group jewel or unique
+		-- 3. DPS
+		-- 4. EHP
+		local function sortFunc(a, b)
+			if a == b then return end
+
+			local aParams = { a.compareSlot.selItemId == 0 and 1 or 0, similar(a.selItem, a.isSameUnique), a.output.FullDPS, a.output.CombinedDPS, a.output.TotalEHP, a.compareSlot.label }
+			local bParams = { b.compareSlot.selItemId == 0 and 1 or 0, similar(b.selItem, b.isSameUnique), b.output.FullDPS, b
+				.output.CombinedDPS, b.output.TotalEHP, b.compareSlot.label }
+			for i = 1, #aParams do
+				if aParams[i] == nil or bParams[i] == nil then
+					-- continue
+				elseif aParams[i] > bParams[i] then
+					return true
+				elseif aParams[i] < bParams[i] then
+					return false
+				end
+			end
+			return true
+		end
+		table.sort(slots, sortFunc)
+		
+		for _, slotEntry in ipairs(slots) do
+			addCompareForSlot(slotEntry.compareSlot, slotEntry.selItem, slotEntry.output)
+		end
+		
 	end
-	tooltip:AddLine(14, colorCodes.TIP.."Tip: Press Ctrl+D to disable the display of stat differences.")
 
 	if launch.devModeAlt then
 		-- Modifier debugging info

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -1223,7 +1223,7 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build)
 	if node.type == "Socket" and node.alloc then
 		local socket, jewel = build.itemsTab:GetSocketAndJewelForNodeID(node.id)
 		if jewel then
-			build.itemsTab:AddItemTooltip(tooltip, jewel, { nodeId = node.id })
+			build.itemsTab:AddItemTooltip(tooltip, jewel, socket)
 			if node.distanceToClassStart and node.distanceToClassStart > 0 then
 				tooltip:AddSeparator(14)
 				tooltip:AddLine(16, string.format("^7Distance to start: %d", node.distanceToClassStart))

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -1105,14 +1105,11 @@ function TradeQueryClass:PriceItemRowDisplay(row_idx, top_pane_alignment_ref, ro
 		local item = new("Item", result.item_string)
 		tooltip:Clear()
 		if slotTbl.slotName == "Watcher's Eye" then
-			local firstValidSlot = self:findValidSlotForWatchersEye()
-			local currentItem = firstValidSlot.selItemId ~= 0 and self.itemsTab.items[firstValidSlot.selItemId] 
-			local eyeEquipped = currentItem and currentItem.name:find("Watcher's Eye")
-			-- for watcher's eye we can compare to an already existing one, or
-			-- default to comparing with all active sockets
-			self.itemsTab:AddItemTooltip(tooltip, item, eyeEquipped and firstValidSlot or nil)
+			-- for watcher's eye we don't have a target slot. this will also
+			-- mean we compare against an existing watcher's eye if one exists
+			self.itemsTab:AddItemTooltip(tooltip, item, nil)
 		else
-			self.itemsTab:AddItemTooltip(tooltip, item, slotTbl)
+			self.itemsTab:AddItemTooltip(tooltip, item, activeSlot)
 		end
 		addMegalomaniacCompareToTooltipIfApplicable(tooltip, pb_index)
 		tooltip:AddSeparator(10)
@@ -1141,17 +1138,11 @@ function TradeQueryClass:PriceItemRowDisplay(row_idx, top_pane_alignment_ref, ro
 			-- item.baseName is nil and throws error in the following AddItemTooltip func
 			-- if the item is unidentified
 			local item = new("Item", item_string)
-			-- for watcher's eye we can compare to an already existing one, or
-			-- default to comparing with all active sockets
 			if slotTbl.slotName == "Watcher's Eye" then
-				local firstValidSlot = self:findValidSlotForWatchersEye()
-				local currentItem = firstValidSlot.selItemId ~= 0 and self.itemsTab.items[firstValidSlot.selItemId]
-				local eyeEquipped = currentItem and currentItem.name:find("Watcher's Eye")
-				-- for watcher's eye we can compare to an already existing one, or
-				-- default to comparing with all active sockets
-				self.itemsTab:AddItemTooltip(tooltip, item, eyeEquipped and firstValidSlot or nil, true)
+				-- we have no comparison slot for the watcher's eye
+				self.itemsTab:AddItemTooltip(tooltip, item, nil, true)
 			else
-				self.itemsTab:AddItemTooltip(tooltip, item, slotTbl, true)
+				self.itemsTab:AddItemTooltip(tooltip, item, activeSlot, true)
 			end
 			addMegalomaniacCompareToTooltipIfApplicable(tooltip, selected_result_index)
 		end

--- a/src/Modules/Main.lua
+++ b/src/Modules/Main.lua
@@ -1032,7 +1032,7 @@ function main:OpenOptionsPopup()
 	nextRow()
 	controls.slotOnlyTooltips = new("CheckBoxControl", { "TOPLEFT", nil, "TOPLEFT" }, { defaultLabelPlacementX, currentY, 20 }, "^7Show tooltips only for affected slots:", function(state)
 		self.slotOnlyTooltips = state
-	end)
+	end, "Shows comparisons in tooltips only for the slot you are currently placing the item in, instead of all slots.")
 	controls.slotOnlyTooltips.state = self.slotOnlyTooltips
 
 	nextRow()


### PR DESCRIPTION
### Description of the problem being solved:

This changes the sorting for jewel tooltips and helps with comparisons that are absurdly large, and occasionally unusable. It doesn't directly fix the problem as tooltips can still go off-screen, but showing more relevant sockets first means the tooltip is much more useful.

Sockets are sorted by:

1. empty sockets
2. same base group jewel or same unique
3. DPS
4. EHP (only if DPS was equal, not a combination of the two)

The stat diff hiding tip is also moved to the top of the list so it's actually visible. Limit: x uniques also now only show comparisons with the slots that have the same unique, if the limit has been reached.

### Steps taken to verify a working solution:
- Manual testing

### Link to a build that showcases this PR:

https://pobb.in/FMc4FF8VymuS (adorned build from Poe.ninja)

### Before screenshot:

<img width="997" height="1212" alt="image" src="https://github.com/user-attachments/assets/2cf1f5b9-a9b0-455b-94d2-54bd174bcccd" />


### After screenshot:

<img width="763" height="1312" alt="Path{space}of{space}Building_2026-04-10_16-19-40" src="https://github.com/user-attachments/assets/4e351923-1e9a-4b44-9bf7-12af320f6f46" />

Comments welcome. This mostly seemed necessary because #9649 compares Watcher's eye's to all sockets and the tooltip doesn't have a scroll functionality. I'm not sure if this is better for other use cases.

