### PR TITLE
Add support for Companionship Support

### DIFF
--- a/src/Data/Skills/sup_dex.lua
+++ b/src/Data/Skills/sup_dex.lua
@@ -1417,6 +1417,14 @@ skills["SupportCompanionship"] = {
 	addSkillTypes = { },
 	excludeSkillTypes = { SkillType.MinionsAreUndamagable, SkillType.Triggered, },
 	statDescriptionScope = "gem_stat_descriptions",
+	statMap = {
+		["support_companionship_minion_maximum_life_+%_final_if_at_most_one_minion"] = {
+			mod("MinionModifier", "LIST", { mod = mod("Life", "MORE", nil) }, 0, 0, { type = "Condition", var = "OnlyMinion" }),
+		},
+		["damage_removed_from_minions_before_life_or_es_%_if_only_one_minion"] = {
+			mod("takenFromMinionBeforeYou", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", unscalable = true }),
+		},
+	},
 	qualityStats = {
 		{ "minion_maximum_life_+%", 1 },
 	},

--- a/src/Export/Skills/sup_dex.txt
+++ b/src/Export/Skills/sup_dex.txt
@@ -179,6 +179,14 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill SupportCompanionship
+	statMap = {
+		["support_companionship_minion_maximum_life_+%_final_if_at_most_one_minion"] = {
+			mod("MinionModifier", "LIST", { mod = mod("Life", "MORE", nil) }, 0, 0, { type = "Condition", var = "OnlyMinion" }),
+		},
+		["damage_removed_from_minions_before_life_or_es_%_if_only_one_minion"] = {
+			mod("takenFromMinionBeforeYou", "BASE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff", unscalable = true }),
+		},
+	},
 #mods
 
 #skill SupportCriticalStrikeAffliction

--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -175,6 +175,9 @@ function calcs.reducePoolsByDamage(poolTable, damageTable, actor)
 		if output.FrostShieldLife then
 			alliesTakenBeforeYou["frostShield"] = { remaining = output.FrostShieldLife, percent = output.FrostShieldDamageMitigation / 100 }
 		end
+		if output.TotalMinionLife then
+			alliesTakenBeforeYou["minion"] = { remaining = output.TotalMinionLife, percent = output.MinionAllyDamageMitigation / 100 }
+		end
 		if output.TotalSpectreLife then
 			alliesTakenBeforeYou["spectres"] = { remaining = output.TotalSpectreLife, percent = output.SpectreAllyDamageMitigation / 100 }
 		end
@@ -417,6 +420,9 @@ local function incomingDamageBreakdown(breakdownTable, poolsRemaining, output)
 	--region Breakdown inserts
 	if output.FrostShieldLife and output.FrostShieldLife > 0 then
 		t_insert(breakdownTable, s_format("\t%d "..colorCodes.GEM.."Frost Shield Life ^7(%d remaining)", output.FrostShieldLife - poolsRemaining.AlliesTakenBeforeYou["frostShield"].remaining, poolsRemaining.AlliesTakenBeforeYou["frostShield"].remaining))
+	end
+	if output.TotalMinionLife and output.TotalMinionLife > 0 then
+		t_insert(breakdownTable, s_format("\t%d "..colorCodes.GEM.."Total Minion Life ^7(%d remaining)", output.TotalMinionLife - poolsRemaining.AlliesTakenBeforeYou["minion"].remaining, poolsRemaining.AlliesTakenBeforeYou["minion"].remaining))
 	end
 	if output.TotalSpectreLife and output.TotalSpectreLife > 0 then
 		t_insert(breakdownTable, s_format("\t%d "..colorCodes.GEM.."Total Spectre Life ^7(%d remaining)", output.TotalSpectreLife - poolsRemaining.AlliesTakenBeforeYou["spectres"].remaining, poolsRemaining.AlliesTakenBeforeYou["spectres"].remaining))
@@ -2445,6 +2451,12 @@ function calcs.buildDefenceEstimations(env, actor)
 			}
 		end
 		
+		-- from Minion
+		output["MinionAllyDamageMitigation"] = modDB:Sum("BASE", nil, "takenFromMinionBeforeYou")
+		if output["MinionAllyDamageMitigation"] ~= 0 then
+			output["TotalMinionLife"] = modDB:Sum("BASE", nil, "Multiplier:MinionLife")
+		end
+		
 		-- from spectres
 		output["SpectreAllyDamageMitigation"] = modDB:Sum("BASE", nil, "takenFromSpectresBeforeYou")
 		if output["SpectreAllyDamageMitigation"] ~= 0 then
