### PR TITLE
Fix Heroic Tragedy variants not being correct in Timeless list

### DIFF
--- a/src/Classes/TimelessJewelListControl.lua
+++ b/src/Classes/TimelessJewelListControl.lua
@@ -231,7 +231,7 @@ Limited to: 1 Historic
 Variant: Cadiro (Supreme Decadence)
 Variant: Victario (Supreme Grandstanding)
 Variant: Caspiro (Supreme Ostentation)
-Selected Variant:  ]] .. variant .. "\n" .. [[
+Selected Variant: ]] .. variant .. "\n" .. [[
 Radius: Large
 Implicits: 0
 {variant:1}Commissioned ]] .. data.seed .. [[ coins to commemorate Cadiro

--- a/src/Classes/TimelessJewelListControl.lua
+++ b/src/Classes/TimelessJewelListControl.lua
@@ -102,7 +102,7 @@ Limited to: 1 Historic
 Variant: Vorana (Black Scythe Training)
 Variant: Uhtred (Celestial Mathematics)
 Variant: Medved (The Unbreaking Circle)
-Selected Variant:  ]] .. variant .. "\n" .. [[
+Selected Variant: ]] .. variant .. "\n" .. [[
 Radius: Large
 Implicits: 0
 {variant:1}Remembrancing ]] .. data.seed .. [[ songworthy deeds by the line of Vorana


### PR DESCRIPTION
Fixes #9842 .

### Description of the problem being solved:

The `Selected Variant: n` line had a double space, which caused the variant to always be Medved. Elegant Hubris also seemed to have the same problem.

### Steps taken to verify a working solution:
- Importing vorana and uhtred tested
