### PR TITLE
Fix Raise Spectre damage being affected by hidden elemental conversion multiplier

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -80,11 +80,6 @@ local function calcDamage(activeSkill, output, cfg, breakdown, damageType, typeF
 		end
 		local convMult = conversionTable[otherType][damageType]
 		if convMult > 0 then
-			local convPortion = conversionTable[otherType].conversion[damageType]
-			if convPortion > 0 and cfg.summonSkillName and cfg.summonSkillName == "Raise Spectre" and otherType == "Physical" and damageType ~= "Chaos" then
-				local physBonus = 1 + data.monsterPhysConversionMultiTable[activeSkill.actor.level] / 100
-				convMult = (convMult - convPortion) + convPortion * physBonus
-			end
 			-- Damage is being converted/gained from the other damage type
 			local min, max = calcDamage(activeSkill, output, cfg, breakdown, otherType, typeFlags, damageType)
 			addMin = addMin + min * convMult


### PR DESCRIPTION
Fixes #9949

### Description of the problem being solved:
In #9150 I added support for the phys conversion damage bonus mechanic that GGG added for enemy monsters. In 3.28 they removed this bonus from applying to spectres but I hadn't removed it from PoB yet

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/8fiplr0x

### Before screenshot:
<img width="207" height="254" alt="image" src="https://github.com/user-attachments/assets/fbe9c7a5-5d17-4028-82e2-f8df01da973d" />
<img width="525" height="216" alt="image" src="https://github.com/user-attachments/assets/0d3a900c-24ad-4a1d-b01c-51bee2dcf19e" />

### After screenshot:
<img width="237" height="257" alt="image" src="https://github.com/user-attachments/assets/a5d01a47-6cdf-43ea-94a2-07a559c66814" />
<img width="523" height="216" alt="image" src="https://github.com/user-attachments/assets/f3d5cb95-5ed2-485b-ad15-2a7f28a0895a" />
