### PR TITLE
Add abyss sockets to comparison tab

### DIFF
--- a/src/Classes/CompareTab.lua
+++ b/src/Classes/CompareTab.lua
@@ -2657,19 +2657,64 @@ function CompareTabClass:ComparePowerBuilder(compareEntry, powerStat, categories
 			if cItem and cItem.raw and not (pItem and pItem.name == cItem.name) then
 				local newItem = new("Item", cItem.raw)
 				newItem:NormaliseQuality()
+				
+				-- if our comparison has abyssal jewels, but the primary build
+				-- doesn't, add those temporarily to the build to work around
+				-- calcfunc not being able to take in multiple items
+				local cmpJewels = {}
+				local oldEquipped = {}
+				if newItem.abyssalSocketCount > 0 then
+					for idx = 1, newItem.abyssalSocketCount do
+						local abyssSlotName = string.format("%s Abyssal Socket %d", slotName, idx)
+						local cmpJewelSlot = compareEntry.itemsTab.slots[abyssSlotName]
+						-- save old id and unequip existing
+						oldEquipped[abyssSlotName] = self.primaryBuild.itemsTab.slots[abyssSlotName]
+						self.primaryBuild.itemsTab.slots[abyssSlotName]:SetSelItemId(0)
+						if cmpJewelSlot.selItemId > 0 then
+							local cmpJewel = compareEntry.itemsTab.items[cmpJewelSlot.selItemId]
+							-- due to a previous bug where jewel slots didn't
+							-- get cleared when becoming inactive, so the item
+							-- might not exist
+							if cmpJewel then
+								-- copy item
+								local itemCopy = new("Item", cmpJewel:BuildRaw())
+								table.insert(cmpJewels, itemCopy)
+								self.primaryBuild.itemsTab:AddItem(itemCopy, false)
+
+								-- equip copied
+								self.primaryBuild.itemsTab.slots[abyssSlotName]:SetSelItemId(itemCopy.id)
+							end
+						end
+					end
+				end
+
+
 				local output = calcFunc({ repSlotName = slotName, repItem = newItem }, useFullDPS)
 				local impact = self.primaryBuild.calcsTab:CalculatePowerStat(powerStat, output, calcBase)
 				local impactStr, impactVal, combinedImpactStr, impactPercent, impactIsZero = formatImpact(impact)
+
+				-- restore abyss jewel state
+				if newItem.abyssalSocketCount > 0 then
+					for k, v in pairs(oldEquipped) do
+						self.primaryBuild.itemsTab.slots[k]:SetSelItemId(v)
+					end
+					for _, item in ipairs(cmpJewels) do
+						self.primaryBuild.itemsTab:DeleteItem(item)
+					end
+				end
 
 				if not impactIsZero then
 					-- Get rarity color for item name
 					local rarityColor = colorCodes[cItem.rarity] or colorCodes.NORMAL
 
+
+					local abyssJewelText = #cmpJewels > 0 and
+						s_format(", %d Jewel%s", #cmpJewels, #cmpJewels > 1 and "s" or "") or ""
 					t_insert(results, {
 						category = "Item",
 						categoryColor = rarityColor,
 						nameColor = rarityColor,
-						name = (cItem.name or "Unknown") .. ", " .. slotName,
+						name = (cItem.name or "Unknown") .. ", " .. slotName .. abyssJewelText,
 						itemObj = newItem,
 						slotName = slotName,
 						impact = impactVal,

--- a/src/Classes/CompareTab.lua
+++ b/src/Classes/CompareTab.lua
@@ -2668,8 +2668,9 @@ function CompareTabClass:ComparePowerBuilder(compareEntry, powerStat, categories
 						local abyssSlotName = string.format("%s Abyssal Socket %d", slotName, idx)
 						local cmpJewelSlot = compareEntry.itemsTab.slots[abyssSlotName]
 						-- save old id and unequip existing
-						oldEquipped[abyssSlotName] = self.primaryBuild.itemsTab.slots[abyssSlotName]
-						self.primaryBuild.itemsTab.slots[abyssSlotName]:SetSelItemId(0)
+						local primaryJewelSlot = self.primaryBuild.itemsTab.slots[abyssSlotName]
+						oldEquipped[abyssSlotName] = primaryJewelSlot.selItemId
+						primaryJewelSlot:SetSelItemId(0)
 						if cmpJewelSlot.selItemId > 0 then
 							local cmpJewel = compareEntry.itemsTab.items[cmpJewelSlot.selItemId]
 							-- due to a previous bug where jewel slots didn't

--- a/src/Classes/CompareTab.lua
+++ b/src/Classes/CompareTab.lua
@@ -2478,26 +2478,8 @@ function CompareTabClass:ComparePowerBuilder(compareEntry, powerStat, categories
 			t_insert(baseSlots, 10, "Ring 3")
 		end
 
-		-- abyssal sockets
-		local socketSet = {}
-		local function saveActiveAbyssSocket(k, v)
-			if type(k) == "string" and k:match("Abyssal Socket")
-				and v.shown() then
-				socketSet[k] = (socketSet[k] or 0) + 1
-			end
-		end
-		for k, v in pairs(compareEntry.itemsTab.slots) do
-			saveActiveAbyssSocket(k, v)
-		end
-		for k, v in pairs(self.primaryBuild.itemsTab.slots) do
-			saveActiveAbyssSocket(k, v)
-		end
-		-- consider only if both have the socket allocated
-		for k, count in pairs(socketSet) do
-			if count == 2 then
-				t_insert(baseSlots, k)
-			end
-		end
+		-- we only use jewel slots if both sides have them available
+		self:AddAbyssSockets(compareEntry, baseSlots, true)
 		
 		for _, slotName in ipairs(baseSlots) do
 			local cSlot = compareEntry.itemsTab and compareEntry.itemsTab.slots[slotName]
@@ -2664,27 +2646,9 @@ function CompareTabClass:ComparePowerBuilder(compareEntry, powerStat, categories
 			t_insert(baseSlots, 10, "Ring 3")
 		end
 
-		-- abyssal sockets
-		local socketSet = {}
-		local function saveActiveAbyssSocket(k, v)
-			if type(k) == "string" and k:match("Abyssal Socket")
-				and v.shown() then
-				socketSet[k] = (socketSet[k] or 0) + 1
-			end
-		end
-		for k, v in pairs(compareEntry.itemsTab.slots) do
-			saveActiveAbyssSocket(k, v)
-		end
-		for k, v in pairs(self.primaryBuild.itemsTab.slots) do
-			saveActiveAbyssSocket(k, v)
-		end
-		-- consider only if both have the socket allocated
-		for k, count in pairs(socketSet) do
-			if count == 2 then
-				t_insert(baseSlots, k)
-			end
-		end
-
+		-- we only use jewel slots if both sides have them available
+		self:AddAbyssSockets(compareEntry, baseSlots, true)
+		
 		for _, slotName in ipairs(baseSlots) do
 			local cSlot = compareEntry.itemsTab and compareEntry.itemsTab.slots[slotName]
 			local cItem = cSlot and compareEntry.itemsTab.items[cSlot.selItemId]
@@ -3589,30 +3553,32 @@ function CompareTabClass:ShouldShowRing3(compareEntry)
 	return primaryHas or compareHas
 end
 
+--- @param comparison table
+--- @param destTable string[]
+--- @param requireBothSides boolean
+function CompareTabClass:AddAbyssSockets(comparison, destTable, requireBothSides)
+	local equipmentSlots = {"Weapon 1", "Weapon 2", "Helmet", "Body Armour", "Gloves", "Boots", "Belt"}
+
+	for _, slot in ipairs(equipmentSlots) do
+		for number = 1, 6 do
+			local abyssalSocketName = string.format("%s Abyssal Socket %d", slot, number)
+			local mainHas = self.primaryBuild.itemsTab.slots[abyssalSocketName].shown()
+			local comparisonHas = comparison.itemsTab.slots[abyssalSocketName].shown()
+			if (requireBothSides and mainHas and comparisonHas)
+				or ((not requireBothSides) and (mainHas or comparisonHas)) then
+				table.insert(destTable, abyssalSocketName)
+			end
+		end
+	end
+end
+
 function CompareTabClass:DrawItems(vp, compareEntry, inputEvents)
 	local baseSlots = { "Weapon 1", "Weapon 2", "Helmet", "Body Armour", "Gloves", "Boots", "Amulet", "Ring 1", "Ring 2", "Belt", "Flask 1", "Flask 2", "Flask 3", "Flask 4", "Flask 5" }
 	if self:ShouldShowRing3(compareEntry) then
 		t_insert(baseSlots, 10, "Ring 3")
 	end
 
-	-- abyssal sockets
-	local socketSet = {}
-	local function saveActiveAbyssSocket(k, v)
-		if type(k) == "string" and k:match("Abyssal Socket")
-			and v.shown() then
-			socketSet[k] = true
-		end
-	end
-	for k, v in pairs(compareEntry.itemsTab.slots) do
-		saveActiveAbyssSocket(k, v)
-	end
-	for k, v in pairs(self.primaryBuild.itemsTab.slots) do
-		saveActiveAbyssSocket(k, v)
-	end
-	-- show if either has a socket allocated
-	for k, _ in pairs(socketSet) do
-		t_insert(baseSlots, k)
-	end
+	self:AddAbyssSockets(compareEntry, baseSlots, false)
 
 	local primaryEnv = self.primaryBuild.calcsTab and self.primaryBuild.calcsTab.mainEnv
 	local primaryHasRing3 = primaryEnv and primaryEnv.modDB:Flag(nil, "AdditionalRingSlot")

--- a/src/Classes/CompareTab.lua
+++ b/src/Classes/CompareTab.lua
@@ -3550,6 +3550,25 @@ function CompareTabClass:DrawItems(vp, compareEntry, inputEvents)
 	if self:ShouldShowRing3(compareEntry) then
 		t_insert(baseSlots, 10, "Ring 3")
 	end
+
+	-- abyssal sockets
+	local socketSet = {}
+	local function saveActiveAbyssSocket(k, v)
+		if type(k) == "string" and k:match("Abyssal Socket")
+			and v.selItemId and v.selItemId ~= 0 then
+			socketSet[k] = true
+		end
+	end
+	for k, v in pairs(compareEntry.itemsTab.activeItemSet) do
+		saveActiveAbyssSocket(k, v)
+	end
+	for k, v in pairs(self.primaryBuild.itemsTab.activeItemSet) do
+		saveActiveAbyssSocket(k, v)
+	end
+	for k, _ in pairs(socketSet) do
+		t_insert(baseSlots, k)
+	end
+
 	local primaryEnv = self.primaryBuild.calcsTab and self.primaryBuild.calcsTab.mainEnv
 	local primaryHasRing3 = primaryEnv and primaryEnv.modDB:Flag(nil, "AdditionalRingSlot")
 	local lineHeight = 20

--- a/src/Classes/CompareTab.lua
+++ b/src/Classes/CompareTab.lua
@@ -2477,6 +2477,28 @@ function CompareTabClass:ComparePowerBuilder(compareEntry, powerStat, categories
 		if self:ShouldShowRing3(compareEntry) then
 			t_insert(baseSlots, 10, "Ring 3")
 		end
+
+		-- abyssal sockets
+		local socketSet = {}
+		local function saveActiveAbyssSocket(k, v)
+			if type(k) == "string" and k:match("Abyssal Socket")
+				and v.shown() then
+				socketSet[k] = (socketSet[k] or 0) + 1
+			end
+		end
+		for k, v in pairs(compareEntry.itemsTab.slots) do
+			saveActiveAbyssSocket(k, v)
+		end
+		for k, v in pairs(self.primaryBuild.itemsTab.slots) do
+			saveActiveAbyssSocket(k, v)
+		end
+		-- consider only if both have the socket allocated
+		for k, count in pairs(socketSet) do
+			if count == 2 then
+				t_insert(baseSlots, k)
+			end
+		end
+		
 		for _, slotName in ipairs(baseSlots) do
 			local cSlot = compareEntry.itemsTab and compareEntry.itemsTab.slots[slotName]
 			local cItem = cSlot and compareEntry.itemsTab.items[cSlot.selItemId]
@@ -2641,6 +2663,28 @@ function CompareTabClass:ComparePowerBuilder(compareEntry, powerStat, categories
 		if self:ShouldShowRing3(compareEntry) then
 			t_insert(baseSlots, 10, "Ring 3")
 		end
+
+		-- abyssal sockets
+		local socketSet = {}
+		local function saveActiveAbyssSocket(k, v)
+			if type(k) == "string" and k:match("Abyssal Socket")
+				and v.shown() then
+				socketSet[k] = (socketSet[k] or 0) + 1
+			end
+		end
+		for k, v in pairs(compareEntry.itemsTab.slots) do
+			saveActiveAbyssSocket(k, v)
+		end
+		for k, v in pairs(self.primaryBuild.itemsTab.slots) do
+			saveActiveAbyssSocket(k, v)
+		end
+		-- consider only if both have the socket allocated
+		for k, count in pairs(socketSet) do
+			if count == 2 then
+				t_insert(baseSlots, k)
+			end
+		end
+
 		for _, slotName in ipairs(baseSlots) do
 			local cSlot = compareEntry.itemsTab and compareEntry.itemsTab.slots[slotName]
 			local cItem = cSlot and compareEntry.itemsTab.items[cSlot.selItemId]
@@ -3555,16 +3599,17 @@ function CompareTabClass:DrawItems(vp, compareEntry, inputEvents)
 	local socketSet = {}
 	local function saveActiveAbyssSocket(k, v)
 		if type(k) == "string" and k:match("Abyssal Socket")
-			and v.selItemId and v.selItemId ~= 0 then
+			and v.shown() then
 			socketSet[k] = true
 		end
 	end
-	for k, v in pairs(compareEntry.itemsTab.activeItemSet) do
+	for k, v in pairs(compareEntry.itemsTab.slots) do
 		saveActiveAbyssSocket(k, v)
 	end
-	for k, v in pairs(self.primaryBuild.itemsTab.activeItemSet) do
+	for k, v in pairs(self.primaryBuild.itemsTab.slots) do
 		saveActiveAbyssSocket(k, v)
 	end
+	-- show if either has a socket allocated
 	for k, _ in pairs(socketSet) do
 		t_insert(baseSlots, k)
 	end

--- a/src/Classes/CompareTab.lua
+++ b/src/Classes/CompareTab.lua
@@ -3602,8 +3602,8 @@ end
 --- @param destTable string[]
 --- @param requireBothSides boolean
 function CompareTabClass:AddAbyssSockets(comparison, destTable, requireBothSides)
-	local equipmentSlots = {"Weapon 1", "Weapon 2", "Helmet", "Body Armour", "Gloves", "Boots", "Belt"}
-
+	local equipmentSlots = { "Weapon 1", "Weapon 2", "Weapon 1 Swap", "Weapon 2 Swap", "Helmet", "Body Armour", "Gloves",
+		"Boots", "Belt" }
 	for _, slot in ipairs(equipmentSlots) do
 		for number = 1, 6 do
 			local abyssalSocketName = string.format("%s Abyssal Socket %d", slot, number)
@@ -3618,7 +3618,8 @@ function CompareTabClass:AddAbyssSockets(comparison, destTable, requireBothSides
 end
 
 function CompareTabClass:DrawItems(vp, compareEntry, inputEvents)
-	local baseSlots = { "Weapon 1", "Weapon 2", "Helmet", "Body Armour", "Gloves", "Boots", "Amulet", "Ring 1", "Ring 2", "Belt", "Flask 1", "Flask 2", "Flask 3", "Flask 4", "Flask 5" }
+	local baseSlots = { "Weapon 1", "Weapon 2", "Weapon 1 Swap", "Weapon 2 Swap", "Helmet", "Body Armour", "Gloves",
+		"Boots", "Amulet", "Ring 1", "Ring 2", "Belt", "Flask 1", "Flask 2", "Flask 3", "Flask 4", "Flask 5" }
 	if self:ShouldShowRing3(compareEntry) then
 		t_insert(baseSlots, 10, "Ring 3")
 	end

--- a/src/Classes/ItemSlotControl.lua
+++ b/src/Classes/ItemSlotControl.lua
@@ -102,6 +102,11 @@ function ItemSlotClass:Populate()
 	end
 	for i, abyssalSocket in ipairs(self.abyssalSocketList) do
 		abyssalSocket.inactive = i > abyssalSocketCount
+		if abyssalSocket.inactive then
+			-- this can be inconvenient, but otherwise it is possible to double
+			-- equip jewels by moving the jewel while the socket is inactive
+			abyssalSocket:SetSelItemId(0)
+		end
 	end
 end
 


### PR DESCRIPTION
Fixes lack of abyss sockets in comparison tab.

### Steps taken to verify a working solution:
- Manual testing with the following profile

### Link to a build that showcases this PR:

https://pobb.in/d6CYO2E54PHy

### After screenshot:
<img width="838" height="356" alt="image" src="https://github.com/user-attachments/assets/d7e5ca4b-46d6-44ab-b54b-c3d4dba4eedd" />
<img width="1193" height="545" alt="image" src="https://github.com/user-attachments/assets/07531998-7562-43e1-a635-acd3feeb51ed" />

