### PR TITLE
Fix URL spoofing issue with imported URLs

### DIFF
--- a/src/Modules/BuildSiteTools.lua
+++ b/src/Modules/BuildSiteTools.lua
@@ -7,25 +7,34 @@
 buildSites = { }
 
 -- Import/Export websites list used in dropdowns
+-- label: What a user sees in the export dropdown and when the import box recognizes the website
+-- id: Protocol handler id used to load builds with the pob: URL scheme e.g. pob://Maxroll/siteSpecificBuildId
+-- matchURL: A pattern to match URLs belonging to this website to show a valid url message in ImportTab
+-- regexURL: Copied link from website to extract the build ID and pass to downloadURL to get the raw build XML
+-- downloadURL: The URL to download the raw build code
+-- codeOut: Gets prepended to returned code from postUrl.  Needed to enable export in ImportTab
+-- postUrl: The URL to upload a build code.  Needed to enable export in ImportTab
+-- postFields: The POST fields prepended to base64-encoded XML.  Needed to enable export in ImportTab
+-- linkURL: The URL pattern to link to the provided build code (Unused currently)
 buildSites.websiteList = {
 	{
-		label = "Maxroll", id = "Maxroll", matchURL = "maxroll%.gg/poe/pob/.*", regexURL = "maxroll%.gg/poe/pob/(.+)%s*$", downloadURL = "maxroll%.gg/poe/api/pob/%1",
+		label = "Maxroll", id = "Maxroll", matchURL = "^https://maxroll%.gg/poe/pob/.*", regexURL = "maxroll%.gg/poe/pob/(.+)%s*$", downloadURL = "maxroll%.gg/poe/api/pob/%1",
 		codeOut = "https://maxroll.gg/poe/pob/", postUrl = "https://maxroll.gg/poe/api/pob", postFields = "pobCode=", linkURL = "maxroll%.gg/poe/pob/%1"
 	},
 	{
-		label = "pobb.in", id = "POBBin", matchURL = "pobb%.in/.+", regexURL = "pobb%.in/(.+)%s*$", downloadURL = "pobb.in/pob/%1",
+		label = "pobb.in", id = "POBBin", matchURL = "^https://pobb%.in/.+", regexURL = "pobb%.in/(.+)%s*$", downloadURL = "pobb.in/pob/%1",
 		codeOut = "https://pobb.in/", postUrl = "https://pobb.in/pob/", postFields = "", linkURL = "pobb.in/%1"
 	},
 	{
-		label = "PoeNinja", id = "PoeNinja", matchURL = "poe%.ninja/?p?o?e?1?/pob/%w+", regexURL = "poe%.ninja/?p?o?e?1?/pob/(%w+)%s*$", downloadURL = "poe.ninja/poe1/pob/raw/%1",
+		label = "PoeNinja", id = "PoeNinja", matchURL = "^https://poe%.ninja/?p?o?e?1?/pob/%w+", regexURL = "poe%.ninja/?p?o?e?1?/pob/(%w+)%s*$", downloadURL = "poe.ninja/poe1/pob/raw/%1",
 		codeOut = "", postUrl = "https://poe.ninja/poe1/pob/api/upload", postFields = "code=", linkURL="poe.ninja/poe1/pob/%1"
 	},
 	{
-		label = "Pastebin.com", id = "pastebin", matchURL = "pastebin%.com/%w+", regexURL = "pastebin%.com/(%w+)%s*$", downloadURL = "pastebin.com/raw/%1", linkURL = "pastebin.com/%1"
+		label = "Pastebin.com", id = "pastebin", matchURL = "^https://pastebin%.com/%w+", regexURL = "pastebin%.com/(%w+)%s*$", downloadURL = "pastebin.com/raw/%1", linkURL = "pastebin.com/%1"
 	},
-	{ label = "PastebinP.com", id = "pastebinProxy", matchURL = "pastebinp%.com/%w+", regexURL = "pastebinp%.com/(%w+)%s*$", downloadURL = "pastebinp.com/raw/%1", linkURL = "pastebin.com/%1" },
-	{ label = "Rentry.co", id = "rentry", matchURL = "rentry%.co/%w+", regexURL = "rentry%.co/(%w+)%s*$", downloadURL = "rentry.co/paste/%1/raw", linkURL = "rentry.co/%1" },
-	{ label = "poedb.tw", id = "PoEDB", matchURL = "poedb%.tw/.+", regexURL = "poedb%.tw/pob/(.+)%s*$", downloadURL = "poedb.tw/pob/%1/raw", codeOut = "", postUrl = "https://poedb.tw/pob/api/gen", postFields = "", linkURL = "poedb.tw/pob/%1" },
+	{ label = "PastebinP.com", id = "pastebinProxy", matchURL = "^https://pastebinp%.com/%w+", regexURL = "pastebinp%.com/(%w+)%s*$", downloadURL = "pastebinp.com/raw/%1", linkURL = "pastebin.com/%1" },
+	{ label = "Rentry.co", id = "rentry", matchURL = "^https://rentry%.co/%w+", regexURL = "rentry%.co/(%w+)%s*$", downloadURL = "rentry.co/paste/%1/raw", linkURL = "rentry.co/%1" },
+	{ label = "poedb.tw", id = "PoEDB", matchURL = "^https://poedb%.tw/.+", regexURL = "poedb%.tw/pob/(.+)%s*$", downloadURL = "poedb.tw/pob/%1/raw", codeOut = "", postUrl = "https://poedb.tw/pob/api/gen", postFields = "", linkURL = "poedb.tw/pob/%1" },
 }
 
 --- Uploads a PoB build code to a website


### PR DESCRIPTION
Fixes #9753

### Description of the problem being solved:
An import URL could be queried by PoB if an attacker got their URL to match one of the allowed website patterns.  This would give an attacker access to a user's IP address when they hit the malicious server.  I could also put in the same protection for `regexURL`, but every instance where we use that it's being guarded by `matchURL` in the first place.

Before:
<img width="521" height="129" alt="image" src="https://github.com/user-attachments/assets/e7a0e305-7d40-4650-9b38-bcfc479df530" />
After:
<img width="450" height="112" alt="image" src="https://github.com/user-attachments/assets/5566a951-2423-4348-bf9c-be3dc148ab60" />
<img width="508" height="104" alt="image" src="https://github.com/user-attachments/assets/d1ac89a8-08e8-4c91-b0dc-7c289148526c" />