### PR TITLE
Fix catalyst lines not showing on import

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -1092,7 +1092,7 @@ function ImportTabClass:ImportItem(itemData, slotName)
 					["Attribute"] = 6,
 					["Physical and Chaos Damage"] = 7,
 					["Resistance"] = 8,
-					["Suffix"] = 9,
+					["Prefix"] = 9,
 					["Defense"] = 10,
 					["Elemental Damage"] = 11,
 					["Critical"] = 12,

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -1082,6 +1082,21 @@ function ImportTabClass:ImportItem(itemData, slotName)
 		for _, property in pairs(itemData.properties) do
 			if property.name == "Quality" then
 				item.quality = tonumber(property.values[1][1]:match("%d+"))
+			elseif property.name:match("Quality %(") then
+				local catalystMap = {
+					["Attack"] = 1,
+					["Speed"] = 2,
+					["Life and Mana"] = 3,
+					["Caster"] = 4,
+					["Attribute"] = 5,
+					["Physical and Chaos Damage"] = 6,
+					["Resistance"] = 7,
+					["Defense"] = 8,
+					["Elemental Damage"] = 9,
+					["Critical"] = 10,
+				}
+				item.catalyst = catalystMap[property.name:match("Quality %((.*) Modifiers%)")]
+				item.catalystQuality = tonumber(property.values[1][1]:match("%d+"))
 			elseif property.name == "Radius" then
 				item.jewelRadiusLabel = property.values[1][1]
 			elseif property.name == "Limited to" then

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -1086,14 +1086,16 @@ function ImportTabClass:ImportItem(itemData, slotName)
 				local catalystMap = {
 					["Attack"] = 1,
 					["Speed"] = 2,
-					["Life and Mana"] = 3,
-					["Caster"] = 4,
-					["Attribute"] = 5,
-					["Physical and Chaos Damage"] = 6,
-					["Resistance"] = 7,
-					["Defense"] = 8,
-					["Elemental Damage"] = 9,
-					["Critical"] = 10,
+					["Suffix"] = 3,
+					["Life and Mana"] = 4,
+					["Caster"] = 5,
+					["Attribute"] = 6,
+					["Physical and Chaos Damage"] = 7,
+					["Resistance"] = 8,
+					["Suffix"] = 9,
+					["Defense"] = 10,
+					["Elemental Damage"] = 11,
+					["Critical"] = 12,
 				}
 				item.catalyst = catalystMap[property.name:match("Quality %((.*) Modifiers%)")]
 				item.catalystQuality = tonumber(property.values[1][1]:match("%d+"))


### PR DESCRIPTION
### Description of the problem being solved:
When importing an item to PoB that has a catalyst applied, the line showing it has a catalyst doesn't appear (This PR doesn't add the ability to modify the catalyst still).  Discovered from https://old.reddit.com/r/PathOfExileBuilds/comments/1t2slyf/pobcodes_new_features_and_major_ux_improvements/ojq8bhb/
### Steps taken to verify a working solution:
- Import several builds from PoE.Ninja that contain catalyst-affected items