### PR TITLE
Remove "m_floor" step from breach ring aura effect calculation.

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1411,7 +1411,7 @@ function calcs.perform(env, skipEHP)
 			for _, value in ipairs(modDB:Tabulate("INC", { }, element .. "Damage")) do
 				local mod = value.mod
 				local modifiers = calcLib.getConvertedModTags(mod, multiplier, true)
-				local converted = m_floor(mod.value * multiplier)
+				local converted = mod.value * multiplier
 				if limit and converted > 0 then
 					local remaining = limit - totalConverted
 					if remaining <= 0 then


### PR DESCRIPTION
Fixes #9721 

### Description of the problem being solved:
Small converted values (< 1) were being incorrectly discarded during the **per-mod conversion step** for Breach ring Aura Effect scaling (e.g. `"Auras from ... at (10-15)% of their value, up to a maximum of 150%"`).

The issue occurred because each individual damage source was:
1. converted independently (`mod.value * multiplier`)
2. immediately truncated using `m_floor`
3. only then accumulated into the final total

This caused loss of fractional contributions from small sources.

### Steps taken to verify a working solution:
- Confirmed that small-value contributions now correctly accumulate
- Observed expected scaling changes in Aura Effect totals
- Verified DPS differences in provided builds

### Link to a build that showcases this PR:
These PoB are the same provided in the issue.
1- https://pobb.in/zBPqbSTWQ5do - After the changes it is noticeable the damage increase lost because of the round step in the aura effect calculation process.
_(From Hit DPS: 1,341,983,007.8 to Hit DPS: 1,431,909,704.3, in both cases the item "The Will of Xoph" were equipped)_

2- https://pobb.in/1evKsFjeHOuN - Here it is possible to see the increases from smaller values.
_(From Aura Effect Mod: x1.15 to Aura Effect Mod: x1.45, no changes to the build were made)_

### Before screenshot:
**PoB 1, Scenario were the round step is ENABLED**
<img width="1517" height="937" alt="with_round_use_case" src="https://github.com/user-attachments/assets/0ece8113-45ec-47f3-8330-cef44aa1adbb" />

**PoB 2, Scenario were the round step is ENABLED**
<img width="1517" height="937" alt="with_round_aura_effect" src="https://github.com/user-attachments/assets/5d828db8-f24a-4d5f-aa44-4346d557ea7c" />

### After screenshot:
**PoB 1, Scenario were the round step is REMOVED**
<img width="1517" height="937" alt="without_round_use_case" src="https://github.com/user-attachments/assets/1af180d4-d213-478f-97f1-49563682f969" />

**PoB 2, Scenario were the round step is REMOVED**
<img width="1629" height="896" alt="without_round_aura_effect" src="https://github.com/user-attachments/assets/303d30fd-fba8-4fca-811c-f2e9e4fd12f5" />
