### PR TITLE
Fix crash on selecting some Imbued gems + trigger supports not working

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -113,8 +113,8 @@ function GemSelectClass:PopulateGemList()
 			local levelRequirement = gemData.grantedEffect.levels[1].levelRequirement or 1
 			if characterLevel >= levelRequirement or not matchLevel then
 				if self.imbuedSelect then
-					-- Imbued dropdown only allows non-exceptional support gems.
-					if gemData.grantedEffect.support and not gemData.tagString:match("Exceptional") and not gemData.grantedEffect.plusVersionOf then
+					-- Imbued dropdown only allows non-exceptional support gems and supports that don't grant active skills
+					if gemData.grantedEffect.support and not gemData.tagString:match("Exceptional") and not gemData.grantedEffect.plusVersionOf and (not gemData.secondaryGrantedEffect or gemData.secondaryGrantedEffect.support) then
 						self.gems["Default:" .. gemId] = gemData
 					end
 				else
@@ -139,7 +139,7 @@ function GemSelectClass:FilterSupport(gemId, gemData)
 	end
 
 	if self.imbuedSelect then
-		return gemData.grantedEffect.support and not gemData.tagString:match("Exceptional")	and self.sortCache.canSupport[gemId]
+		return self.sortCache.canSupport[gemId]
 	end
 
 	return (not gemData.grantedEffect.support

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1516,7 +1516,12 @@ function calcs.initEnv(build, mode, override, specEnv)
 				end
 				-- if the slot has an imbued support, add it as an ExtraSupport
 				if build.skillsTab.imbuedSupportBySlot and build.skillsTab.imbuedSupportBySlot[slotName] and group.imbuedSupport then
-					addExtraSupports(nil, build.skillsTab.imbuedSupportBySlot[slotName], 1)
+					local imbuedSupport = build.skillsTab.imbuedSupportBySlot[slotName]
+					addExtraSupports(nil, imbuedSupport, 1)
+					local imbuedGemData = env.data.gems[env.data.gemForSkill[imbuedSupport]]
+					if imbuedGemData and imbuedGemData.secondaryGrantedEffect and imbuedGemData.secondaryGrantedEffect.support then
+						addExtraSupports(nil, imbuedGemData.secondaryGrantedEffect, 1)
+					end
 				end
 
 				for gemIndex, gemInstance in ipairs(group.gemList) do


### PR DESCRIPTION
### Description of the problem being solved:
Fixes the crash that occurred when an imbued support tried to grant a active skill
Fixes imbued supports that granted a secondary granted effect like cast on crit, cast when damage taken or cast while channeling

### Steps taken to verify a working solution:
-
-
-

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
