### PR TITLE
Fix Cord Belt anoint comparison tooltip

### DIFF
--- a/spec/System/TestItemTools_spec.lua
+++ b/spec/System/TestItemTools_spec.lua
@@ -45,4 +45,42 @@ describe("TestItemTools", function()
 			assert.are.equals(expected, result)
 		end)
 	end
+
+	it("uses the displayed item slot for anoint comparison tooltips", function()
+		if not common.classes.ItemsTab then
+			LoadModule("Classes/ItemsTab")
+		end
+		local item = new("Item", [[
+Rarity: Rare
+Dire Thread
+Cord Belt
+Can be Anointed
+]])
+		local overrides = { }
+		local fakeItemsTab = setmetatable({
+			displayItem = item,
+			build = {
+				spec = { allocNodes = { } },
+				calcsTab = {
+					GetMiscCalculator = function()
+						return function(override)
+							table.insert(overrides, override)
+							return { }
+						end
+					end,
+				},
+				AddStatComparesToTooltip = function()
+					return 1
+				end,
+			},
+		}, common.classes.ItemsTab)
+		local tooltip = {
+			AddLine = function() end,
+		}
+
+		fakeItemsTab:AppendAnointTooltip(tooltip, { id = 1, dn = "Acrimony" })
+
+		assert.are.equals("Belt", overrides[1].repSlotName)
+		assert.are.equals("Belt", overrides[2].repSlotName)
+	end)
 end)

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2405,7 +2405,7 @@ function ItemsTabClass:anointItem(node)
 	return item
 end
 
----Appends tooltip information for anointing a new passive tree node onto the currently editing amulet
+---Appends tooltip information for anointing a new passive tree node onto the currently editing item
 ---@param tooltip table @The tooltip to append into
 ---@param node table @The passive tree node that will be anointed, or nil to remove the current anoint.
 function ItemsTabClass:AppendAnointTooltip(tooltip, node, actionText)
@@ -2439,8 +2439,9 @@ function ItemsTabClass:AppendAnointTooltip(tooltip, node, actionText)
 		header = "^7"..actionText.." nothing will give you: "
 	end
 	local calcFunc = self.build.calcsTab:GetMiscCalculator()
-	local outputBase = calcFunc({ repSlotName = "Amulet", repItem = self.displayItem })
-	local outputNew = calcFunc({ repSlotName = "Amulet", repItem = self:anointItem(node) })
+	local repSlotName = self.displayItem.base and self.displayItem.base.type or "Amulet"
+	local outputBase = calcFunc({ repSlotName = repSlotName, repItem = self.displayItem })
+	local outputNew = calcFunc({ repSlotName = repSlotName, repItem = self:anointItem(node) })
 	local numChanges = self.build:AddStatComparesToTooltip(tooltip, outputBase, outputNew, header)
 	if node and numChanges == 0 then
 		tooltip:AddLine(14, "^7"..actionText.." "..node.dn.." changes nothing.")


### PR DESCRIPTION
## Summary

- Fix Cord Belt anoint comparison tooltips incorrectly using the amulet slot for calculations.
- Use the displayed item's base type for the temporary comparison slot, so Cord Belts compare as `Belt` and amulets still compare as `Amulet`.
- Add a regression test that verifies Cord Belt anoint tooltips pass `repSlotName = "Belt"` to both calculator calls.

## Changes

- `src/Classes/ItemsTab.lua`
  - Replaces the hardcoded `repSlotName = "Amulet"` in `AppendAnointTooltip` with the displayed item's base type.
- `spec/System/TestItemTools_spec.lua`
  - Adds a focused test for Cord Belt anoint tooltip comparison slot selection.

## Test plan

- [x] Targeted `TestItemTools_spec.lua` regression test passes.
  - 31 tests passed.
- [x] Manual verification: hovering an anointable Cord Belt uses the belt slot for comparison instead of applying the temporary item replacement to the amulet slot.

## Screenshots

Skipped: this is a small calculation-slot fix for an existing tooltip, with no UI layout or wording change.