@@ -2561,6 +2573,9 @@ function calcs.buildDefenceEstimations(env, actor)
 		local alliesTakenBeforeYou = {}
 		if output.FrostShieldLife then
 			alliesTakenBeforeYou["frostShield"] = { remaining = output.FrostShieldLife, percent = output.FrostShieldDamageMitigation / 100 }
+		end
+		if output.TotalMinionLife then
+			alliesTakenBeforeYou["minion"] = { remaining = output.TotalMinionLife, percent = output.MinionAllyDamageMitigation / 100 }
 		end
 		if output.TotalSpectreLife then
 			alliesTakenBeforeYou["spectres"] = { remaining = output.TotalSpectreLife, percent = output.SpectreAllyDamageMitigation / 100 }
@@ -3122,6 +3137,11 @@ function calcs.buildDefenceEstimations(env, actor)
 			if output["FrostShieldLife"] > 0 then
 				local poolProtected = output["FrostShieldLife"] / (output["FrostShieldDamageMitigation"] / 100) * (1 - output["FrostShieldDamageMitigation"] / 100)
 				output[damageType.."TotalHitPool"] = m_max(output[damageType.."TotalHitPool"] - poolProtected, 0) + m_min(output[damageType.."TotalHitPool"], poolProtected) / (1 - output["FrostShieldDamageMitigation"] / 100)
+			end
+			-- minions
+			if output["TotalMinionLife"] and output["TotalMinionLife"] > 0 then
+				local poolProtected = output["TotalMinionLife"] / (output["MinionAllyDamageMitigation"] / 100) * (1 - output["MinionAllyDamageMitigation"] / 100)
+				output[damageType.."TotalHitPool"] = m_max(output[damageType.."TotalHitPool"] - poolProtected, 0) + m_min(output[damageType.."TotalHitPool"], poolProtected) / (1 - output["MinionAllyDamageMitigation"] / 100)
 			end
 			-- spectres
 			if output["TotalSpectreLife"] and output["TotalSpectreLife"] > 0 then
@@ -3763,6 +3783,10 @@ function calcs.buildDefenceEstimations(env, actor)
 			if resourcesLost.frostShield then
 				resourcesLostSum = resourcesLostSum + resourcesLost.frostShield
 				t_insert(breakdownTable, s_format("\t%d "..colorCodes.GEM.."Frost Shield Life", resourcesLost.frostShield))
+			end
+			if resourcesLost.minion then
+				resourcesLostSum = resourcesLostSum + resourcesLost.minion
+				t_insert(breakdownTable, s_format("\t%d "..colorCodes.GEM.."Total Minion Life", resourcesLost.minion))
 			end
 			if resourcesLost.spectres then
 				resourcesLostSum = resourcesLostSum + resourcesLost.spectres

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1338,6 +1338,7 @@ function calcs.perform(env, skipEHP)
 					env.player.modDB:NewMod("Multiplier:NonVaalSummonedMinion", "BASE", output[activeSkill.minion.minionData.limit], "Config", { type = "Condition", var = "Combat" })
 				end
 				minionCount[activeSkill.minion.minionData.limit] = true
+				t_insert(minionCount, activeSkill.minion.minionData.limit)
 			end
 		end
 		if activeSkill.skillTypes[SkillType.CreatesMinion] and not activeSkill.skillTypes[SkillType.MinionsAreUndamagable] then
@@ -1368,6 +1369,10 @@ function calcs.perform(env, skipEHP)
 			activeSkill.infoMessage = "Triggered by a Crit from The Saviour"
 			activeSkill.infoTrigger = "Saviour"
 		end
+	end
+
+	if #minionCount == 1 then
+		modDB.conditions["OnlyMinion"] = true
 	end
 
 	-- Special Rarity / Quantity Calc for Bisco's


### PR DESCRIPTION
### Description of the problem being solved:
Uses the minion count code to see if more than one minion type exists and if it does then the support no longer grants it's affect to the minion
Was unsure if we wanted to also then limit the max count for that minion in the sidebar too but I don't think it really matters

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/di6gh30u

### Before screenshot:
<img width="743" height="208" alt="image" src="https://github.com/user-attachments/assets/c1fe906f-e44f-401c-bed3-53da827d1cd6" />

### After screenshot:
<img width="735" height="256" alt="image" src="https://github.com/user-attachments/assets/19315ec2-2203-4534-a2c2-11bf8e5e59a6" />
