### PR TITLE
Fallback to API trade query when HTML query fetch fails

### DIFF
--- a/src/Classes/TradeQueryRequests.lua
+++ b/src/Classes/TradeQueryRequests.lua
@@ -310,20 +310,43 @@ function TradeQueryRequestsClass:SearchWithURL(url, callback)
 		table.insert(paths, path)
 	end
 	if #paths < 2 or #paths > 3 then
-		return callback(nil, "Invalid URL", nil)
+		callback(nil, "Invalid URL", nil)
+		return
 	end
-	local realm, league, queryId
+
+	local realm
+	local league
+	local queryId
 	if #paths == 3 then
 		realm = paths[1]
+		league = paths[2]
+		queryId = paths[3]
+	else
+		league = paths[1]
+		queryId = paths[2]
 	end
-	league = paths[#paths-1]
-	queryId = paths[#paths]
+
+	local function runSearch(query)
+		self:SearchWithQuery(realm, league, query, function(items, errMsg)
+			callback(items, errMsg, query)
+		end)
+	end
+
 	self:FetchSearchQueryHTML(realm, league, queryId, function(query, errMsg)
-		if errMsg then
-			return callback(nil, errMsg, nil)
+		if query then
+			runSearch(query)
+			return
 		end
-		self:SearchWithQuery(realm, league, query, function(items, searchErrMsg)
-			callback(items, searchErrMsg, query)
+
+		ConPrintf("Trade URL HTML query fetch failed, trying API fallback: %s", tostring(errMsg))
+
+		self:FetchSearchQuery(realm, league, queryId, function(apiQuery, apiErrMsg)
+			if not apiQuery then
+				callback(nil, apiErrMsg or errMsg or "Could not fetch trade query", nil)
+				return
+			end
+
+			runSearch(apiQuery)
 		end)
 	end)
 end


### PR DESCRIPTION
Fixes #9907.

Description of the problem being solved:

When using the "Price Item" feature with a pasted trade URL, PoB attempts to retrieve the saved trade query by downloading and parsing the trade search HTML page.

Recently, this request has started returning HTTP 403 responses for some users, causing the "Price Item" functionality to fail entirely.

This change preserves the existing behavior by first attempting to retrieve the query from the trade search HTML page. If that request fails, PoB now falls back to retrieving the query through the /api/trade/search/<league>/<queryId> endpoint and continues the search normally.

This allows "Price Item" searches initiated from a trade URL to continue functioning even when the trade HTML page cannot be fetched.

Steps taken to verify a working solution:
Verified that "Price Item" succeeds when provided with a valid trade URL that previously returned HTTP 403.
Verified that search results are displayed correctly after the API fallback is used.
Verified that existing behavior remains unchanged when the HTML query fetch succeeds.
Verified that "Find Best" functionality continues to work as expected.
Link to a build that showcases this PR:

N/A

Before screenshot:

<img width="864" height="590" alt="image" src="https://github.com/user-attachments/assets/8c3fb553-a6fe-42d3-855a-c4b706981b00" />

After screenshot:

<img width="846" height="585" alt="image" src="https://github.com/user-attachments/assets/75e34a50-465f-4b2f-8880-752e02fa6fe6" />