### PR TITLE
Fix impale DPS with zero duration

### DIFF
--- a/spec/System/TestImpale_spec.lua
+++ b/spec/System/TestImpale_spec.lua
@@ -58,6 +58,20 @@ describe("TestAttacks", function()
 		assert.are.equals(150*1.3, build.calcsTab.mainOutput.ImpaleDPS) -- 5 impales * 10% stored damage * 1.3 attacks per second
 	end)
 
+	it("impale with zero duration has zero dps", function()
+		build.configTab.input.customMods = "\z
+		never deal critical strikes\n\z
+		Impale Damage dealt to Enemies Impaled by you Overwhelms 100% Physical Damage Reduction\n\z
+		Overwhelm 100% physical damage reduction\n\z
+		100% less Impale Duration\n\z
+		"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(0, build.calcsTab.mainOutput.ImpaleDuration)
+		assert.are.equals(0, build.calcsTab.mainOutput.ImpaleDPS)
+	end)
+
 	it("impale with inc damage taken", function()
 		-- 0% crit
 		build.configTab.input.customMods = "\z

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -5875,7 +5875,7 @@ function calcs.offence(env, actor, activeSkill)
 			output.ImpaleDPS = output.impaleStoredHitAvg * ((output.ImpaleModifier or 1) - 1) * output.HitChance / 100 * skillData.dpsMultiplier
 		end
 		if output.ImpaleDuration <= 0 then
-    		output.ImpaleDPS = 0
+			output.ImpaleDPS = 0
 		end
 		if skillData.showAverage then
 			output.WithImpaleDPS = output.AverageDamage + output.ImpaleDPS

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -5918,6 +5918,9 @@ function calcs.offence(env, actor, activeSkill)
 		if quantityMultiplier > 1 then
 			t_insert(breakdown.ImpaleDPS, s_format("x %g ^8(quantity multiplier for this skill)", quantityMultiplier))
 		end
+		if output.ImpaleDuration <= 0 then
+			t_insert(breakdown.ImpaleDPS, s_format("x 0 ^8(no Impale Duration)"))
+		end
 		t_insert(breakdown.ImpaleDPS, s_format("= %.1f", output.ImpaleDPS))
 		end
 	end

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -5874,6 +5874,9 @@ function calcs.offence(env, actor, activeSkill)
 		else
 			output.ImpaleDPS = output.impaleStoredHitAvg * ((output.ImpaleModifier or 1) - 1) * output.HitChance / 100 * skillData.dpsMultiplier
 		end
+		if output.ImpaleDuration <= 0 then
+    		output.ImpaleDPS = 0
+		end
 		if skillData.showAverage then
 			output.WithImpaleDPS = output.AverageDamage + output.ImpaleDPS
 			output.CombinedAvg = output.CombinedAvg + output.ImpaleDPS


### PR DESCRIPTION
Adds tests for zero impale duration and prevents ImpaleDPS from contributing when ImpaleDuration is 0.

Fixes #9499 .

### Description of the problem being solved:

Impale DPS was still being calculated and displayed when Impale Duration was 0.

### Steps taken to verify a working solution:
- Added a test for zero Impale Duration.
- Ran `busted --lua=luajit`
  - Result: 225 successes / 0 failures / 0 errors / 0 pending
- Imported the build from #9499  and verified the behavior before and after the change.
- Confirmed Impale Duration = 0s and Impale DPS = 0 after the fix.

### Link to a build that showcases this PR:
`https://pobb.in/zjvK1N9gCoT8`
### Before screenshot:
<img width="686" height="252" alt="image" src="https://github.com/user-attachments/assets/953d3c54-d26c-4720-9195-da459f5b8d04" />
<img width="682" height="201" alt="image" src="https://github.com/user-attachments/assets/a5f9ae63-fb8b-4361-b313-b07f22871f3e" />
<img width="567" height="213" alt="image" src="https://github.com/user-attachments/assets/0fcba2d6-299c-49e6-a2c8-d4a4ccde0a57" />


### After screenshot:
<img width="679" height="239" alt="image" src="https://github.com/user-attachments/assets/7fe9368f-ca97-426d-afdd-17b23edf921d" />
<img width="686" height="250" alt="image" src="https://github.com/user-attachments/assets/6c79b671-ce1b-4024-adba-39d97494b061" />
<img width="563" height="248" alt="image" src="https://github.com/user-attachments/assets/a03a2c1f-bae8-4201-8639-0cf34c783200" />


