### PR TITLE
Fix Gem quality tooltips

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -776,7 +776,7 @@ function SkillsTabClass:CreateGemSlot(index)
 				-- Do the stats one at a time because we're not guaranteed to get the descriptions in the same order we look at them here
 				local stats = { }
 				stats[qual[1]] = qual[2] * 20
-				local descriptions = self.build.data.describeStats(stats, grantedEffect.statDescriptionScope)
+				local descriptions = self.build.data.describeStats(stats, grantedEffect.statDescriptionScope, true)
 				-- line may be nil if the value results in no line due to not being enough quality
 				for _, line in ipairs(descriptions) do
 					if line then

--- a/src/Data/StatDescriptions/active_skill_gem_stat_descriptions.lua
+++ b/src/Data/StatDescriptions/active_skill_gem_stat_descriptions.lua
@@ -763,6 +763,20 @@ return {
 					k="milliseconds_to_seconds_2dp",
 					v=1
 				},
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
+				},
+				text="{0:+d} seconds to Base duration"
+			},
+			[2]={
+				[1]={
+					k="milliseconds_to_seconds_2dp",
+					v=1
+				},
 				limit={
 					[1]={
 						[1]=1000,
@@ -771,7 +785,7 @@ return {
 				},
 				text="Base duration is {0} second"
 			},
-			[2]={
+			[3]={
 				[1]={
 					k="milliseconds_to_seconds_2dp",
 					v=1
@@ -1732,6 +1746,10 @@ return {
 				[1]={
 					k="negate",
 					v=1
+				},
+				[2]={
+					k="canonical_line",
+					v=true
 				},
 				limit={
 					[1]={
@@ -3283,6 +3301,26 @@ return {
 	[124]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]=1,
+						[2]=1
+					}
+				},
+				text="Fires {0:+d} Projectile"
+			},
+			[2]={
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]=2,
+						[2]="#"
+					}
+				},
+				text="Fires {0:+d} Projectiles"
+			},
+			[3]={
 				limit={
 					[1]={
 						[1]=1,
@@ -3291,7 +3329,7 @@ return {
 				},
 				text="Fires 1 Projectile"
 			},
-			[2]={
+			[4]={
 				limit={
 					[1]={
 						[1]=2,
@@ -6066,6 +6104,16 @@ return {
 	[230]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]=1,
+						[2]="#"
+					}
+				},
+				text="{0:+d} to Maximum Hiveborn"
+			},
+			[2]={
 				limit={
 					[1]={
 						[1]=1,

--- a/src/Data/StatDescriptions/beam_skill_stat_descriptions.lua
+++ b/src/Data/StatDescriptions/beam_skill_stat_descriptions.lua
@@ -31,6 +31,26 @@ return {
 	[2]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]=1,
+						[2]=1
+					}
+				},
+				text="Beam Splits towards {0:+d} additional target"
+			},
+			[2]={
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
+				},
+				text="Beam Splits towards {0:+d} additional targets"
+			},
+			[3]={
 				limit={
 					[1]={
 						[1]=1,
@@ -39,7 +59,7 @@ return {
 				},
 				text="Beam Splits towards {0} additional target"
 			},
-			[2]={
+			[4]={
 				limit={
 					[1]={
 						[1]="#",

--- a/src/Data/StatDescriptions/gem_stat_descriptions.lua
+++ b/src/Data/StatDescriptions/gem_stat_descriptions.lua
@@ -4941,6 +4941,34 @@ return {
 					k="milliseconds_to_seconds",
 					v=1
 				},
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]=1000,
+						[2]=1000
+					}
+				},
+				text="Innervation lasts {0:+d} second"
+			},
+			[2]={
+				[1]={
+					k="milliseconds_to_seconds",
+					v=1
+				},
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
+				},
+				text="Innervation lasts {0:+d} seconds"
+			},
+			[3]={
+				[1]={
+					k="milliseconds_to_seconds",
+					v=1
+				},
 				limit={
 					[1]={
 						[1]=1000,
@@ -4949,7 +4977,7 @@ return {
 				},
 				text="Innervation lasts {0} second"
 			},
-			[2]={
+			[4]={
 				[1]={
 					k="milliseconds_to_seconds",
 					v=1
@@ -7181,6 +7209,30 @@ return {
 	[263]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]=1,
+						[2]="#"
+					}
+				},
+				text="Supported Skills have {0:+d}% increased Cooldown Recovery Rate"
+			},
+			[2]={
+				[1]={
+					k="negate",
+					v=1
+				},
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]="#",
+						[2]=-1
+					}
+				},
+				text="Supported Skills have {0:+d}% reduced Cooldown Recovery Rate"
+			},
+			[3]={
 				limit={
 					[1]={
 						[1]=1,
@@ -7189,7 +7241,7 @@ return {
 				},
 				text="Supported Skills have {0}% increased Cooldown Recovery Rate"
 			},
-			[2]={
+			[4]={
 				[1]={
 					k="negate",
 					v=1
@@ -10110,6 +10162,10 @@ return {
 					k="negate",
 					v=1
 				},
+				[2]={
+					k="canonical_line",
+					v=true
+				},
 				limit={
 					[1]={
 						[1]="#",
@@ -10240,6 +10296,16 @@ return {
 	[374]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
+				},
+				text="Killing Blows with Supported Skills cause Enemies to have {0:+d}% chance to Explode, dealing a tenth of their maximum Life as Damage of a Random Element"
+			},
+			[2]={
 				limit={
 					[1]={
 						[1]=1,
@@ -10248,7 +10314,7 @@ return {
 				},
 				text="Killing Blows with Supported Skills cause Enemies to have a {0}% chance to Explode, dealing a tenth of their maximum Life as Damage of a Random Element"
 			},
-			[2]={
+			[3]={
 				limit={
 					[1]={
 						[1]=100,
@@ -10785,6 +10851,20 @@ return {
 	[397]={
 		[1]={
 			[1]={
+				[1]={
+					k="reminderstring",
+					v="ReminderTextFlee"
+				},
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]=1,
+						[2]="#"
+					}
+				},
+				text="Supported Skills have {0:+d}% chance to cause Monsters to Flee on Hit"
+			},
+			[2]={
 				[1]={
 					k="reminderstring",
 					v="ReminderTextFlee"
@@ -11500,6 +11580,16 @@ return {
 	[427]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]=1,
+						[2]="#"
+					}
+				},
+				text="Kill Normal and Magic Rarity Enemies that have {0:+d}% Life or\nlower when Hit by Supported Skills"
+			},
+			[2]={
 				limit={
 					[1]={
 						[1]=1,
@@ -13845,6 +13935,10 @@ return {
 				[2]={
 					k="reminderstring",
 					v="ReminderTextUpfrontCost"
+				},
+				[3]={
+					k="reminderstring",
+					v="ReminderTextTransfusionNearbyMinion"
 				},
 				limit={
 					[1]={
@@ -20815,6 +20909,28 @@ return {
 	[776]={
 		[1]={
 			[1]={
+				[1]={
+					k="divide_by_ten_1dp_if_required",
+					v=1
+				},
+				[2]={
+					k="reminderstring",
+					v="ReminderTextPower"
+				},
+				[3]={
+					k="reminderstring",
+					v="ReminderTextSoulEaterNonAura"
+				},
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]=1,
+						[2]="#"
+					}
+				},
+				text="Consuming a Corpse with Supported Skills has {0:+d}% chance to grant a Soul per Power"
+			},
+			[2]={
 				[1]={
 					k="divide_by_ten_1dp_if_required",
 					v=1

--- a/src/Data/StatDescriptions/minion_attack_skill_stat_descriptions.lua
+++ b/src/Data/StatDescriptions/minion_attack_skill_stat_descriptions.lua
@@ -2955,6 +2955,10 @@ return {
 					k="negate",
 					v=1
 				},
+				[2]={
+					k="canonical_line",
+					v=true
+				},
 				limit={
 					[1]={
 						[1]="#",

--- a/src/Data/StatDescriptions/minion_skill_stat_descriptions.lua
+++ b/src/Data/StatDescriptions/minion_skill_stat_descriptions.lua
@@ -6202,6 +6202,10 @@ return {
 					k="negate",
 					v=1
 				},
+				[2]={
+					k="canonical_line",
+					v=true
+				},
 				limit={
 					[1]={
 						[1]="#",

--- a/src/Data/StatDescriptions/minion_spell_damage_skill_stat_descriptions.lua
+++ b/src/Data/StatDescriptions/minion_spell_damage_skill_stat_descriptions.lua
@@ -1749,6 +1749,10 @@ return {
 					k="negate",
 					v=1
 				},
+				[2]={
+					k="canonical_line",
+					v=true
+				},
 				limit={
 					[1]={
 						[1]="#",

--- a/src/Data/StatDescriptions/skill_stat_descriptions.lua
+++ b/src/Data/StatDescriptions/skill_stat_descriptions.lua
@@ -14189,6 +14189,10 @@ return {
 					k="negate",
 					v=1
 				},
+				[2]={
+					k="canonical_line",
+					v=true
+				},
 				limit={
 					[1]={
 						[1]="#",
@@ -15581,6 +15585,30 @@ return {
 	[479]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]=1,
+						[2]="#"
+					}
+				},
+				text="{0:+d}% more Damage with Bleeding"
+			},
+			[2]={
+				[1]={
+					k="negate",
+					v=1
+				},
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]="#",
+						[2]=-1
+					}
+				},
+				text="{0:+d}% less Damage with Bleeding"
+			},
+			[3]={
 				limit={
 					[1]={
 						[1]=1,
@@ -15589,7 +15617,7 @@ return {
 				},
 				text="{0}% more Damage with Bleeding"
 			},
-			[2]={
+			[4]={
 				[1]={
 					k="negate",
 					v=1
@@ -15937,6 +15965,10 @@ return {
 				[1]={
 					k="negate",
 					v=1
+				},
+				[2]={
+					k="canonical_line",
+					v=true
 				},
 				limit={
 					[1]={
@@ -18386,6 +18418,10 @@ return {
 				text="Buff grants {0} Flask Charge every 3 seconds"
 			},
 			[2]={
+				[1]={
+					k="canonical_line",
+					v=true
+				},
 				limit={
 					[1]={
 						[1]="#",
@@ -23138,6 +23174,16 @@ return {
 	[692]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]=1,
+						[2]="#"
+					}
+				},
+				text="Hits from Final wave deal {0:+d}% of Damage per stage"
+			},
+			[2]={
 				limit={
 					[1]={
 						[1]=1,
@@ -27272,6 +27318,10 @@ return {
 					k="negate",
 					v=1
 				},
+				[2]={
+					k="canonical_line",
+					v=true
+				},
 				limit={
 					[1]={
 						[1]="#",
@@ -28749,6 +28799,26 @@ return {
 	[900]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]=1,
+						[2]=1
+					}
+				},
+				text="Has {0:+d} Flame"
+			},
+			[2]={
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
+				},
+				text="Has {0:+d} Flames"
+			},
+			[3]={
 				limit={
 					[1]={
 						[1]=1,
@@ -28757,7 +28827,7 @@ return {
 				},
 				text="Has {0} Flame"
 			},
-			[2]={
+			[4]={
 				limit={
 					[1]={
 						[1]="#",
@@ -28817,6 +28887,10 @@ return {
 				[1]={
 					k="negate",
 					v=1
+				},
+				[2]={
+					k="canonical_line",
+					v=true
 				},
 				limit={
 					[1]={
@@ -31097,6 +31171,26 @@ return {
 	[972]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]=1,
+						[2]=1
+					}
+				},
+				text="Creates {0:+d} Bone Spire"
+			},
+			[2]={
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]=2,
+						[2]="#"
+					}
+				},
+				text="Creates {0:+d} Bone Spires"
+			},
+			[3]={
 				limit={
 					[1]={
 						[1]=1,
@@ -31105,7 +31199,7 @@ return {
 				},
 				text="Creates {0} Bone Spire"
 			},
-			[2]={
+			[4]={
 				limit={
 					[1]={
 						[1]=2,
@@ -31123,6 +31217,26 @@ return {
 	[973]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]=1,
+						[2]=1
+					}
+				},
+				text="Creates {0:+d} Ashen Pillar"
+			},
+			[2]={
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]=2,
+						[2]="#"
+					}
+				},
+				text="Creates {0:+d} Ashen Pillars"
+			},
+			[3]={
 				limit={
 					[1]={
 						[1]=1,
@@ -31131,7 +31245,7 @@ return {
 				},
 				text="Creates {0} Ashen Pillar"
 			},
-			[2]={
+			[4]={
 				limit={
 					[1]={
 						[1]=2,
@@ -32315,6 +32429,10 @@ return {
 				[1]={
 					k="negate",
 					v=1
+				},
+				[2]={
+					k="canonical_line",
+					v=true
 				},
 				limit={
 					[1]={
@@ -39231,7 +39349,7 @@ return {
 						[2]="#"
 					}
 				},
-				text="Skills Triggered by Suspended Mirages deal {0}% more Damage"
+				text="Skills used by Suspended Mirages deal {0}% more Damage"
 			},
 			[2]={
 				[1]={
@@ -39244,7 +39362,7 @@ return {
 						[2]=-1
 					}
 				},
-				text="Skills Triggered by Suspended Mirages deal {0}% less Damage"
+				text="Skills used by Suspended Mirages deal {0}% less Damage"
 			}
 		},
 		name="sand_mirage_damage",
@@ -39363,6 +39481,30 @@ return {
 	[1275]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]=1,
+						[2]="#"
+					}
+				},
+				text="Burning Damage applied by Detonation deals {0:+d}% more Damage per Totem Detonated"
+			},
+			[2]={
+				[1]={
+					k="negate",
+					v=1
+				},
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]="#",
+						[2]=-1
+					}
+				},
+				text="Burning Damage applied by Detonation deals {0:+d}% less Damage Totem Detonated"
+			},
+			[3]={
 				limit={
 					[1]={
 						[1]=1,
@@ -39371,7 +39513,7 @@ return {
 				},
 				text="Burning Damage applied by Detonation deals {0}% more Damage per Totem Detonated"
 			},
-			[2]={
+			[4]={
 				[1]={
 					k="negate",
 					v=1
@@ -48927,6 +49069,26 @@ return {
 	[1623]={
 		[1]={
 			[1]={
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]=1,
+						[2]=1
+					}
+				},
+				text="Creates {0:+d} Fissure"
+			},
+			[2]={
+				["gem_quality"]=true,
+				limit={
+					[1]={
+						[1]="#",
+						[2]="#"
+					}
+				},
+				text="Creates {0:+d} Fissures"
+			},
+			[3]={
 				limit={
 					[1]={
 						[1]=1,
@@ -48935,7 +49097,7 @@ return {
 				},
 				text="Creates {0} Fissure"
 			},
-			[2]={
+			[4]={
 				limit={
 					[1]={
 						[1]="#",

--- a/src/Data/StatDescriptions/tincture_stat_descriptions.lua
+++ b/src/Data/StatDescriptions/tincture_stat_descriptions.lua
@@ -920,6 +920,10 @@ return {
 					k="negate",
 					v=2
 				},
+				[2]={
+					k="canonical_line",
+					v=true
+				},
 				limit={
 					[1]={
 						[1]="#",
@@ -1187,6 +1191,10 @@ return {
 				[1]={
 					k="negate",
 					v=1
+				},
+				[2]={
+					k="canonical_line",
+					v=true
 				},
 				limit={
 					[1]={

--- a/src/Export/Scripts/statdesc.lua
+++ b/src/Export/Scripts/statdesc.lua
@@ -41,8 +41,8 @@ local function processStatFile(name)
 			if langName then
 				curLang = nil--{ }
 				--curDescriptor.lang[langName] = curLang
-			elseif curLang then
-				local statLimits, text, special = line:match('([%d%-#!| ]+) "(.-)"%s*(.*)')
+			elseif curLang and not line:match('table_only') then
+				local statLimits, quality, text, special = line:match('([%d%-#| !]+)%s*([%w_]*)%s*"(.-)"%s*(.*)')
 				if statLimits then
 					local desc = { text = text, limit = { } }
 					for statLimit in statLimits:gmatch("[!%d%-#|]+") do
@@ -67,12 +67,37 @@ local function processStatFile(name)
 						end
 						table.insert(desc.limit, limit)
 					end
-					for k, v in special:gmatch("([%w%%_]+) (%w+)") do
-						table.insert(desc, {
-							k = k,
-							v = tonumber(v) or v,
-						})
-						nk[k] = v
+					local specialTokens = { }
+					for token in special:gmatch("([%w%%_]+)") do
+						table.insert(specialTokens, token)
+					end
+					local tokenIndex = 1
+					while tokenIndex <= #specialTokens do
+						local token = specialTokens[tokenIndex]
+						if token == "canonical_line" then
+							table.insert(desc, {
+								k = "canonical_line",
+								v = true,
+							})
+							nk["canonical_line"] = true
+							tokenIndex = tokenIndex + 1
+						else
+							local value = specialTokens[tokenIndex + 1]
+							if value then
+								table.insert(desc, {
+									k = token,
+									v = tonumber(value) or value,
+								})
+								nk[token] = value
+								tokenIndex = tokenIndex + 2
+							else
+								tokenIndex = tokenIndex + 1
+							end
+						end
+					end
+					if quality:match("gem_quality") then
+						desc[quality] = true
+						nk["gem_quality"] = true
 					end
 					table.insert(curLang, desc)
 				end

--- a/src/Export/statdesc.lua
+++ b/src/Export/statdesc.lua
@@ -37,8 +37,8 @@ local function parseStatFile(target, order, fileName)
 			if langName then
 				curLang = { }
 				--curDescriptor.lang[langName] = curLang
-			else
-				local statLimits, text, special = line:match('([%d%-#| ]+) "(.-)"%s*(.*)')
+			elseif not line:match('table_only') then
+				local statLimits, quality, text, special = line:match('([%d%-#| !]+)%s*([%w_]*)%s*"(.-)"%s*(.*)')
 				if statLimits then
 					local desc = { text = text, limit = { } }
 					for statLimit in statLimits:gmatch("[!%d%-#|]+") do
@@ -63,12 +63,37 @@ local function parseStatFile(target, order, fileName)
 						end
 						table.insert(desc.limit, limit)
 					end
-					for k, v in special:gmatch("([%w%%_]+) (%w+)") do
-						table.insert(desc, {
-							k = k,
-							v = tonumber(v) or v,
-						})
-						nk[k] = v
+					local specialTokens = { }
+					for token in special:gmatch("([%w%%_]+)") do
+						table.insert(specialTokens, token)
+					end
+					local tokenIndex = 1
+					while tokenIndex <= #specialTokens do
+						local token = specialTokens[tokenIndex]
+						if token == "canonical_line" then
+							table.insert(desc, {
+								k = "canonical_line",
+								v = true,
+							})
+							nk["canonical_line"] = true
+							tokenIndex = tokenIndex + 1
+						else
+							local value = specialTokens[tokenIndex + 1]
+							if value then
+								table.insert(desc, {
+									k = token,
+									v = tonumber(value) or value,
+								})
+								nk[token] = value
+								tokenIndex = tokenIndex + 2
+							else
+								tokenIndex = tokenIndex + 1
+							end
+						end
+					end
+					if quality:match("gem_quality") then
+						desc[quality] = true
+						nk["gem_quality"] = true
 					end
 					table.insert(curLang, desc)
 				end

--- a/src/Modules/StatDescriber.lua
+++ b/src/Modules/StatDescriber.lua
@@ -28,22 +28,24 @@ local function getScope(scopeName)
 	end
 end
 
-local function matchLimit(lang, val) 
+local function matchLimit(lang, val, quality) 
 	for _, desc in ipairs(lang) do
-		local match = true
-		for i, limit in ipairs(desc.limit) do
-			if limit[1] == "!" then
-				if val[i].min == limit[2] then
+		if quality or not desc.gem_quality then -- Skip gem_quality lines for regular mods
+			local match = true
+			for i, limit in ipairs(desc.limit) do
+				if limit[1] == "!" then
+					if val[i].min == limit[2] then
+						match = false
+						break
+					end
+				elseif (limit[2] ~= "#" and val[i].min > limit[2]) or (limit[1] ~= "#" and val[i].min < limit[1]) then
 					match = false
 					break
 				end
-			elseif (limit[2] ~= "#" and val[i].min > limit[2]) or (limit[1] ~= "#" and val[i].min < limit[1]) then
-				match = false
-				break
 			end
-		end
-		if match then
-			return desc
+			if match then
+				return desc
+			end
 		end
 	end
 end
@@ -188,7 +190,7 @@ local function applySpecial(val, spec)
 	end
 end
 
-return function(stats, scopeName)
+return function(stats, scopeName, quality)
 	local rootScope = getScope(scopeName)
 
 	-- Figure out which descriptions we need, and identify them by the first stat that they describe
@@ -233,7 +235,7 @@ return function(stats, scopeName)
 			end
 			val[i].fmt = "d"
 		end
-		local desc = matchLimit(descriptor.description[1], val)
+		local desc = matchLimit(descriptor.description[1], val, quality)
 		if desc then
 			for _, spec in ipairs(desc) do
 				applySpecial(val, spec)


### PR DESCRIPTION
### Description of the problem being solved:
Not sure when they added it but a bunch of gem tooltips in PoE 1 have their own stat description that is meant to be used only for quality tooltips
Fixed an issue with `cannoincal_line` which is meant to be used for the trade site and also an issue when a stat description has 2 special identifiers in a row
e.g. `#|-1 "{0}% less Critical Strike Chance" canonical_line negate 1`
 `canonical_line ` gets treated as the first argument for the type and `negate` as the value instead of knowing to treat `canonical_line` as its own singular case
PoB 2 didn't have this issue as they removed reminder text values from stat descriptions

### Before screenshot:
<img width="666" height="73" alt="image" src="https://github.com/user-attachments/assets/1e834072-f559-4625-922f-a606dbc3e454" />
<img width="604" height="71" alt="image" src="https://github.com/user-attachments/assets/29e5a1a3-354a-4d73-b760-9bc2534909ce" />
<img width="623" height="71" alt="image" src="https://github.com/user-attachments/assets/66c70c3e-a4f1-4bf4-a5d7-b36a6f3d0533" />

### After screenshot:
<img width="680" height="79" alt="image" src="https://github.com/user-attachments/assets/171ebbbc-b48f-4084-b135-764c219bfdec" />
<img width="606" height="69" alt="image" src="https://github.com/user-attachments/assets/7f7a264a-df59-4caa-83d7-5a538014b78c" />
<img width="623" height="66" alt="image" src="https://github.com/user-attachments/assets/129035a7-2e93-499f-9d8c-9c75c6327948" />
