### PR TITLE
Fix Blade Blast default stage cap

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -100,6 +100,38 @@ describe("TestAttacks", function()
 		assert.True(build.calcsTab.mainEnv.enemyDB:Sum("BASE", nil, "FireResist") < 0)
 	end)
 
+	it("Defaults Blade Blast to the skill's blade cap", function()
+		build.skillsTab:PasteSocketGroup("Blade Blast 20/0  1\n")
+		runCallback("OnFrame")
+
+		local mainSocketGroup = build.skillsTab.socketGroupList[build.mainSocketGroup]
+		local activeSkill = mainSocketGroup.displaySkillList[mainSocketGroup.mainActiveSkill]
+		local calcsSkillSelectControls = build.calcsTab.sectionList[1].controls
+		build:RefreshSkillSelectControls(calcsSkillSelectControls, build.calcsTab.input.skill_number, "Calcs")
+
+		assert.are.equals("50", build.controls.mainSkillStageCount.buf)
+		assert.are.equals("50", calcsSkillSelectControls.mainSkillStageCount.buf)
+		assert.are.equals(50, activeSkill.skillData.stagesMax)
+		assert.are.equals(50, activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "Multiplier:BladeBlastStage"))
+		assert.are.equals(49, activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "Multiplier:BladeBlastStageAfterFirst"))
+
+		local cappedAverageDamage = build.calcsTab.mainOutput.AverageDamage
+		local cappedTotalDPS = build.calcsTab.mainOutput.TotalDPS
+		local cappedCombinedDPS = build.calcsTab.mainOutput.CombinedDPS
+		activeSkill.activeEffect.srcInstance.skillStageCount = 51
+		build.modFlag = true
+		build.buildFlag = true
+		runCallback("OnFrame")
+
+		activeSkill = mainSocketGroup.displaySkillList[mainSocketGroup.mainActiveSkill]
+		assert.are.equals("51", build.controls.mainSkillStageCount.buf)
+		assert.are.equals(50, activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "Multiplier:BladeBlastStage"))
+		assert.are.equals(49, activeSkill.skillModList:Sum("BASE", activeSkill.skillCfg, "Multiplier:BladeBlastStageAfterFirst"))
+		assert.are.equals(cappedAverageDamage, build.calcsTab.mainOutput.AverageDamage)
+		assert.are.equals(cappedTotalDPS, build.calcsTab.mainOutput.TotalDPS)
+		assert.are.equals(cappedCombinedDPS, build.calcsTab.mainOutput.CombinedDPS)
+	end)
+
 	it("Test Adrenaline affecting blight max stage count", function()
 		build.skillsTab:PasteSocketGroup("Blight 20/0  1\n")
 		runCallback("OnFrame")

--- a/src/Data/Skills/act_dex.lua
+++ b/src/Data/Skills/act_dex.lua
@@ -1382,7 +1382,7 @@ skills["BladeBlast"] = {
 		area = true,
 	},
 	baseMods = {
-		mod("Multiplier:BladeBlastMaxStages", "BASE", 900, 0, 0),
+		mod("Multiplier:BladeBlastMaxStages", "BASE", 50, 0, 0),
 		skill("dpsBaseMultiplier", 1, { type = "Multiplier", var = "BladeBlastStage" }),
 	},
 	qualityStats = {

--- a/src/Export/Skills/act_dex.txt
+++ b/src/Export/Skills/act_dex.txt
@@ -237,7 +237,7 @@ local skills, mod, flag, skill = ...
 			activeSkill.skillData.hitTimeOverride = 1
 		end
 	end,
-#baseMod mod("Multiplier:BladeBlastMaxStages", "BASE", 900, 0, 0)
+#baseMod mod("Multiplier:BladeBlastMaxStages", "BASE", 50, 0, 0)
 #baseMod skill("dpsBaseMultiplier", 1, { type = "Multiplier", var = "BladeBlastStage" })
 #mods
 


### PR DESCRIPTION
### Description of the problem being solved

Fixes #9836.

Blade Blast was modeled with `Multiplier:BladeBlastMaxStages` set to 900. I aligned the internal value to the tooltip's so #9728 works as intended.

### Steps taken to verify a working solution

- Verified a fresh Blade Blast skill now defaults to 50 stages in the sidebar and Calcs skill controls.
- Added regression coverage setting Blade Blast to 51 stages to confirm damage doesn't increase past the 50-stage cap.
