### PR TITLE
Add stat descriptions tooltip to Power Report

### DIFF
--- a/src/Classes/PowerReportListControl.lua
+++ b/src/Classes/PowerReportListControl.lua
@@ -125,13 +125,13 @@ function PowerReportListClass:GetRowValue(column, index, report)
 		or ""
 end
 
-function PowerReportListClass:AddValueTooltip(tooltip, index, entry)
+function PowerReportListClass:AddValueTooltip(tooltip, _, node)
 	if main.popups[1] then
 		tooltip:Clear()
 		return
 	end
-	if tooltip:CheckForUpdate(entry) and entry.sd then
-		for _, line in ipairs(entry.sd) do
+	if tooltip:CheckForUpdate(node) and node.sd then
+		for _, line in ipairs(node.sd) do
 			tooltip:AddLine(16, line)
 		end
 	end

--- a/src/Classes/PowerReportListControl.lua
+++ b/src/Classes/PowerReportListControl.lua
@@ -124,3 +124,15 @@ function PowerReportListClass:GetRowValue(column, index, report)
 		or column == 5 and report.pathPowerStr
 		or ""
 end
+
+function PowerReportListClass:AddValueTooltip(tooltip, index, entry)
+	if main.popups[1] then
+		tooltip:Clear()
+		return
+	end
+	if tooltip:CheckForUpdate(entry) and entry.sd then
+		for _, line in ipairs(entry.sd) do
+			tooltip:AddLine(16, line)
+		end
+	end
+end

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -1118,7 +1118,7 @@ function TreeTabClass:BuildPowerReportList(currentStat)
 				x = node.x,
 				y = node.y,
 				type = node.type,
-				sd = copyTable(node.sd, true),
+				sd = node.sd,
 				pathDist = pathDist
 			})
 		end
@@ -1147,7 +1147,7 @@ function TreeTabClass:BuildPowerReportList(currentStat)
 				pathPowerStr = "--",
 				id = node.id,
 				type = node.type,
-				sd = copyTable(node.sd, true),
+				sd = node.sd,
 				pathDist = "Cluster"
 			})
 		end

--- a/src/Classes/TreeTab.lua
+++ b/src/Classes/TreeTab.lua
@@ -1118,6 +1118,7 @@ function TreeTabClass:BuildPowerReportList(currentStat)
 				x = node.x,
 				y = node.y,
 				type = node.type,
+				sd = copyTable(node.sd, true),
 				pathDist = pathDist
 			})
 		end
@@ -1146,6 +1147,7 @@ function TreeTabClass:BuildPowerReportList(currentStat)
 				pathPowerStr = "--",
 				id = node.id,
 				type = node.type,
+				sd = copyTable(node.sd, true),
 				pathDist = "Cluster"
 			})
 		end


### PR DESCRIPTION
Fixes #9750 

### Description of the problem being solved:
Add stat descriptions tooltips when hovering nodes in the power report. Original ask is for cluster nodes, but I added this for all nodes by default. Can pull back to clusters only if desired as tree nodes can already be navigated to.

### After screenshot:
Cluster Nodes
<img width="843" height="169" alt="image" src="https://github.com/user-attachments/assets/70ffc46b-9db5-4598-9876-c939eabb87b3" />

Tree Nodes
<img width="931" height="273" alt="image" src="https://github.com/user-attachments/assets/7bfe05e1-5336-4d8e-9c28-92d37c46e4b5" />

