### PR TITLE
Re-add Balbala variant (The Traitor) to Brutal Restraint

### DIFF
--- a/src/Data/Uniques/jewel.lua
+++ b/src/Data/Uniques/jewel.lua
@@ -1835,6 +1835,7 @@ Implicits: 0
 {variant:1}Denoted service of (500-8000) dekhara in the akhara of Asenath
 {variant:2}Denoted service of (500-8000) dekhara in the akhara of Deshret
 {variant:3}Denoted service of (500-8000) dekhara in the akhara of Nasima
+{variant:4}Denoted service of (500-8000) dekhara in the akhara of Balbala
 Passives in radius are Conquered by the Maraketh
 Historic
 ]],[[

--- a/src/Export/Uniques/jewel.lua
+++ b/src/Export/Uniques/jewel.lua
@@ -1739,6 +1739,7 @@ Implicits: 0
 {variant:1}Denoted service of (500-8000) dekhara in the akhara of Asenath
 {variant:2}Denoted service of (500-8000) dekhara in the akhara of Deshret
 {variant:3}Denoted service of (500-8000) dekhara in the akhara of Nasima
+{variant:4}Denoted service of (500-8000) dekhara in the akhara of Balbala
 Passives in radius are Conquered by the Maraketh
 Historic
 ]],[[


### PR DESCRIPTION
This variant somehow got removed with the unique export script changes. Manually added it back to `src/Export/Uniques/jewel.lua`, and ran `uModsToText` to update `src/Data/Uniques/jewel.lua`.

### Description of the problem being solved:
https://github.com/PathOfBuildingCommunity/PathOfBuilding/commit/ff5eb7ea4233817a912aaa3e6d49d81fad49b1db accidentally removed The Traitor/Balbala variant of Brutal Restraint. Adding this variant from the Uniques Item tab adds the following jewel, which does nothing:
<img width="694" height="331" alt="image" src="https://github.com/user-attachments/assets/f804d6c9-7e1a-4653-8035-0b8966e71a57" />
(Keystone not converted):
<img width="737" height="434" alt="image" src="https://github.com/user-attachments/assets/98446bd2-cd0e-4294-88ef-003d0418bc59" />


### Steps taken to verify a working solution:
- Creating the item now correctly shows the mod and seed range again:
<img width="691" height="469" alt="image" src="https://github.com/user-attachments/assets/1089a7e3-9d61-4002-964e-7372a20a006e" />

- Keystone is also transformed:
<img width="828" height="518" alt="image" src="https://github.com/user-attachments/assets/e56dfb46-b0f5-4c0a-9d6c-4b61731d0ee4" />


### Link to a build that showcases this PR:
https://pobb.in/wCZS-oePD0co

### Before screenshot:
<img width="737" height="434" alt="image" src="https://github.com/user-attachments/assets/98446bd2-cd0e-4294-88ef-003d0418bc59" />

### After screenshot:
<img width="828" height="518" alt="image" src="https://github.com/user-attachments/assets/e56dfb46-b0f5-4c0a-9d6c-4b61731d0ee4" />