### PR TITLE
Fix parent directory creation for absolute POSIX paths

### DIFF
--- a/src/UpdateCheck.lua
+++ b/src/UpdateCheck.lua
@@ -305,7 +305,7 @@ local ops = { }
 local opsRuntime = { }
 for _, data in pairs(updateFiles) do
 	-- Ensure that the destination path of this file exists
-	local dirStr = ""
+	local dirStr = data.fullPath:sub(1,1) == "/" and "/" or ""
 	for dir in data.fullPath:gmatch("([^/]+/)") do
 		dirStr = dirStr .. dir
 		MakeDir(dirStr)


### PR DESCRIPTION
The `[^/]+/` match pattern requires at least on non-slash character before the trailing slash. This works on Windows where absolute paths start with a drive letter.

With absolute POSIX paths, the leading slash is skipped by this pattern causing the accumulated `dirStr` to not start with a slash. `dirStr` is then interpreted as a relative path, causing the directories to be erroneously created in the current working directory.

This change fixes the erroneous behavior with absolute POSIX paths by initializing `dirStr` with a slash if the `fullPath` starts with a slash. It retains the current behavior on Windows systems.