### PR TITLE
Fix Dual Wield mastery granting damage when using a Thrusting + non-thrusting sword

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -221,7 +221,14 @@ local function doActorAttribsConditions(env, actor)
 		if (actor.weaponData1.type == "Dagger" or actor.weaponData1.countsAsAll1H) and (actor.weaponData2.type == "Dagger" or actor.weaponData2.countsAsAll1H) then
 			condList["DualWieldingDaggers"] = true
 		end
-		if (env.data.weaponTypeInfo[actor.weaponData1.type].label or actor.weaponData1.subType or actor.weaponData1.type) ~= (env.data.weaponTypeInfo[actor.weaponData2.type].label or actor.weaponData2.subType or actor.weaponData2.type) then
+		local function getWeaponType(weaponData)
+			-- GGG treats thrusting one handed swords as the same class as one handed swords
+			if weaponData.type == "One Handed Sword" and weaponData.subType == "Thrusting" then
+				return "One Handed Sword"
+			end
+			return env.data.weaponTypeInfo[weaponData.type].label or weaponData.subType or weaponData.type
+		end
+		if getWeaponType(actor.weaponData1) ~= getWeaponType(actor.weaponData2) then
 			local info1 = env.data.weaponTypeInfo[actor.weaponData1.type]
 			local info2 = env.data.weaponTypeInfo[actor.weaponData2.type]
 			if info1.oneHand and info2.oneHand then


### PR DESCRIPTION
Fixes #9374

### Description of the problem being solved:
The mastery that grants damage when you are wielding two different weapon types is not meant to work if you are wielding a non-thrusting sword with a thrusting sword as GGG have hard coded these weapons to share the same weapon type

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/vfgpxm0u

### Before screenshot:
<img width="547" height="308" alt="image" src="https://github.com/user-attachments/assets/63fbd799-a9ff-4fd3-aba8-32015ce28d1c" />

### After screenshot:
<img width="534" height="156" alt="image" src="https://github.com/user-attachments/assets/098ebfba-e123-4cdb-bebd-e4805f0d0a19" />
