### PR TITLE
Set anchor collapse on comparison tab collectors

### DIFF
--- a/spec/System/TestCompareTab_spec.lua
+++ b/spec/System/TestCompareTab_spec.lua
@@ -1,0 +1,25 @@
+describe("CompareTab", function()
+	it("hides skill detail controls after removing the final comparison", function()
+		newBuild()
+		local compareTab = build.compareTab
+		compareTab.compareEntries = { { label = "Test" } }
+		compareTab.activeCompareIndex = 1
+		local controls = {
+			compareTab.controls.cmpMainSkill,
+			compareTab.controls.cmpSkillPart,
+			compareTab.controls.cmpStageCount,
+			compareTab.controls.cmpMineCount,
+			compareTab.controls.cmpMinion,
+			compareTab.controls.cmpMinionSkill,
+		}
+		for _, control in ipairs(controls) do
+			control.shown = true
+		end
+
+		compareTab:RemoveBuild(1)
+
+		for _, control in ipairs(controls) do
+			assert.is_false(control:IsShown())
+		end
+	end)
+end)

--- a/src/Classes/CompareTab.lua
+++ b/src/Classes/CompareTab.lua
@@ -344,6 +344,7 @@ function CompareTabClass:InitControls()
 	-- ============================================================
 	self.controls.cmpSkillLabel = new("LabelControl", {"TOPLEFT", self.controls.subTabAnchor, "TOPLEFT"}, {0, -32, 0, 16}, "^7Skill:")
 	self.controls.cmpSkillLabel.shown = setsEnabled
+	self.controls.cmpSkillLabel.anchor.collapse = true
 
 	-- Socket group dropdown
 	self.controls.cmpSocketGroup = new("DropDownControl", {"LEFT", self.controls.cmpSkillLabel, "RIGHT"}, {4, 0, 200, 20}, {}, function(index, value)
@@ -355,6 +356,7 @@ function CompareTabClass:InitControls()
 	self.controls.cmpSocketGroup.shown = setsEnabled
 	self.controls.cmpSocketGroup.maxDroppedWidth = 500
 	self.controls.cmpSocketGroup.enableDroppedWidth = true
+	self.controls.cmpSocketGroup.anchor.collapse = true
 
 	-- Active skill within group
 	self.controls.cmpMainSkill = new("DropDownControl", {"LEFT", self.controls.cmpSocketGroup, "RIGHT"}, {4, 0, 225, 20}, {}, function(index, value)
@@ -368,6 +370,7 @@ function CompareTabClass:InitControls()
 		end
 	end)
 	self.controls.cmpMainSkill.shown = false
+	self.controls.cmpMainSkill.anchor.collapse = true
 
 	-- Skill part (multi-part skills)
 	self.controls.cmpSkillPart = new("DropDownControl", {"LEFT", self.controls.cmpMainSkill, "RIGHT"}, {4, 0, 200, 20}, {}, function(index, value)
@@ -385,10 +388,12 @@ function CompareTabClass:InitControls()
 		end
 	end)
 	self.controls.cmpSkillPart.shown = false
+	self.controls.cmpSkillPart.anchor.collapse = true
 
 	-- Stage count
 	self.controls.cmpStageCountLabel = new("LabelControl", {"LEFT", self.controls.cmpSkillPart, "RIGHT"}, {6, 0, 0, 16}, "^7Stages:")
 	self.controls.cmpStageCountLabel.shown = function() return self.controls.cmpStageCount.shown end
+	self.controls.cmpStageCountLabel.anchor.collapse = true
 	self.controls.cmpStageCount = new("EditControl", {"LEFT", self.controls.cmpStageCountLabel, "RIGHT"}, {4, 0, 52, 20}, "", nil, "%D", 5, function(buf)
 		local entry = self:GetActiveCompare()
 		if entry then
@@ -404,10 +409,12 @@ function CompareTabClass:InitControls()
 		end
 	end)
 	self.controls.cmpStageCount.shown = false
+	self.controls.cmpStageCount.anchor.collapse = true
 
 	-- Mine count
 	self.controls.cmpMineCountLabel = new("LabelControl", {"LEFT", self.controls.cmpStageCount, "RIGHT"}, {6, 0, 0, 16}, "^7Mines:")
 	self.controls.cmpMineCountLabel.shown = function() return self.controls.cmpMineCount.shown end
+	self.controls.cmpMineCountLabel.anchor.collapse = true
 	self.controls.cmpMineCount = new("EditControl", {"LEFT", self.controls.cmpMineCountLabel, "RIGHT"}, {4, 0, 52, 20}, "", nil, "%D", 5, function(buf)
 		local entry = self:GetActiveCompare()
 		if entry then
@@ -423,6 +430,7 @@ function CompareTabClass:InitControls()
 		end
 	end)
 	self.controls.cmpMineCount.shown = false
+	self.controls.cmpMineCount.anchor.collapse = true
 
 	-- Minion selector
 	self.controls.cmpMinion = new("DropDownControl", {"LEFT", self.controls.cmpMineCount, "RIGHT"}, {6, 0, 140, 20}, {}, function(index, value)
@@ -447,6 +455,7 @@ function CompareTabClass:InitControls()
 		end
 	end)
 	self.controls.cmpMinion.shown = false
+	self.controls.cmpMinion.anchor.collapse = true
 
 	-- Minion skill selector
 	self.controls.cmpMinionSkill = new("DropDownControl", {"LEFT", self.controls.cmpMinion, "RIGHT"}, {4, 0, 140, 20}, {}, function(index, value)
@@ -464,6 +473,7 @@ function CompareTabClass:InitControls()
 		end
 	end)
 	self.controls.cmpMinionSkill.shown = false
+	self.controls.cmpMinionSkill.anchor.collapse = true
 
 	-- ============================================================
 	-- Calcs view skill detail controls (per-build, independent of sidebar & regular Calcs tab)

--- a/src/Classes/CompareTab.lua
+++ b/src/Classes/CompareTab.lua
@@ -1268,6 +1268,12 @@ function CompareTabClass:RemoveBuild(index)
 		if self.activeCompareIndex == 0 and #self.compareEntries > 0 then
 			self.activeCompareIndex = 1
 		end
+		if #self.compareEntries == 0 then
+			for _, control in ipairs({ self.controls.cmpMainSkill, self.controls.cmpSkillPart, self.controls.cmpStageCount,
+				self.controls.cmpMineCount, self.controls.cmpMinion, self.controls.cmpMinionSkill }) do
+				control.shown = false
+			end
+		end
 		self:UpdateBuildSelector()
 	end
 end


### PR DESCRIPTION
Fixes #9864.

### Description of the problem being solved:

### Steps taken to verify a working solution:
-
-
-

### Link to a build that showcases this PR:

### Before screenshot:
<img width="631" height="122" alt="image" src="https://github.com/user-attachments/assets/1cbe30a0-83dd-49f6-bfbb-2aa73715686f" />

### After screenshot:
<img width="878" height="195" alt="image" src="https://github.com/user-attachments/assets/87ced176-7acc-44f6-b2f2-a144f97361fc" />

Apparently there's already support for this in the anchor system.