### PR TITLE
Fix Divine Sentinel Templar Aura's duplicating effect

### DIFF
--- a/src/Data/Skills/sup_str.lua
+++ b/src/Data/Skills/sup_str.lua
@@ -1666,12 +1666,12 @@ skills["SupportDivineSentinel"] = {
 		},
 	},
 	baseMods = {
-		mod("PhysicalDamageGainAsFire", "BASE", 15, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true }, { type = "Condition", var = "DivineSentinelPhysAsFire" }),
-		mod("PhysicalDamageGainAsLightning", "BASE", 15, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true }, { type = "Condition", var = "DivineSentinelPhysAsLightning" }),
-		mod("LifeRegenPercent", "BASE", 1.5, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true }, { type = "Condition", var = "DivineSentinelRegenLife" }),
-		mod("ManaRegen", "INC", 30, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true }, { type = "Condition", var = "DivineSentinelRegenMana" }),
-		mod("ChaosResist", "BASE", 23, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true }, { type = "Condition", var = "DivineSentinelChaosResistance" }),
-		mod("CurseEffectOnSelf", "INC", -50, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true }, { type = "Condition", var = "DivineSentinelSelfCurseEffect" }),
+		mod("PhysicalDamageGainAsFire", "BASE", 15, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true, effectName = "TemplarAuraPhysAsFire" }, { type = "Condition", var = "DivineSentinelPhysAsFire" }),
+		mod("PhysicalDamageGainAsLightning", "BASE", 15, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true, effectName = "TemplarAuraPhysAsLightning" }, { type = "Condition", var = "DivineSentinelPhysAsLightning" }),
+		mod("LifeRegenPercent", "BASE", 1.5, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true, effectName = "TemplarAuraLifeRegen" }, { type = "Condition", var = "DivineSentinelRegenLife" }),
+		mod("ManaRegen", "INC", 30, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true, effectName = "TemplarAuraManaRegen" }, { type = "Condition", var = "DivineSentinelRegenMana" }),
+		mod("ChaosResist", "BASE", 23, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true, effectName = "TemplarAuraChaosResist" }, { type = "Condition", var = "DivineSentinelChaosResistance" }),
+		mod("CurseEffectOnSelf", "INC", -50, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true, effectName = "TemplarAuraSelfCurseEffect" }, { type = "Condition", var = "DivineSentinelSelfCurseEffect" }),
 	},
 	qualityStats = {
 		{ "minion_maximum_life_+%", 0.5 },

--- a/src/Export/Skills/sup_str.txt
+++ b/src/Export/Skills/sup_str.txt
@@ -241,12 +241,12 @@ local skills, mod, flag, skill = ...
 		["summoned_sentinels_have_random_templar_aura"] = {
 		},
 	},
-#baseMod mod("PhysicalDamageGainAsFire", "BASE", 15, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true }, { type = "Condition", var = "DivineSentinelPhysAsFire" })
-#baseMod mod("PhysicalDamageGainAsLightning", "BASE", 15, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true }, { type = "Condition", var = "DivineSentinelPhysAsLightning" })
-#baseMod mod("LifeRegenPercent", "BASE", 1.5, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true }, { type = "Condition", var = "DivineSentinelRegenLife" })
-#baseMod mod("ManaRegen", "INC", 30, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true }, { type = "Condition", var = "DivineSentinelRegenMana" })
-#baseMod mod("ChaosResist", "BASE", 23, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true }, { type = "Condition", var = "DivineSentinelChaosResistance" })
-#baseMod mod("CurseEffectOnSelf", "INC", -50, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true }, { type = "Condition", var = "DivineSentinelSelfCurseEffect" })
+#baseMod mod("PhysicalDamageGainAsFire", "BASE", 15, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true, effectName = "TemplarAuraPhysAsFire" }, { type = "Condition", var = "DivineSentinelPhysAsFire" })
+#baseMod mod("PhysicalDamageGainAsLightning", "BASE", 15, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true, effectName = "TemplarAuraPhysAsLightning" }, { type = "Condition", var = "DivineSentinelPhysAsLightning" })
+#baseMod mod("LifeRegenPercent", "BASE", 1.5, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true, effectName = "TemplarAuraLifeRegen" }, { type = "Condition", var = "DivineSentinelRegenLife" })
+#baseMod mod("ManaRegen", "INC", 30, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true, effectName = "TemplarAuraManaRegen" }, { type = "Condition", var = "DivineSentinelRegenMana" })
+#baseMod mod("ChaosResist", "BASE", 23, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true, effectName = "TemplarAuraChaosResist" }, { type = "Condition", var = "DivineSentinelChaosResistance" })
+#baseMod mod("CurseEffectOnSelf", "INC", -50, 0, 0, { type = "GlobalEffect", effectType = "Aura", unscalable = true, effectName = "TemplarAuraSelfCurseEffect" }, { type = "Condition", var = "DivineSentinelSelfCurseEffect" })
 #mods
 
 #skill SupportElementalDamageWithAttacks


### PR DESCRIPTION
### Description of the problem being solved:
When you linked Divine Sentinel to a vaal sentinel skill then it would apply the auras twice.
Adding the effect name to the Aura's makes them only apply once now

### Link to a build that showcases this PR:
https://pobb.in/lmm3B4gMibps

### Before screenshot:
<img width="727" height="140" alt="image" src="https://github.com/user-attachments/assets/7a1ffd72-050d-4ad4-b2d0-bdebe8bd11c5" />

### After screenshot:
<img width="724" height="126" alt="image" src="https://github.com/user-attachments/assets/1e72b8d7-846b-4b09-8a14-716dbdb932cb" />
