### PR TITLE
Add support for pob.codes build exporting, and pob:// protocol for launching PoB from pob.codes

### DIFF
--- a/src/Modules/BuildSiteTools.lua
+++ b/src/Modules/BuildSiteTools.lua
@@ -22,6 +22,10 @@ buildSites.websiteList = {
 		codeOut = "https://maxroll.gg/poe/pob/", postUrl = "https://maxroll.gg/poe/api/pob", postFields = "pobCode=", linkURL = "maxroll%.gg/poe/pob/%1"
 	},
 	{
+		label = "pob.codes", id = "PoBCodes", matchURL = "^https://pob%.codes/b/.+", regexURL = "pob%.codes/b/(.+)%s*$", downloadURL = "api.pob.codes/%1/raw",
+		codeOut = "https://pob.codes/b/", postUrl = "https://api.pob.codes/pob/plain", postFields = "", linkURL = "pob.codes/b/%1"
+	},
+	{
 		label = "pobb.in", id = "POBBin", matchURL = "^https://pobb%.in/.+", regexURL = "pobb%.in/(.+)%s*$", downloadURL = "pobb.in/pob/%1",
 		codeOut = "https://pobb.in/", postUrl = "https://pobb.in/pob/", postFields = "", linkURL = "pobb.in/%1"
 	},


### PR DESCRIPTION
No reported Issues Fixed

### Description of the problem being solved:

This adds https://pob.codes/ as a supported site for exporting builds directly from PoB, and also will allow me to add an "Open in PoB" button to the site so that users can launch the build into PoB without copy/pasting build codes.

I've briefly talked with LocalIdentity about this on Discord (I'm `hammerlock.`) but I haven't heard back in a while. Transparently he hasn't explicitly agreed to approve this change, though he seemed open to it. My hope is that by submitting a PR it simplifies the process for you all. I'm happy to provide as much detail as is needed about pob.codes for this to be approved. 

If you don't want pob.codes to be available for export, we could omit `codeOut`, `PostUrl`, and `postFields`, so that I could still add a 'launch with PoB' button to my website.

### Steps taken to verify a working solution:
- Added the 4 line code change
- Launched PoB in dev mode and imported a build successfully https://pob.codes/b/Vvsg9n1x1jt
- Modified the build briefly and generated an export/share link https://pob.codes/b/SIRoWhlBHvH

### Link to a build that showcases this PR:
N/A

### Before screenshot:
<img width="832" height="251" alt="image" src="https://github.com/user-attachments/assets/d2496144-4e8a-4938-b788-5295c83565df" />

### After screenshot:
<img width="814" height="249" alt="image" src="https://github.com/user-attachments/assets/375c22c1-3b13-4edc-afb2-ff81544f444e" />

