### PR TITLE
Mastery Mod (Not Supported) losing relationship to mod, when assigning masteries

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -1458,15 +1458,17 @@ function PassiveTreeViewClass:AddNodeTooltip(tooltip, node, build)
 		local lineCount = 0
 		for n, effect in ipairs(mNode.masteryEffects) do
 			local existingMastery = isValueInTable(build.spec.masterySelections, effect.effect)
-			if not existingMastery then
-				effect = build.spec.tree.masteryEffects[effect.effect]
-				for _, line in ipairs(effect.sd) do
-					lineCount = lineCount + 1
+			local effectData = build.spec.tree.masteryEffects[effect.effect]
+			-- Must step through every mod, and filter out already allocated mods later 
+			-- Otherwise red not supported text applies to the wrong indexes
+			for _, line in ipairs(effectData.sd) do
+				lineCount = lineCount + 1
+				if not existingMastery then
 					addModInfoToTooltip(mNode, lineCount, line)
 				end
-				if n < #mNode.masteryEffects then
-					tooltip:AddLine(6, "")
-				end
+			end
+			if not existingMastery and n < #mNode.masteryEffects then
+				tooltip:AddLine(6, "")
 			end
 		end
 		tooltip:AddSeparator(14)


### PR DESCRIPTION
No reported Issues Fixed

### Description of the problem being solved:

When assigning masteries, the (Not Supported in PoB Yet) text loses its relationship with the underlying mod its tooltipping, if Mod 3 and Mod 4 are unsupported but mod 1 is already assigned a mastery. it simply shifts the index down

### Steps taken to verify a working solution:
1. Side by side comparison of trees in dev build vs 2.65.0.

### Link to a build that showcases this PR:
Demo tree only <https://pobb.in/Y3K_UFscbIzl>

### Before screenshot:
<img width="1119" height="609" alt="image" src="https://github.com/user-attachments/assets/037135b1-1208-4299-bb17-7141b46d74c4" />
<img width="1119" height="609" alt="image" src="https://github.com/user-attachments/assets/6337ccfe-efb6-4b81-8390-294f72091133" />

### After screenshot:

<img width="1119" height="609" alt="image" src="https://github.com/user-attachments/assets/429e070e-ed48-43c4-83e9-02ca18424085" />

/First MR to the project