### PR TITLE
Fix Maven Memory Game damage

### DIFF
--- a/src/Data/BossSkills.lua
+++ b/src/Data/BossSkills.lua
@@ -143,7 +143,7 @@ return {
 	["Maven Memory Game"] = {
 		DamageType = "Spell",
 		DamageMultipliers = {
-			Physical = { 104.29090544842, 0.52145452724208 }
+			Physical = { 26.072726362104, 0.13036363181052 }
 		},
 		UberDamageMultiplier = 1.0086206896552,
 		speed = 7500,

--- a/src/Export/Scripts/bossData.lua
+++ b/src/Export/Scripts/bossData.lua
@@ -23,7 +23,7 @@ local oldMethod = {
 	CleansingFireWall = { Fire = { 3304.677, 20 } },
 	GSConsumeBossDisintegrateBeam = { Lightning = { 3735.061, 50 } },
 	MavenSuperFireProjectileImpact = { Fire = { 4955.383, 0 }, SkillUberDamageMult = 201 },
-	MavenMemoryGame = { Physical = { 34505.376, 0 } },
+	MavenMemoryGame = { Physical = { 8626.344, 0 } },
 }
 
 -- exports and calculates the damage multipliers of the skill


### PR DESCRIPTION
Fixes #9756

### Description of the problem being solved:
At the start of 3.27 they added a new physical damage conversion multiplier. I added support for boss skills to be correctly scaled but didn't realise that we had hardcoded some boss values that were not being pulled from the game files
The Maven Memory Game attack had its base damage effectiveness go from 12.5 in 3.26 to 3.125 in 3.27 but cause we were not exporting the skill from the game files, it just had 300% more damage from the conversion multi mod

We should really have all boss skills exported from the game files. I really do not like how we currently export them as believe that it would be far better to export the monster and their skills similarly to how we have spectres and minions 

### Before screenshot:
<img width="606" height="75" alt="image" src="https://github.com/user-attachments/assets/0be91e5e-72e9-4126-bee1-af6647c796b5" />

### After screenshot:
<img width="611" height="75" alt="image" src="https://github.com/user-attachments/assets/56af6b50-015d-4584-84f3-d6edf55ab82c" />
