### PR TITLE
render ascendancy flavor text only at higher zoom levels

### DIFF
--- a/src/Classes/PassiveTreeView.lua
+++ b/src/Classes/PassiveTreeView.lua
@@ -552,8 +552,9 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 		local scrX, scrY = treeToScreen(group.x, group.y)
 		if group.ascendancyName then
 			if group.isAscendancyStart then
-				if group.ascendancyName ~= spec.curAscendClassBaseName and (not spec.curSecondaryAscendClass or group.ascendancyName ~= spec.curSecondaryAscendClass.id) then
-					SetDrawColor(1, 1, 1, 0.25)
+				local isSelectedAscendancy = group.ascendancyName == spec.curAscendClassBaseName or (spec.curSecondaryAscendClass and group.ascendancyName == spec.curSecondaryAscendClass.id)
+				if not isSelectedAscendancy then
+					SetDrawColor(1, 1, 1, 0.50)
 				end
 				self:DrawAsset(tree.assets["Classes"..group.ascendancyName], scrX, scrY, scale)
 
@@ -583,7 +584,6 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 					end
 					if ascendancyData and ascendancyData.flavourTextRect then
 						local rect = ascendancyData.flavourTextRect
-						local textColor = "^x" .. ascendancyData.flavourTextColour
 
 						-- Normal ascendancy images are 1300x1300, bloodline appears to be 1488x1412
 						local offsetX = rect.x - (isAlternateAscendancy and 744 or 650)
@@ -591,7 +591,19 @@ function PassiveTreeViewClass:Draw(build, viewPort, inputEvents)
 
 						local textX, textY = treeToScreen(group.x + offsetX, group.y + offsetY)
 
-						DrawString(textX, textY, "LEFT", 52 * scale, "FONTIN ITALIC", textColor .. ascendancyData.flavourText)
+						local flavourTextBaseFontSize = 52
+						local flavourTextMinZoom = 2.5
+						if self.zoom >= flavourTextMinZoom then
+							local textColor = "^x" .. ascendancyData.flavourTextColour
+							if not isSelectedAscendancy then
+								local colour = ascendancyData.flavourTextColour
+								textColor = string.format("^x%02X%02X%02X",
+									m_floor(tonumber(colour:sub(1, 2), 16) * 0.5),
+									m_floor(tonumber(colour:sub(3, 4), 16) * 0.5),
+									m_floor(tonumber(colour:sub(5, 6), 16) * 0.5))
+							end
+							DrawString(textX, textY, "LEFT", flavourTextBaseFontSize * scale, "FONTIN ITALIC", textColor .. ascendancyData.flavourText)
+						end
 					end
 				else
 					ConPrintTable(tree.classes)


### PR DESCRIPTION
let's only render ascendancy flavor text when we are actually zoomed in enough to read it.

also, dim unselected ascendancy flavor text at a clip of 50% (to match the existing background dimming).

### Description of the problem being solved:

When zoomed out, many ascendancy flavor texts bleed out from its portrait. Fix this by hiding flavor text until an appropriate zoom level is reached.

While we're here, let's also dim any unselected ascendancy's flavor text at a clip of 50% (matching existing background art dimming).

### Steps taken to verify a working solution:
- Visually inspect flavor text at various zoom levels
- Select/Deselect ascendancy to see flavor text dimming 


### Link to a build that showcases this PR:

N/A, empty build will suffice.

### Images

<details>
<summary>Before/After Images</summary>

### Before screenshot:

When zoomed out, we see bleeding text which looks unprofessional. You can't read this text anyways.

<img width="372" height="499" alt="image" src="https://github.com/user-attachments/assets/e2eb0a45-f8ea-4c53-8c8e-0337165b499a" />

*notice the text clipping out*

### After screenshot:

Hide the flavor text when zoomed out.

<img width="261" height="353" alt="image" src="https://github.com/user-attachments/assets/d54e64b1-a7a1-40c0-bb45-c352d8cda430" />

*notice no text*

</details>


<details>
<summary>Before/After Images (text dimming)</summary>

<img width="255" alt="image" src="https://github.com/user-attachments/assets/cedacb79-085e-43c8-92e9-079346569438" />

*notice both the selected and unselected ascendancy have the same text style*

### After Screenshot (text dimming on unselected)

<img width="255" alt="image" src="https://github.com/user-attachments/assets/1c28485b-407f-42e3-86d6-bdb9f1fe28a2" />

As you can see, it is now much more obvious which ascendancy is selected and we have a more coherent design language by dimming unselected ascendancy's background **and flavour text**.


</details>


### A GIF showing the **new** look, text disappears at low zoom levels, unselected ascendancy flav. text is dim

<img width="255" alt="variants" src="https://github.com/user-attachments/assets/6a898d2b-4e22-4225-bdbc-580add765bae" />
