### PR TITLE
Fix: private league fetch failure crashes the trader. (TradeQuery.lua:157: table index is nil) (Cloudflare)

### DIFF
--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -141,6 +141,10 @@ end
 -- Method to pull down and interpret the PoE.Ninja JSON endpoint data
 function TradeQueryClass:PullPoENinjaCurrencyConversion(league)
 	local now = get_time()
+	if not league or league == "" then
+		self:SetNotice(self.controls.pbNotice, "Error: No trade league selected")
+		return
+	end
 	-- Limit PoE Ninja Currency Conversion request to 1 per hour
 	if (now - self.lastCurrencyConversionRequest) < 3600 then
 		self:SetNotice(self.controls.pbNotice, "PoE Ninja Rate Limit Exceeded: " .. tostring(3600 - (now - self.lastCurrencyConversionRequest)))
@@ -684,10 +688,17 @@ function TradeQueryClass:SetCurrencyConversionButton()
 	end
 	self.controls.updateCurrencyConversion.label = currencyLabel
 	self.controls.updateCurrencyConversion.enabled = function()
+		if not self.pbLeague or self.pbLeague == "" or not self.controls.league.selIndex then
+			return false
+		end
 		return self.pbFileTimestampDiff[self.controls.league.selIndex] == nil or self.pbFileTimestampDiff[self.controls.league.selIndex] >= 3600
 	end
 	self.controls.updateCurrencyConversion.tooltipFunc = function(tooltip)
 		tooltip:Clear()
+		if not self.pbLeague or self.pbLeague == "" or not self.controls.league.selIndex then
+			tooltip:AddLine(16, "Trade leagues are still loading or unavailable")
+			return
+		end
 		if self.lastCurrencyFileTime[self.controls.league.selIndex] ~= nil then
 			self.pbFileTimestampDiff[self.controls.league.selIndex] = get_time() - self.lastCurrencyFileTime[self.controls.league.selIndex]
 		end
@@ -1227,7 +1238,19 @@ end
 
 -- Method to update realms and leagues
 function TradeQueryClass:UpdateRealms()
-	local function setRealmDropList()
+	local setRealmDropList
+	local function useStaticRealms()
+		ConPrintf("Using static realms list")
+		self.allLeagues = {}
+		self.realmIds = {
+			["PC"]   = "pc",
+			["PS4"]  = "sony",
+			["Xbox"] = "xbox",
+		}
+		setRealmDropList()
+	end
+
+	setRealmDropList = function()
 		self.realmDropList = {}
 		for realm, _ in pairs(self.realmIds) do
 			-- place PC as the first entry
@@ -1249,7 +1272,8 @@ function TradeQueryClass:UpdateRealms()
 		ConPrintf("Fetching realms and leagues using POESESSID")
 		self.tradeQueryRequests:FetchRealmsAndLeaguesHTML(function(data, errMsg)
 			if errMsg then
-				self:SetNotice(self.controls.pbNotice, "Error while fetching league list: "..errMsg)
+				self:SetNotice(self.controls.pbNotice, "Error while fetching private league list, using public leagues: "..errMsg)
+				useStaticRealms()
 				return
 			end
 			local leagues = data.leagues
@@ -1270,12 +1294,6 @@ function TradeQueryClass:UpdateRealms()
 		end)
 	else
 		-- Fallback to static list
-		ConPrintf("Using static realms list")
-		self.realmIds = {
-			["PC"]   = "pc",
-			["PS4"]  = "sony",
-			["Xbox"] = "xbox",
-		}
-		setRealmDropList()
+		useStaticRealms()
 	end
 end

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -1272,7 +1272,7 @@ function TradeQueryClass:UpdateRealms()
 		ConPrintf("Fetching realms and leagues using POESESSID")
 		self.tradeQueryRequests:FetchRealmsAndLeaguesHTML(function(data, errMsg)
 			if errMsg then
-				self:SetNotice(self.controls.pbNotice, "Error while fetching private league list, using public leagues: "..errMsg)
+				self:SetNotice(self.controls.pbNotice, "Error while fetching private leagues; falling back to public leagues")
 				useStaticRealms()
 				return
 			end

--- a/src/Classes/TradeQueryRequests.lua
+++ b/src/Classes/TradeQueryRequests.lua
@@ -451,13 +451,14 @@ function TradeQueryRequestsClass:FetchLeagues(realm, callback)
 			local json_data = dkjson.decode(response.body)
 			if not json_data or json_data.error then
 				errMsg = json_data and json_data.error or "Failed to get leagues"
+				return callback(nil, errMsg)
 			end
 			local leagues = {}
-				for _, value in pairs(json_data) do
-					if (not value.id:find("SSF") and not value.id:find("Solo")) then
-						table.insert(leagues, value.id)
-					end
+			for _, value in pairs(json_data) do
+				if (not value.id:find("SSF") and not value.id:find("Solo")) then
+					table.insert(leagues, value.id)
 				end
+			end
 			callback(leagues, errMsg)
 		end
 	)


### PR DESCRIPTION
Fixes #9176 .

### Description of the problem being solved:

When retrieving leagues, if the `private` leagues fetch fails, it takes down the trader, even if the `public` leagues retrieve worked.
This fix proposes that it should instead continue , with just the public leagues it could retrieve.

```
Error:

In download callback: Classes/TradeQuery.lua:157: table index is nil
stack traceback:
	Classes/TradeQuery.lua:157: in function 'callback'
	Classes/TradeQuery.lua:85: in function 'callback'
	Launch.lua:319: in function <Launch.lua:318>
	[C]: in function 'PCall'
	Launch.lua:230: in function <Launch.lua:222>
v2.65.0 master
Press Enter/Escape to dismiss, or F5 to restart the application.
Press CTRL + C to copy error text.
```


#### Cause

The `public` leagues fetch is done using the `API`, and bypasses this issue entirely.
The `private` leagues fetch is done using `HTTP callout` (because there is no API for this), and runs into Cloudflare, if unlucky.

The private leagues fetch may hit Cloudflare challenge pages.
This is not an expected response, hence the crash. (The contents will be "Enable Javascript and cookies to continue")

This may not always happen, depending on how Cloudflare feels about you. (i.e. flaky repro)
Using a VPN might make it easier to reproduce.

The first sign of trouble is your trader window has no leagues populated.
The actual crash is produced on Get Currencies Conversion Rates or so.

#### Other changes

- flow changes: some guard against "missing leagues" state
-


### Steps taken to verify a working solution:
- "works here"™
- ran docker tests
-

### Link to a build that showcases this PR:
n/a
### Before screenshot:
n/a
### After screenshot:
n/a