### PR TITLE
Add UndoState for Imbued Support

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -238,6 +238,7 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 				self.displayGroup.imbuedSupport = nil
 			end
 		end
+		self.modFlag = true
 	end, true, true)
 	local function isImbuedEnabled() -- socketedIn must be set and the displayGroup must have an imbued, otherwise disable the imbued dropdown
 		return (self.displayGroup and self.displayGroup.slot and ((self.imbuedSupportBySlot[self.displayGroup.slot] and self.displayGroup.imbuedSupport) or not self.imbuedSupportBySlot[self.displayGroup.slot]))
@@ -254,6 +255,7 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 		self.displayGroup.imbuedSupport = nil
 		self.imbuedSupportBySlot[self.displayGroup.slot] = nil
 		self.build.buildFlag = true
+		self.modFlag = true
 	end)
 	self.controls.imbuedSupportClear.enabled = function()
 		return isImbuedEnabled()

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -224,6 +224,7 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 			return
 		end
 		local updateDisplayGroup = self.displayGroup and targetSlot == self.displayGroup.slot
+		self:AddUndoState()
 		if gemData and (type(gemData) == "string" or gemData.id) then
 			local gem = data.gems[gemData.id or gemData]
 			self.imbuedSupportBySlot[targetSlot] = gem.grantedEffect
@@ -238,7 +239,6 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 				self.displayGroup.imbuedSupport = nil
 			end
 		end
-		self.modFlag = true
 	end, true, true)
 	local function isImbuedEnabled() -- socketedIn must be set and the displayGroup must have an imbued, otherwise disable the imbued dropdown
 		return (self.displayGroup and self.displayGroup.slot and ((self.imbuedSupportBySlot[self.displayGroup.slot] and self.displayGroup.imbuedSupport) or not self.imbuedSupportBySlot[self.displayGroup.slot]))
@@ -254,8 +254,8 @@ local SkillsTabClass = newClass("SkillsTab", "UndoHandler", "ControlHost", "Cont
 		self.controls.imbuedSupport:SetText("")
 		self.displayGroup.imbuedSupport = nil
 		self.imbuedSupportBySlot[self.displayGroup.slot] = nil
+		self:AddUndoState()
 		self.build.buildFlag = true
-		self.modFlag = true
 	end)
 	self.controls.imbuedSupportClear.enabled = function()
 		return isImbuedEnabled()


### PR DESCRIPTION
### Description of the problem being solved:
Technical. Set undoState for changes to imbued support, which also updates modFlag as well which was needed.

### Steps taken to verify a working solution:
- Verify Save enabled on imbued added, removed, changed
- Verify ctrl z functionality

### before
<img width="1266" height="739" alt="modflagimbuedbefore" src="https://github.com/user-attachments/assets/ebd0d2be-ef3b-4385-8814-7a3a89dee8bf" />

### after
<img width="1266" height="739" alt="modflagimbuedafter" src="https://github.com/user-attachments/assets/e7ac6d0b-5bda-4a6e-9b60-22d0ea1f5a51" />
