### PR TITLE
Remove tattoo tooltip and popup for cluster jewel keystones

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -1351,7 +1351,7 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build)
 	if node and (node.isTattoo
 			or (node.type == "Normal" and (node.dn == "Strength" or node.dn == "Dexterity" or node.dn == "Intelligence"))
 			or (node.type == "Notable" and #node.sd > 0 and (node.sd[1]:match("+30 to Dexterity") or node.sd[1]:match("+30 to Strength") or node.sd[1]:match("+30 to Intelligence")))
-			or (node.type == "Keystone") or (node.type == "Mastery") )
+			or (node.type == "Keystone" and not node.expansionSkill) or (node.type == "Mastery"))
 	then
 		tooltip:AddSeparator(14)
 		local nodeEditType = (node.type == "Mastery") and "runegraft" or "tattoo"

--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -418,7 +418,7 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 		elseif hoverNode and (hoverNode.isTattoo
 			or (hoverNode.type == "Normal" and (hoverNode.dn == "Strength" or hoverNode.dn == "Dexterity" or hoverNode.dn == "Intelligence"))
 			or (hoverNode.type == "Notable" and #hoverNode.sd > 0 and (hoverNode.sd[1]:match("+30 to Dexterity") or hoverNode.sd[1]:match("+30 to Strength") or hoverNode.sd[1]:match("+30 to Intelligence")))
-			or hoverNode.type == "Keystone")
+			or hoverNode.type == "Keystone") and not hoverNode.expansionSkill
 		then
 			build.treeTab:ModifyNodePopup(hoverNode, viewPort)
 			build.buildFlag = true
@@ -1351,7 +1351,8 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build)
 	if node and (node.isTattoo
 			or (node.type == "Normal" and (node.dn == "Strength" or node.dn == "Dexterity" or node.dn == "Intelligence"))
 			or (node.type == "Notable" and #node.sd > 0 and (node.sd[1]:match("+30 to Dexterity") or node.sd[1]:match("+30 to Strength") or node.sd[1]:match("+30 to Intelligence")))
-			or (node.type == "Keystone" and not node.expansionSkill) or (node.type == "Mastery"))
+			or (node.type == "Keystone") or (node.type == "Mastery"))
+			and not node.expansionSkill
 	then
 		tooltip:AddSeparator(14)
 		local nodeEditType = (node.type == "Mastery") and "runegraft" or "tattoo"

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -838,6 +838,11 @@ function TreeTabClass:OpenExportPopup()
 end
 
 function TreeTabClass:ModifyNodePopup(selectedNode)
+	-- ignore cluster jewel Keystones like Secrets of Suffering
+	if selectedNode.type == "Keystone" and selectedNode.expansionSkill then
+		return
+	end
+
 	local controls = { }
 	local modGroups = { }
 	local treeNodes = self.build.spec.tree.nodes

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -838,11 +838,6 @@ function TreeTabClass:OpenExportPopup()
 end
 
 function TreeTabClass:ModifyNodePopup(selectedNode)
-	-- ignore cluster jewel Keystones like Secrets of Suffering
-	if selectedNode.type == "Keystone" and selectedNode.expansionSkill then
-		return
-	end
-
 	local controls = { }
 	local modGroups = { }
 	local treeNodes = self.build.spec.tree.nodes


### PR DESCRIPTION
Fixes #9736

### Description of the problem being solved:
Cluster jewel keystones are not allowed to be modified like usual tree keystones. This PR removes the "Tip" tooltip and returns early in the popup logic for keystone nodes with "expansionSkill".

### Steps taken to verify a working solution:
- Verify tooltip not found on cluster jewel keystone
- Verify right click does nothing on cluster jewel keystone
- Verify tree keystones unaffected

### Link to a build that showcases this PR:
<pre>https://pobb.in/KGX_evRKBed2</pre>

### Before screenshot:
<img width="563" height="309" alt="image" src="https://github.com/user-attachments/assets/570ad1f0-c0d1-4aec-a5a0-9df9f62d5036" />

### After screenshot:
<img width="598" height="326" alt="image" src="https://github.com/user-attachments/assets/f5643fc4-4793-4776-871f-c67bc92c1471" />
