### PR TITLE
Implement trigger config matching and FieryImpactHeistMaceImplicit, TriggeredMoltenStrike skills

### DIFF
--- a/spec/System/TestTriggers_spec.lua
+++ b/spec/System/TestTriggers_spec.lua
@@ -1410,7 +1410,7 @@ describe("TestTriggers", function()
 		assert.are.not_equals(math.floor(build.calcsTab.mainOutput.SkillTriggerRate * 100), math.floor(baseRate * 100))
 	end)
 
-	it("skillid config search", function()
+	it("skillId config search", function()
 		build.itemsTab:CreateDisplayItemFromRaw([[Rarity: RARE
 		Physical 1H Mace
 		Boom Mace

--- a/spec/System/TestTriggers_spec.lua
+++ b/spec/System/TestTriggers_spec.lua
@@ -1409,4 +1409,36 @@ describe("TestTriggers", function()
 		runCallback("OnFrame")
 		assert.are.not_equals(math.floor(build.calcsTab.mainOutput.SkillTriggerRate * 100), math.floor(baseRate * 100))
 	end)
+
+	it("skillid config search", function()
+		build.itemsTab:CreateDisplayItemFromRaw([[Rarity: RARE
+		Physical 1H Mace
+		Boom Mace
+		Crafted: true
+		Prefix: {range:0.5}LocalIncreasedPhysicalDamagePercent5
+		Prefix: {range:0.5}LocalIncreasedPhysicalDamagePercentAndAccuracyRating5
+		Prefix: {range:0.5}LocalAddedPhysicalDamage6
+		Suffix: {range:0.5}LocalIncreasedAttackSpeed3
+		Suffix: {range:0.5}LocalCriticalStrikeChance3
+		Suffix: {range:0.5}LocalCriticalMultiplier4
+		Quality: 20
+		Sockets: R-R-R
+		LevelReq: 70
+		Implicits: 1
+		Trigger Level 20 Fiery Impact on Melee Hit with this Weapon
+		172% increased Physical Damage
+		Adds 16 to 29 Physical Damage
+		12% increased Attack Speed
+		22% increased Critical Strike Chance
+		+27% to Global Critical Strike Multiplier
+		+111 to Accuracy Rating]])
+		build.itemsTab:AddDisplayItem()
+		runCallback("OnFrame")
+
+		build.skillsTab:PasteSocketGroup("Smite 20/0  1\n")
+		runCallback("OnFrame")
+
+		local baseRate = build.calcsTab.mainOutput.SkillTriggerRate
+		assert.True(build.calcsTab.mainOutput.SkillTriggerRate ~= nil)
+	end)
 end)

--- a/src/Modules/CalcTriggers.lua
+++ b/src/Modules/CalcTriggers.lua
@@ -1540,6 +1540,12 @@ local configTable = {
 			return {source = env.player.mainSkill}
 		end
 	end,
+	["TriggeredMoltenStrike"] = function(env)
+		return {triggerSkillCond = function(env, skill) return (skill.skillTypes[SkillType.Melee] or skill.skillTypes[SkillType.Attack]) end}
+	end,
+	["FieryImpactHeistMaceImplicit"] = function(env)
+		return {triggerSkillCond = function(env, skill) return (skill.skillTypes[SkillType.Melee] or skill.skillTypes[SkillType.Attack]) end}
+	end,
 }
 
 -- Find unique item trigger name
@@ -1569,7 +1575,9 @@ function calcs.triggers(env, actor)
 		local triggerNameLower = triggerName and triggerName:lower()
 		local awakenedTriggerNameLower = triggerNameLower and triggerNameLower:gsub("^awakened ", "")
 		local uniqueNameLower = uniqueName and uniqueName:lower()
-		local config = skillNameLower and configTable[skillNameLower] and configTable[skillNameLower](env)
+		local skillId = actor.mainSkill.activeEffect.grantedEffect.id
+		local config = skillId and configTable[skillId] and configTable[skillId](env)
+		config = config or skillNameLower and configTable[skillNameLower] and configTable[skillNameLower](env)
         config = config or triggerNameLower and configTable[triggerNameLower] and configTable[triggerNameLower](env)
         config = config or awakenedTriggerNameLower and configTable[awakenedTriggerNameLower] and configTable[awakenedTriggerNameLower](env)
         config = config or uniqueNameLower and configTable[uniqueNameLower] and configTable[uniqueNameLower](env)

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3201,6 +3201,7 @@ local specialModList = {
 	["trigger level (%d+) (.+) when you lose cat's stealth"] = function(num, _, skill) return triggerExtraSkill(skill, num) end,
 	["trigger level (%d+) (.+) when your trap is triggered"] = function(num, _, skill) return triggerExtraSkill(skill, num) end,
 	["trigger level (%d+) (.+) on hit with this weapon"] = function(num, _, skill) return triggerExtraSkill(skill, num) end,
+	["trigger level (%d+) (.+) on melee hit"] = function(num, _, skill) return triggerExtraSkill(skill, num) end,
 	["trigger level (%d+) (.+) on melee hit while cursed"] = function(num, _, skill) return triggerExtraSkill(skill, num) end,
 	["trigger level (%d+) (.+) on melee hit with this weapon"] = function(num, _, skill) return triggerExtraSkill(skill, num) end,
 	["trigger level (%d+) (.+) every [%d%.]+ seconds while phasing"] = function(num, _, skill) return triggerExtraSkill(skill, num) end,


### PR DESCRIPTION
### Description of the problem being solved:
Implements ability to match a trigger config by skillId. This is generally a preferred approach if the skills is a "triggered" variant as it prevents accidental application of trigger logic to "normal" skills

Adds a basic test for the trigger config by skillId matching.

The added line in ModParser could be merged into other simillar ones but i left it as is for readability as that block is complicated enough as is.

### Steps taken to verify a working solution:
- Test linked build
- Write test.

### Link to a build that showcases this PR:

```
eNrdXOtv2zgS_1z_FYSB_bTXOJIfcYNkF46TNAHi1men3btPC0aibW1p0StRSbyH-99vhtTTiW3S8uGA6wJdSZ4ZzvzIefDVi19fl5w8sygORHjZdE5Om4SFnvCDcH7Z_PZ4-7Hf_PWXxsWYysXX2VUScPzll8aHC_VMljQIp8L7weTnSCSry6bbJM8BexkJn10270fjr5PHJvEWNKKeZNEDe2Z8kEihf5dRwuBXTuP4C13Ch6kHajQJjT0W-sPi-xcRAuETDf1AZm-SRnMmv2eqt38H1Vc0lAsmwhH9Q0SfhZ_R5t-DsPKdoz5gdhMs-nAx5nTNoqmkkjxTnkC7vRP3rNftdz-1z7pNEsMvl80BoEXn7Jou4e9my57zKoliuYf99OS023VzzumKMX8rcU42jtjNbMY8GTyzYRTI4YKG3q5GihYMyJ2TCvUo4TJY8YBF-xW7M9Cl3emd9Z32Wfu00-v3M85HISm_Hk-3M1YphTSnNBI7TDiHIW9EO2Exi56phAG5k36LrUOxfApC5g-e5zt4nV7RDUJwX7yE-zUb0ZAORSzNKMcsAgeUVgxT5gnwWds2LDkfghkzp7SyI2Ww1eYwO26mpnTWgg9TaALRyIxyKhK-k9ItSOX22OD02oXb_LmLspB3zV63UvU7JXG7CAtx9-F2I3r9krhdhCXlngV6_lbKdv_EdT857tnp2VkReFUwurkbb9ckb2G8WMeBR_mIvgbLZAlB9ZH-YDsaPCsG6nwhQwhj9qy3QcTsuYYQmIy5igC4oCI2ZeuUwkkQ3kFtMPC8BOqMtQGU6LkGQ33FvHMkvQ89Q6HfwkglgR3pusowASfFuuCJ78i8p1vaSH3dLFJN2JyFaXNrM5YHxrzFZ4B3QuV29bqVwG4IK5LugrUq1ADWEkhVjr0gnXwqM1rChCxmMBUxOmTRfD1dBIz7dtSZWkO6MoS5zL0L7i3NWUFRZrWE5Dca-WZJykwnp5cr9UzjXVF5Ay5NbYTUiHHGgMFn-2rboj4Xf2B1zu3YBtFSJJGhBZrYyIAsn-i5yIT5iSeNoMonGVcc5n6mZuRcoCfnVqwDKan341r4c2PQVCNWHFX9pslqBREER8MeAR-LgI7JEiYBgUkdVdB-haG8y6NLDWBeNW2goLVoIK8UTFvZYLCxBbO9sTEF8b4mnDcdOoJgsYQUoKbRI2EQaW5h1mc05VOEhlPJsXgBzRe4bhFvr4beo4aayECViIV_rY3lV8iNGrgJfaivwBWM29jkKJp5DJYQPuP4mkpK_LR0_k6jgIbSUX248dHVHcto5C0eYBRcNstvt5TzJwgR8BXlX7TU8hQ-DUU4C-aE6kUR9TJlMl_zyb-QwM8-KpM8tgD_YREJk-UTi2De4HZAgVCtR7GQLdfV8Kntep-1W-HbXGp5n-fstMKUxmjB-YSGu1vLtZx6AuCZYuiMd6pXbWozxhgxvRs33udsVxgxDI6zMt8QedRwP-r9T70qF4aQ_WxvWstN28_bcz71P1WYy7l7T3ct8wW1G-S8gyEtXqDZWw4_mwOK4OwBtH36ZkDut22TaTN6m-iWQ7lHwY3BtZlWtwB56nSqzVVqvy1MuW9iPGLX0MY-z8SVhrJNuIZs1MFxMA_415kK7OCVeQTd58YLqJT2e3HJknwg_RbIBYuYr7iHIoEUyPjMcjRWB6JWZMKWkFP9q_WA87WVN2FfWkRMT8dnqGxlRPljMIeciHbsDp3V4VNaPX-foZPTr_IKvToSLlp5olDpRb_h42PEWJpdUMs8seALCYXPYrCm32-3caMjiSXiGS9uRbSkxeaF2yQS5JQ2M1xcFFHrdzRaD4r9kHvIUmHAm2RJUdZa1zgxZkNapTpNd1b0szb-2-RBPXxYSLmKz1utl5eXkxWVCzFjr2D0iSeWrRUwgTUf4x8B5x9Rr9YA_lzNB-qPEtTKJF3o3Z84RRdrsygAo1PUEAUFGMKED1MUGkNyn1EYYJ_Z8kFvwYQISLay1Sz9_veE8kCudRmyEC9Yl4sIf3lcrxDcwcNDM-sAFJ5mdxJrqvhqDcXZLc5JixV2LNeqBNlmFDbxwObUW-NPl80Z5TFLezSVXqkU1EfCQly_8TMhuCs2KDRS6gQhdL_P7sO0tMy7sUI6pNyLFT2nT4iLbubDBWiz2Yp-_czFE-VO9hGHsR6H02UAM28oyVT5hKMg_VLmc3O7sfUxjWShgfpU4stJtH6633A1dc6WSDZikvpQzrXuJUDXQvxayih4SkX8WepMD90YRaVDR9P-l1GNIRl7uDMJKp675zdczQsoJ84dGbyyv5FxvPYWUHd6-Fr0Aom5wGUKRlciJM7hvTISXLKQqD3AN12hdM9hf4yC-Ryjt-aZyij4Udqz7L0LJ4r4nwHqnGc1MeI5gkD7N3IlxFI9bgWTTF9gNncwouDa0ZrcL1cQA_Ygqkg15R2D-I5qwSsPvEBWRrQpsOljlhV0cMNH5QIkiZneg9GmqsikA4oOZTBHug4ggMNMzMNQpk3TsQwllCcq-F6OPBPwa7k-J5PB5KaxCXsjR70xjOhMMv-coPDGOGKz4PWc_CvCWcT56Un33w8CGO9DL2I0Zn51UpMunXYP5BsUa_ITKqGC2C5o4PubQnqNaTLb3apeF1L5vb2VGstblKodSM-89lMX29udRpqDzol72kjzHQD_Ef5rqPQ1YX-ek7PTRjaW4FenkbovURTAScoDlcDAV-uH5C6Q5AXKNCIXQUz0QGk4Z-5P6IraSpJ3rwamAWDFxOkRKYj76c2vToVXQ0QURg238lNmKtHIEA1N42f37CcUrZ3oDVUBTONnx3GQMutkontZOclI-GqmShS-uMoONZ0ev6kbbaVw91K091J09lJ091L09lKcZdUhemfVTd133HQz3TQq2cbQVZWnFFV0fzdhMVXeQ7gxy-3_nzlfOe9WnM9osG50cFEE7gjxaeKFVEeg9lmOn6BkxuSHL2l9ruccV4zn0xkDcnDLZxaTwdM6jtErFSSkYyEB5nHxD9K14EAVN1t0a-vcttFA-GuiF1M2xTi1FXGOo0jPSoyQcR0Bd4wvmTzAknw6Xq2_joJAty4CNkMi17_OsHpnYHdr90LH3gr3-O7VO0QLHAt1zHm3Vx3r4FS3DzuHjKP3bK-rSLv2YHKP4BLdY8Hh1oSjdwTP6NT2DLfugO4ewYyetVO4hzr0cYK7fYlxNC-0SvFYRVtx7Ax-tZN6_eHatQbeORbwnWPBWDdwOEfwuGPIaB8LkO5xnNIG18Ey4UxaJ6QDLD7MNmtHqeuaNnpOYGpsNYIUg3ULxyiAj1F-do81zp3aBVDvOJ5yDGQNjHE3ZdgOUutU59ZGuH6RerQCs3csQd0jdPcxSu-jzcLa5aWobMdB7TOoY064I6MXqMJVIkksI3WF7-b29mb4eP_9Jt_XD2Lv96dkNsMreKlIzfLmyIbaN_ldf04pp0wdESWe4JyuYtykyTY0kqdY_3jZ_B6wF7UXcs0kDXis19LSrRIOVFbSFN9dfkRFybqrnlgxlHTzyiJcoP6NRl4UsFSv_M1aKa0CnkTG42xaWnEDzUyQXkUd0liqk9IaqdJ1PzMpuHCamoOPVry4I8HTltNnayQk7sWvmBfMAg-3tcpdjvv0-psVLtlljqy_K6dwzWRcccRRCdCPNsxjEcR4GRW502crVOdhkPVn-mzDfs08mtquH22Y88P3IrzDnU2Ukn-zkvRFhGqQg9MMAo6bF2nP3nCWf7AR-BUPJKWHVrSkEQSk7IOl40TBUyIzNy69W2GFN4E0QsWdIDNWddtF21DcezGMROUrIBrQt5dCzESpqxNZILNj1WfqUvwqJ7ENu0CX7Rr-8iUFQxDS43na_so9DUMnUfF38CwCX8UG7S4bH-0CBuTa-mLUtYP6YjbvIdSXqFYH0v5On7eyp-eCStzfZIA7cfWEoJfVk4DOVk_CYxB6MonYwQImeSEy2VmDvOXMjs7rVF05R2_En5-oP1iCPvd_MLs6vWrIvS3-X7OZOvFSJID8i9VoFlDNQcGhLtzXlDWVSXgNyNqKeguQsnAjJtWTpfPskUDT4UNfrS3Fk_JdWwtBUBfc5ZXnoZLyezp3jHK5GAvB6wncvEJsLuwdV2eeSFY09DNpX6vl_qHowUwfhKprKtd4pTGupaW6MbBLzkUrmyFefBFQI6Fo_Jq9XEDlD-5E2Cv-D095rjO9W9kxZ5zWpXdupjLCGexfQiz_qSaw-JQe5W3vPN2GhP9AFiVWNUR8FsO0jKZFBYfen4KAgf-MHvQIwyE_iEvoasVCv6TaRWvz36b5D9oMseA=
```


### Before screenshot:

n/a

### After screenshot:

<img width="568" height="497" alt="obraz" src="https://github.com/user-attachments/assets/f3928fee-7cba-4c64-8f74-f2b337615be2" />
