### PR TITLE
Fix missing "Greater" gems from Imbued Support

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -112,13 +112,14 @@ function GemSelectClass:PopulateGemList()
 		if not gemData.grantedEffect.hideFromGemList and (self.sortGemsBy and gemData.tags[self.sortGemsBy] == true or not self.sortGemsBy) then
 			local levelRequirement = gemData.grantedEffect.levels[1].levelRequirement or 1
 			if characterLevel >= levelRequirement or not matchLevel then
+				local isLegacyAwakened = gemData.grantedEffect.legacy and gemData.grantedEffect.plusVersionOf
 				if self.imbuedSelect then
 					-- Imbued dropdown only allows non-exceptional support gems and supports that don't grant active skills
-					if gemData.grantedEffect.support and not gemData.tagString:match("Exceptional") and not gemData.grantedEffect.plusVersionOf and (not gemData.secondaryGrantedEffect or gemData.secondaryGrantedEffect.support) then
+					if gemData.grantedEffect.support and not gemData.tagString:match("Exceptional") and not isLegacyAwakened and (not gemData.secondaryGrantedEffect or gemData.secondaryGrantedEffect.support) then
 						self.gems["Default:" .. gemId] = gemData
 					end
 				else
-					if (showExceptional or showAll) and ((gemData.grantedEffect.legacy and gemData.grantedEffect.plusVersionOf) or gemData.tagString:match("Exceptional")) then
+					if (showExceptional or showAll) and (isLegacyAwakened or gemData.tagString:match("Exceptional")) then
 						if self.skillsTab.showLegacyGems or not gemData.grantedEffect.legacy then
 							self.gems["Default:" .. gemId] = gemData
 						end


### PR DESCRIPTION
Fixes #9817

### Description of the problem being solved:
Updates the filter for imbued supports to block plusVersionOf AND legacy instead of only plusVersionOf.

### Steps taken to verify a working solution:
- Validate GMP, Greater Volley shows in imbued for projectile skills 
- Validate awakened gems still not showing in imbued
- Validate legacy gems still show in the regular gemSelect when legacy toggled


Before
<img width="647" height="267" alt="image" src="https://github.com/user-attachments/assets/b1c06fc3-658e-4b06-aaaf-042ac8f17ca2" />

After
<img width="589" height="222" alt="image" src="https://github.com/user-attachments/assets/ea16ce9d-ac4a-4f41-852e-3ae5ee3811f2" />


