### PR TITLE
Fix Prospero's Protection interaction with Iron Reflexes

### DIFF
--- a/spec/System/TestDefence_spec.lua
+++ b/spec/System/TestDefence_spec.lua
@@ -945,8 +945,19 @@ describe("TestDefence", function()
 
 		-- Get the base + Shabby Jerkin to make this test more adaptable to changes
 		local ironReflexesArmour = build.calcsTab.mainOutput.Armour - baseArmour - baseEvasion
+		assert.are.equals(ironReflexesArmour + baseArmour + baseEvasion, build.calcsTab.mainOutput.Armour)
 
-		print("build.calcsTab.mainOutput.Armour:" .. build.calcsTab.mainOutput.Armour)
+		build.configTab.input.customMods = [[
+			Converts all Evasion Rating to Armour. Dexterity provides no bonus to Evasion Rating
+			you have no dexterity
+			Gain no armour from equipped body armour
+		]]
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+		-- Iron Reflexes and Prospero's Protection
+		assert.are.equals(baseArmour + baseEvasion, build.calcsTab.mainOutput.Armour)
+
+		--print("build.calcsTab.mainOutput.Armour:" .. build.calcsTab.mainOutput.Armour)
 
 		build.configTab.input.customMods = [[
 			Armour from Equipped Body Armour is doubled
@@ -955,7 +966,6 @@ describe("TestDefence", function()
 		]]
 		build.configTab:BuildModList()
 		runCallback("OnFrame")
-
 		-- Evasion from Body Armour is converted to Armour before being doubled
 		assert.are.equals(2*ironReflexesArmour + baseArmour + baseEvasion, build.calcsTab.mainOutput.Armour)
 
@@ -967,26 +977,22 @@ describe("TestDefence", function()
 		]]
 		build.configTab:BuildModList()
 		runCallback("OnFrame")
-
 		-- Only the base armour from the chest is affected.
 		-- Armour converted with Iron Reflexes still applies
-		assert.are.equals(2*ironReflexesArmour + baseArmour + baseEvasion, build.calcsTab.mainOutput.Armour)
+		assert.are.equals(baseArmour + baseEvasion, build.calcsTab.mainOutput.Armour)
+
 		build.configTab.input.customMods = [[
 			Armour from Equipped Body Armour is doubled
 			Converts all Evasion Rating to Armour. Dexterity provides no bonus to Evasion Rating
-			Gain no armour from equipped body armour
 			defences from equipped body armour are doubled if it has no socketed gems
 			you have no dexterity
 		]]
 		build.configTab:BuildModList()
 		runCallback("OnFrame")
-
-		-- Oath Of Maji double defences stack with Unbreakable
 		assert.are.equals(2*2*ironReflexesArmour + baseArmour + baseEvasion, build.calcsTab.mainOutput.Armour)
 
 		build.configTab.input.customMods = [[
 			Armour from Equipped Body Armour is doubled
-			Armour from Equipped Body Armour is doubled
 			Converts all Evasion Rating to Armour. Dexterity provides no bonus to Evasion Rating
 			Gain no armour from equipped body armour
 			defences from equipped body armour are doubled if it has no socketed gems
@@ -994,7 +1000,17 @@ describe("TestDefence", function()
 		]]
 		build.configTab:BuildModList()
 		runCallback("OnFrame")
+		assert.are.equals(baseArmour + baseEvasion, build.calcsTab.mainOutput.Armour)
 
+		build.configTab.input.customMods = [[
+			Armour from Equipped Body Armour is doubled
+			Armour from Equipped Body Armour is doubled
+			Converts all Evasion Rating to Armour. Dexterity provides no bonus to Evasion Rating
+			defences from equipped body armour are doubled if it has no socketed gems
+			you have no dexterity
+		]]
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
 		-- Mod form unbreakable should apply only once
 		assert.are.equals(2*2*ironReflexesArmour + baseArmour + baseEvasion, build.calcsTab.mainOutput.Armour)
 
@@ -1004,14 +1020,37 @@ describe("TestDefence", function()
 			Converts all Evasion Rating to Armour. Dexterity provides no bonus to Evasion Rating
 			Gain no armour from equipped body armour
 			defences from equipped body armour are doubled if it has no socketed gems
+			you have no dexterity
+		]]
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+		assert.are.equals(baseArmour + baseEvasion, build.calcsTab.mainOutput.Armour)
+
+		build.configTab.input.customMods = [[
+			Armour from Equipped Body Armour is doubled
+			Armour from Equipped Body Armour is doubled
+			Converts all Evasion Rating to Armour. Dexterity provides no bonus to Evasion Rating
+			defences from equipped body armour are doubled if it has no socketed gems
 			defences from equipped body armour are doubled if it has no socketed gems
 			you have no dexterity
 		]]
 		build.configTab:BuildModList()
 		runCallback("OnFrame")
-
 		-- Oath Of Maji should apply only once
 		assert.are.equals(2*2*ironReflexesArmour + baseArmour + baseEvasion, build.calcsTab.mainOutput.Armour)
+
+		build.configTab.input.customMods = [[
+			Armour from Equipped Body Armour is doubled
+			Armour from Equipped Body Armour is doubled
+			Converts all Evasion Rating to Armour. Dexterity provides no bonus to Evasion Rating
+			Gain no armour from equipped body armour
+			defences from equipped body armour are doubled if it has no socketed gems
+			defences from equipped body armour are doubled if it has no socketed gems
+			you have no dexterity
+		]]
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+		assert.are.equals(baseArmour + baseEvasion, build.calcsTab.mainOutput.Armour)
 	end)
 	
 	it("MoM + EB", function()

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -846,12 +846,12 @@ function calcs.defence(env, actor)
 				slotCfg.slotName = slot
 				energyShieldBase = not modDB:Flag(nil, "GainNoEnergyShieldFrom" .. slot) and armourData.EnergyShield or 0
 				armourBase = not modDB:Flag(nil, "GainNoArmourFrom" .. slot) and armourData.Armour or 0
-				evasionBase = not modDB:Flag(nil, "GainNoEvasionFrom" .. slot) and armourData.Evasion or 0
+				evasionBase = not (modDB:Flag(nil, "GainNoEvasionFrom" .. slot) or (modDB:Flag(nil, "GainNoArmourFrom" .. slot) and ironReflexes)) and armourData.Evasion or 0
 				wardBase = not modDB:Flag(nil, "GainNoWardFrom" .. slot) and armourData.Ward or 0
 				if slot == "Body Armour" and modDB:Flag(nil, "ConvertBodyArmourArmourEvasionToWard") then
 					local conversion = m_min(modDB:Sum("BASE", nil, "BodyArmourArmourEvasionToWardPercent") / 100, 1)
-					local convertedArmour = armourBase *  conversion
-					local convertedEvasion = evasionBase *  conversion
+					local convertedArmour = armourBase * conversion
+					local convertedEvasion = evasionBase * conversion
 					armourBase = armourBase - convertedArmour
 					evasionBase = evasionBase - convertedEvasion
 					wardBase = wardBase + (convertedEvasion + convertedArmour)
@@ -914,6 +914,7 @@ function calcs.defence(env, actor)
 					if breakdown then
 						breakdown.slot(slot, nil, slotCfg, evasionBase, nil, "Evasion", "ArmourAndEvasion", "Defences")
 					end
+
 					if ironReflexes then
 						armour = armour + evasionBase * calcLib.mod(modDB, slotCfg, "Armour", "Evasion", "ArmourAndEvasion", "Defences")
 					else
@@ -975,6 +976,7 @@ function calcs.defence(env, actor)
 		end
 		evasionBase = modDB:Sum("BASE", nil, "Evasion", "ArmourAndEvasion")
 		if evasionBase > 0 then
+
 			if ironReflexes then
 				armour = armour + evasionBase * calcLib.mod(modDB, nil, "Armour", "Evasion", "ArmourAndEvasion", "Defences")
 				if breakdown then

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -914,7 +914,6 @@ function calcs.defence(env, actor)
 					if breakdown then
 						breakdown.slot(slot, nil, slotCfg, evasionBase, nil, "Evasion", "ArmourAndEvasion", "Defences")
 					end
-
 					if ironReflexes then
 						armour = armour + evasionBase * calcLib.mod(modDB, slotCfg, "Armour", "Evasion", "ArmourAndEvasion", "Defences")
 					else
@@ -976,7 +975,6 @@ function calcs.defence(env, actor)
 		end
 		evasionBase = modDB:Sum("BASE", nil, "Evasion", "ArmourAndEvasion")
 		if evasionBase > 0 then
-
 			if ironReflexes then
 				armour = armour + evasionBase * calcLib.mod(modDB, nil, "Armour", "Evasion", "ArmourAndEvasion", "Defences")
 				if breakdown then


### PR DESCRIPTION
### Description of the problem being solved:
In-game, Prospero's Protection removes all armour from an evasion base that is converted by Iron Reflexes. PoB currently only removes the baseArmour of the body armour. Updating to remove baseEvasion if Iron Reflexes is allocated.

#### In game screen grabs
<img width="1806" height="706" alt="image" src="https://github.com/user-attachments/assets/0cc39b84-b74a-4da8-8adb-24d97474e5b0" />
<img width="1753" height="693" alt="image" src="https://github.com/user-attachments/assets/e67587ed-9e61-4a97-9a8e-7d561d6d112d" />

### Steps taken to verify a working solution:
- Validate ring and Reliquarian Prospero's Protection remove all armour from body armour with and without Iron Reflexes
- Validate Reliquarian Prospero Protection remove all armour with Reliq Brass Dome with and without IR

### Link to a build that showcases this PR:
<pre>eNrFXOtv4zYS_7z5KwQDd2hxTmI9beeSFo7jPNpk49rJbvtpwUi0zQ0tKhKVxC32f78h9bDl-EFZBq4LbC1qfsPhcGY4pIZ7-uv7lGqvOIwI889q-lGjpmHfZR7xx2e1x4fLw1bt118OTvuIT-5H5zGh4s0vB59O5W_tCfke4We1z8zHNe2V4Lc75uGz2s1d_37wUNMofsUU-Do1zZ2gELkch7eirRNzlpDyMAboFBF_yNxnzK9CFgcAqWkchWPMv2TCmd9AOJeiKPqMpgAcutBc01DkYt_rztsHmJKXGIUEwdsA-XyCmX-HvrPwinmZqHk78RfbYWSfTvsUzXA45Ihrr4jGwLJxZNa0CBrOah1QFhrjCzSFv2vHyoDzOIz4FpR-ZGSoYYCxt559RtYPcW80wi4nr7gbEt6dIN_F23EKtPqRvUh9F1NOAkpwuBZh5uyvt0tyZDoZ9QPjiF70h9vFTigZV2L7lfDJOQU1bmS9BLgZ-4TjMog-IxHzS4mvRNyNKQVfU6Id4AiHr4iTLYIsiN5l0yfib1FORnyHfNRlEVej7OMQXJKXAgyxy8CLy_ZREnlLRlidstQ4UkBZaXYbR2-oSlea8W4CDSCsqVEOWUw3UhpzUr4-1uhmHp0u8Pt6Zm1z7iMvGynzbm98hWFc4Fcm3G29gE7rqNHUbaPZtlvNViEE9K77a3GWma8B_cksIi6id-idTOMpBNUH9Iw3dGk356Y1nnAfwscO2EsS4h1gXUY9ddg8zE0Qi1RxZmMhCBD_GrKPjuvGkFfM1k-sVXA4BQsNsHsiSG98V5Xrox_KELxhzV5CDMC7RGbwRDcswY01naROqhZiBniM_bS7mRrkFmN3cgUaHiC-QTyrEJIVNStIN2l2iauCZvXGGsQ2NRnzFEcASypKQNQUNQ-vPg7Hs-GEYOqVo87E6qJAUc-L6E36XtNdKVUsQkuq5CsKPbX1paxMryjaFKANq6iuhFxJU3cY0koAeFg13-6H7LvI0qkSTG-aeVjthFMWh6qjSKg3upe5vLwkm5IB9mJ344o212y24zinsGNTVUGOAkEpLQXtcI7c5wvmjZUVLjsphSjKN4yDAMKIMIktDA7na5lYOSEVJyp50Jz2Hux5k1svdCDWWNUO5rQlOsjzBtVelgBbu3KKC7_yYObE27poHLWbH-b0DoLGFJYCua2-YwoR5xK2X0p7I0mouKfrszcQfiLONaL1Sc4qasiQFEQJsf_3TJl_gVypg57vQbIF3qDcxzJi3s0DmUIYjaILxJEWyaOfS0I5Di9gkgUi6Rej0J3cQtNZbfHpElH6BEFBtHppLv5FnvlwQx4eLTXqolF0fHosT67Er4cQYw1lPu8KCimZeICuxO4HhbPO_Hzpxjur-YSK06oIBJ0l5hUJGXzmYfhhmFZTr-uNltGuOw27ZdR1R3eaddtqtOp2q2WadcNsAYHj6HXHdMy6bjQaZt02zGbdaLfF36ZuGHXTbptOXdetdrPesi0LIMC1brabTbNuOlarXTcMy4K-2jq8tUzdkSBot41G26rbjg2_24bdqjuG3jALB2ViILDN4KCAheM1oyXO12IxtGsUTS5ZOEXz4zcjPXwT2IZU1KfTx8Gt_PFpwnkQnRwfv729HQWIT9gIv8Nid-Sy6XEAIFDxYfRMKD0UfR534L_zcad79SV-_f3ZjILvLf9y2Ok0yZRefY5i632ge_1L9Mjex7f3z5O_fuPed0b_fHkMb15-e7mjLj80_2g8__76-5_A6kwKc5xJc5ocJEbHyZMIGCGB6Uns7lhMrzQEMf_ix1AIFoENhvwKT6PzGfjypUhliqckYFIjFFNB80eMKOGzxEIn7E2sFgn6YRYIO-jc3iZvbvEYNieC7VlthGiEa8V-svPPOe_b5MjUF9rPtn61zEyFpEPM56aaNmjEmxt4Mp7Mwr8Q_JY6Dmyoha3-zdj0T7HTdI7a7YZhG4ZjioRDtKe9p09_QcTW9bZ11Gw3wGQN29bTAYNzXxAwfwghrhiwHIXs_obD2LQ4wsn5wVeMAuZLmbPxr8WnoxQcFgcpntMByhkdgEvz2Yk26Ax6B2nepnUnOOIHw5nvQU7D8b-h1-i_kXaFwqeM5kTTzZaTPZ2jKDt9AUuFdwfdEI049k40IcxBP8Qj8n6iiXPhDQ_DeKTykFrMidY4SK3zRLs6zP8cSL0P8MuJ1rIObqYBJS4RNA1pskIDRVUYRVU8fr7547EHkrEowCHLRg_PHMus7uAmBCUNYKFe6Mo0FrvSD_7haBydBGle-M2TiWEdyezrR8fzIk3XONMsLUsdtSR3FI1JjhYd_APRfoxPGkf2j5-sQ-fnf2lJ_iRoZNKXUqbQtE_oIyRPMcc_FvD_-Um3D037ZwEF08X-mE9SekjNIM91l8gtG_ILST5N_EYTm9kUAh4mbe1HkiNro5BNtd5LTIIAe1qyd9FIpHkshj25t4wSOxqI8tpK9DnzZukbGXIgwxgIuVKr1aSQIjWxa2lQKlAYWynMrRTWVgp7K4XzkWKV7Zkr3DBVS-KFnYiHYByQFnCcvjnRmi0j_f3_97zBYf5nwR2cle4ASYrIHBGthzL_FMZcNLvWoW6AnYPZQVKi9TJ6bZDTR0pWsaTreVjfEE3TBY8yrvny69c1plMAdp5mUQQyJEPWwMIIsEzWbvmz_wTLJawGxx84nGP6Aa-Xwc-doYoYVxRy9miZg1WCQ6IszdCGbyhYZmTvZ0R6eXn0lfKY-5HHKjnR-1KnU4LRJaSRz-UkZYxHe1C9UUXrG6ev8mjKKHC1j1cWobp32vsyJ6OyNuzKg9nJtasrRK9iGevsfE_xu5RSxZq-v_ho70EL1n604FR1NGtfStErLus7C7IHszb3MKH7cC9jXzHLrGoWZuWg5-xBH5WXEbuiUVbFG3tQgl559XAqjsKsiHf2ZdbWHvzUKL1uVM9FzNIZ6d6yF31XRiVw4ihnX5sGs2y_RlnA3tKA0mtvaTsqbTbGbpMwR-lqwX4PflhGe51pTEt1mmijvNtVj7XGvqxrF0Y7TEvldV6vzGHLNCVHUUPMk091IfLwUH5C-IrFB98o-dAgj_rFry6ibpQcXPlBzLWIh7KAvHd52es-3Hzp1VJhpiRyvz3Fo5Go_U67SiB-PH3CoXSGhFR-LvqWNKeUw-QsW56KpV8-KDTVtCh-ipJ3ZzXxvUO-vMAcEQr-7DJKURBhLzs0-8jtmmS12QVeks_COwVOX0FLIRFhZJFR7x2HHFQyf6vAShQ6fxQnkUUUwYgvqEqMkmLyAqvkEL6LIi7LdFS4iCrwIhPRojaUm2mA6JJyszaVAYiBi09r4rtRtEIpXHx2C7BLRsRNadRmPS3uKOomKylU4SErzIv4tEkBnNSOF9FZm4pWZbH6klbTNhX7wi6aFdFpkwI4L_MqMsibmX8tzEWBU4_iDqHizHxpZj8zXxo7-M2cQIHhHQSZ9NN8keE9n-Awf6PAqZN9loo-eE_erqIrUXdaVJNsURmLKKwsQJMWFb0uFhsWo1HhjVpQW2KRtChA0wqfAjhpU5yCNFkqqD9tU1FCWgVYHH_WqOIkMtx2XhnxPkaKDy-rMpRfSPcglyh8q85muRJOiaNM6pb8JWvbEf7IifiEt4JLXnawnYlwuWochOdV4_BAfJfHIVZiMPiQjgyWk5A1yKw6q7hYZ4074vNKrp05JPVmO8NlOZwKWsT_i_S7_YoFYP5KcS1ZzeuSQUY3EsUmqp6xnteQx_4FaHcPrOQQV0ek3dSVLr0rtbaGYxJUkqscK-Jl-kI5Oq1jBHnBtWoCupZTXiJ6jREVt_kYrcZw-S5LJWai3D0OkO9l7O5X5f2lp4HxCHjKQsgLUVVfVYc-ns5WMJoXhR1nO8RTyPrBcTT8Lv7XR6Goopt3eCpbtOGEvXW8V2HBDzAh89o5D0ewjUJpGkBhqlAQYL8g9OlnBomZkF50nD2cdpk_IuO0xCx5WCwyy1uymgtOOMUiI5aFeWmhRZ8iF08Y9XC4YsdKxoTej2Scgk1IXh-7GmZmMCy0J6q1-9nNpzX9NHSrCCpccVgNMgxLL2Dygu3Fu8gqEoqC9S0Sips7CSLI7ztk1bwbR2bn5wPiZoUSJEfk95KlFV4jStkbDA-W3-lGDs1GozC-hRvXKurI9bhFJ622U5xoUcm-Xfcrxlcc2lCW2w3wlL1i73wGvjArZQfC4LaL0bKKgxa1UpuVWqBPr5ZARJCFT5uQdmO1ehdvCCghly9hrAY5ervVLuAWL9oo6rB4g2ajjBnOTcJMAM4RIvpAxjjsstjniu6RG4O4eY5D7EkzkByGmI5KSS8UVcIQhy6TJcTC7JSGmpjZ0j80sK2TCex_tvdhNj50ojAHjQ8OsN1Olnv6cGnlOF84knVOPv1ycHq8_E9m_A9KeHq5</pre>

---

#### Reliquarian prospero before
<img width="630" height="474" alt="image" src="https://github.com/user-attachments/assets/aa003403-6c2f-4e5d-b625-445c0579e0d1" />

#### Reliquarian prospero after
<img width="640" height="498" alt="image" src="https://github.com/user-attachments/assets/29cd588e-35b2-436f-a9a2-74aca98f2fbf" />

---

#### Ring prospero tooltip before
<img width="672" height="593" alt="image" src="https://github.com/user-attachments/assets/fbcd1748-8fa6-42ca-83f8-9c072b4b9cc6" />

#### Ring prospero tooltip after
<img width="679" height="617" alt="image" src="https://github.com/user-attachments/assets/3658c505-f9b9-4be6-b23d-57bf5b29a677" />
