### PR TITLE
Fix some gems being hidden from gem list

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -109,7 +109,7 @@ function GemSelectClass:PopulateGemList()
 	local characterLevel = self.skillsTab.build and self.skillsTab.build.characterLevel or 1
 
 	for gemId, gemData in pairs(self.skillsTab.build.data.gems) do
-		if not gemData.grantedEffect.fromItem and (self.sortGemsBy and gemData.tags[self.sortGemsBy] == true or not self.sortGemsBy) then
+		if not gemData.grantedEffect.hideFromGemList and (self.sortGemsBy and gemData.tags[self.sortGemsBy] == true or not self.sortGemsBy) then
 			local levelRequirement = gemData.grantedEffect.levels[1].levelRequirement or 1
 			if characterLevel >= levelRequirement or not matchLevel then
 				if self.imbuedSelect then

--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -1212,6 +1212,7 @@ skills["SupportDivineBlessing"] = {
 	excludeSkillTypes = { SkillType.SummonsTotem, SkillType.InbuiltTrigger, },
 	statDescriptionScope = "gem_stat_descriptions",
 	fromItem = true,
+	hideFromGemList = true,
 	statMap = {
 		["support_aura_duration_base_buff_duration"] = {
 			skill("auraDuration", nil),
@@ -1385,6 +1386,7 @@ skills["SupportEarthbreaker"] = {
 	excludeSkillTypes = { SkillType.InbuiltTrigger, },
 	statDescriptionScope = "gem_stat_descriptions",
 	fromItem = true,
+	hideFromGemList = true,
 	addFlags = {
 		totem = true,
 	},

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -390,6 +390,7 @@ local skills, mod, flag, skill = ...
 
 #skill SupportDivineBlessing
 	fromItem = true,
+	hideFromGemList = true,
 	statMap = {
 		["support_aura_duration_base_buff_duration"] = {
 			skill("auraDuration", nil),
@@ -416,6 +417,7 @@ local skills, mod, flag, skill = ...
 
 #skill SupportEarthbreaker
 	fromItem = true,
+	hideFromGemList = true,
 	addFlags = {
 		totem = true,
 	},


### PR DESCRIPTION
Fixes #9795

### Description of the problem being solved:
Using `fromItem` isn't going to work as the gem list gets mutated with it from many other places and it's too risky to change those
Instead we now use a different tag that is untouched by anything else so it wont fail
Tried looking in the game files to see if there was anything that'd show if the gems couldn't drop anymore and could not find anything so have to keep it hardcoded:
