### PR TITLE
Fix Tinctures applying their effects even when you have no Mana

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1703,6 +1703,11 @@ function calcs.perform(env, skipEHP)
 	
 	
 	local function mergeTinctures(tinctures)
+		local tincturesNotInflictManaBurn = m_min(modDB:Sum("BASE", nil, "TincturesNotInflictManaBurn"), 100)
+		local canGainRequiredBurn = modDB:Flag(nil, "Condition:WeepingWoundsInsteadOfManaBurn") or (tincturesNotInflictManaBurn < 100 and (output.ManaUnreserved or 0) > 0)
+		if not canGainRequiredBurn then
+			return
+		end
 		local tinctureBuffs = { }
 		local tinctureConditions = {}
 		local tinctureBuffsPerBase = {}
@@ -1773,7 +1778,6 @@ function calcs.perform(env, skipEHP)
 		-- This needs to be done in 2 steps to account for effects affecting life recovery from flasks
 		-- For example Sorrow of the Divine and buffs (like flask recovery watchers eye)
 		mergeFlasks(env.flasks, false, true)
-		mergeTinctures(env.tinctures)
 
 		-- Merge keystones again to catch any that were added by flasks
 		modLib.mergeKeystones(env, env.modDB)
@@ -1920,6 +1924,10 @@ function calcs.perform(env, skipEHP)
 
 	-- Set the life/mana reservations (hold off on GrantReserved"..pool.."AsAura)
 	doActorLifeManaReservation(env.player, not modDB:Flag(nil, "ManaIncreasedByOvercappedLightningRes"))
+
+	if env.mode_combat then
+		mergeTinctures(env.tinctures)
+	end
 
 		-- Process attribute requirements
 	do


### PR DESCRIPTION
### Description of the problem being solved:
Tinctures need stacks of mana burn in order to keep their effect active
If you are using a build with Blood Magic or have 100% Mana reserved then you cannot have any Tincture effects active unless you have Weeping Wounds

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/5c86p0rb

### Before screenshot:
<img width="469" height="449" alt="image" src="https://github.com/user-attachments/assets/66a45e9a-e48a-4919-b0a1-4a799ff20940" />

### After screenshot:
<img width="472" height="546" alt="image" src="https://github.com/user-attachments/assets/d8c752f7-0fc2-4b3e-b6b3-9a694c2c122c" />
