### PR TITLE
Add sorting to add-modifier list

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2699,9 +2699,11 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 	local sourceList = { }
 	local modList = { }
 	local sortList = { { label = "Default", stat = nil } }
+	local sortTransforms = { }
 	for _, entry in ipairs(data.powerStatList) do
 		if entry.stat and not entry.ignoreForNodes then
 			t_insert(sortList, { label = entry.label, stat = entry.stat })
+			sortTransforms[entry.stat] = entry.transform
 		end
 	end
 	local function setDefaultSortOrder()
@@ -2741,6 +2743,9 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 		item:BuildAndParseRaw()
 		local output = calcFunc({ repSlotName = slotName, repItem = item }, useFullDPS)
 		local value = getOutputStatValue(output, stat)
+		if sortTransforms[stat] then
+			value = sortTransforms[stat](value)
+		end
 		listMod.sortValues[stat] = value
 		return value
 	end

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2698,6 +2698,87 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 	local controls = { }
 	local sourceList = { }
 	local modList = { }
+	local sortList = { { label = "Default", stat = nil } }
+	for _, entry in ipairs(data.powerStatList) do
+		if entry.stat and not entry.ignoreForNodes then
+			t_insert(sortList, { label = entry.label, stat = entry.stat })
+		end
+	end
+	local function setDefaultSortOrder()
+		for index, listMod in ipairs(modList) do
+			listMod.defaultSortOrder = index
+			listMod.sortValue = nil
+			listMod.sortValues = nil
+		end
+	end
+	local function getOutputStatValue(output, stat)
+		if stat == "FullDPS" then
+			if output[stat] ~= nil then
+				return output[stat]
+			end
+			if output.Minion and output.Minion.CombinedDPS ~= nil then
+				return output.Minion.CombinedDPS
+			end
+		end
+		if output.Minion and output.Minion[stat] ~= nil then
+			return output.Minion[stat]
+		end
+		if output[stat] ~= nil then
+			return output[stat]
+		end
+		return 0
+	end
+	local function getSortValue(listMod, stat, calcFunc, slotName, useFullDPS)
+		listMod.sortValues = listMod.sortValues or { }
+		if listMod.sortValues[stat] ~= nil then
+			return listMod.sortValues[stat]
+		end
+		local item = new("Item", self.displayItem:BuildRaw())
+		item.id = self.displayItem.id
+		for _, line in ipairs(listMod.mod) do
+			t_insert(item.explicitModLines, { line = checkLineForAllocates(line, self.build.spec.nodes), modTags = listMod.mod.modTags, [listMod.type] = true })
+		end
+		item:BuildAndParseRaw()
+		local output = calcFunc({ repSlotName = slotName, repItem = item }, useFullDPS)
+		local value = getOutputStatValue(output, stat)
+		listMod.sortValues[stat] = value
+		return value
+	end
+	local function applySort(stat, selectFirst)
+		if not controls.modSelect or not controls.modSelect:IsShown() then
+			return
+		end
+		local selected = not selectFirst and modList[controls.modSelect.selIndex] or nil
+		if stat then
+			local slotName = self.displayItem:GetPrimarySlot()
+			local calcFunc = self.build.calcsTab:GetMiscCalculator()
+			local useFullDPS = stat == "FullDPS"
+			for _, listMod in ipairs(modList) do
+				listMod.sortValue = getSortValue(listMod, stat, calcFunc, slotName, useFullDPS)
+			end
+			table.sort(modList, function(a, b)
+				if a.sortValue ~= b.sortValue then
+					return a.sortValue > b.sortValue
+				end
+				return (a.defaultSortOrder or 0) < (b.defaultSortOrder or 0)
+			end)
+		else
+			table.sort(modList, function(a, b)
+				return (a.defaultSortOrder or 0) < (b.defaultSortOrder or 0)
+			end)
+		end
+		controls.modSelect:UpdateSearch()
+		if selected then
+			for index, listMod in ipairs(modList) do
+				if listMod == selected then
+					controls.modSelect.selIndex = index
+					break
+				end
+			end
+		else
+			controls.modSelect:SetSel(1, true)
+		end
+	end
 	---Mutates modList to contain mods from the specified source
 	---@param sourceId string @The crafting source id to build the list of mods for
 	local function buildMods(sourceId)
@@ -2846,6 +2927,7 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 				end
 			end)
 		end
+		setDefaultSortOrder()
 	end
 	if self.displayItem.type ~= "Tincture" and self.displayItem.type ~= "Graft" then
 		if self.displayItem.type ~= "Jewel" then
@@ -2890,8 +2972,21 @@ function ItemsTabClass:AddCustomModifierToDisplayItem()
 	controls.source = new("DropDownControl", {"TOPLEFT",nil,"TOPLEFT"}, {100, 20, 150, 18}, sourceList, function(index, value)
 		buildMods(value.sourceId)
 		controls.modSelect:SetSel(1)
+		if controls.sort then
+			applySort(controls.sort.list[controls.sort.selIndex].stat)
+		end
 	end)
 	controls.source.enabled = #sourceList > 1
+	controls.sortLabel = new("LabelControl", {"TOPRIGHT",nil,"TOPLEFT"}, {350, 20, 0, 16}, "^7Sort by:")
+	controls.sortLabel.shown = function()
+		return sourceList[controls.source.selIndex].sourceId ~= "CUSTOM"
+	end
+	controls.sort = new("DropDownControl", {"TOPLEFT",nil,"TOPLEFT"}, {355, 20, 240, 18}, sortList, function(index, value)
+		applySort(value.stat, true)
+	end)
+	controls.sort.shown = function()
+		return sourceList[controls.source.selIndex].sourceId ~= "CUSTOM"
+	end
 	controls.modSelectLabel = new("LabelControl", {"TOPRIGHT",nil,"TOPLEFT"}, {95, 45, 0, 16}, "^7Modifier:")
 	controls.modSelect = new("DropDownControl", {"TOPLEFT",nil,"TOPLEFT"}, {100, 45, 600, 18}, modList)
 	controls.modSelect.shown = function()


### PR DESCRIPTION
### Description of the problem being solved:

The "Add Modifier to Item" popup in the Items tab lists candidate mods for every source available on the item — prefix / suffix / implicit tiers, bench/master crafts, essences, veiled mods, crafted mods, influenced mods — in source order. When picking between dozens of candidates the user has to eyeball which one most helps the current build, regardless of source.

This PR adds a **Sort** dropdown to the popup. The metrics are drawn from `data.powerStatList` (same source as `CompareTab`, `ItemDBControl`, `NotableDBControl`, `SkillsTab`, `TradeQuery`, and `RadiusJewelData`), so the available sorts stay in sync with every other sort surface in PoB. Selecting a stat recomputes each candidate against the current build via `calcsTab:GetMiscCalculator()` and orders them by the resulting output value. "Default" restores the original source order. The sort applies to the current Source filter, so switching Source re-applies automatically with cached values.

### Steps taken to verify a working solution:

- Ran `busted --run=quick --lua=luajit --output=gtest ../spec` (full spec tree) and got `208 successes / 0 failures / 0 errors` in 32 s.
- Manually verified in the Items tab that:
    - The Sort dropdown is populated with every eligible `data.powerStatList` entry.
    - Sorting by `Life`, `Effective Hit Pool`, `Life Regen`, `Armour`, etc., promotes the expected mods on a sample build.
    - The sort respects the current Source filter (e.g., Source = Suffix + Sort = Life Regen lists only suffix mods ordered by life regen gained).
    - Switching between Source types re-applies the current sort.
    - Selecting `Default` restores the original source order.
    - The cached `sortValues` table avoids re-computing when the user switches back to a previously-selected stat.

### Before — popup without Sort dropdown:

<img width="725" height="112" alt="before-sort-dropdown" src="https://github.com/user-attachments/assets/cf7c5563-d949-42a1-a6a0-a24703f1d379" />

### After — sorted by Life:

<img width="723" height="362" alt="after-sort-by-life" src="https://github.com/user-attachments/assets/840e5bc1-408e-41b4-b0f9-33e5e182453d" />
UPLOADED_URL)

### After — sorted by Effective Hit Pool:

<img width="732" height="374" alt="after-sort-by-ehp" src="https://github.com/user-attachments/assets/c9828a4d-6c6c-4c44-b8de-47738aedec7e" />

### After — Source = Suffix, sorted by Life Regen:

<img width="717" height="360" alt="after-sort-suffix-by-liferegen" src="https://github.com/user-attachments/assets/346c4008-c07b-411c-a527-3444a9b2127c" />
