### PR TITLE
Fix cache invalidation bug when loading a new build

### DIFF
--- a/src/Classes/CompareEntry.lua
+++ b/src/Classes/CompareEntry.lua
@@ -171,6 +171,7 @@ function CompareEntryClass:LoadFromXML(xmlText)
 	end
 
 	self:SyncCalcsSkillSelection()
+	wipeGlobalCache()
 	self.calcsTab:BuildOutput()
 	self.buildFlag = false
 end

--- a/src/Modules/Build.lua
+++ b/src/Modules/Build.lua
@@ -668,6 +668,7 @@ function buildMode:Init(dbFileName, buildName, buildXML, convertBuild, importLin
 	end
 
 	-- Build calculation output tables
+	wipeGlobalCache()
 	self.outputRevision = 1
 	self.calcsTab:BuildOutput()
 	self:RefreshStatList()


### PR DESCRIPTION
Fixes #9947

### Description of the problem being solved:

See issue

### Steps taken to verify a working solution:
- Run script provided in issue with the extra wipe commented out and adapted to be ran in the tests container:

<details><summary>repro.lua</summary>

```lua
-- contamination_repro.lua
-- Repro for: stale GlobalCache trigger data survives loading a new build
-- when calcsTab:BuildOutput() is invoked directly (PoB v2.65.0).
-- Run from a stock PathOfBuilding checkout's src/ directory:
--     luajit contamination_repro.lua buildA.xml buildB.xml
-- Expected output: build A's reload (step 3) wrongly reports build B's
-- TotalDPS/SkillTriggerRate; after wipeGlobalCache() they are restored.

-- capture our args BEFORE booting: PoB itself consumes arg[1] as an
-- optional import URL (Modules/Main.lua), so it must not see our paths
local pathA, pathB = assert(arg[1], "arg1: buildA.xml"), assert(arg[2], "arg2: buildB.xml")
arg[1], arg[2] = nil, nil

package.path = package.path .. ";../runtime/lua/?.lua;../runtime/lua/?/init.lua"
dofile("HeadlessWrapper.lua")

local function readFile(p)
	local f = assert(io.open(p, "r"), "cannot open " .. tostring(p))
	local s = f:read("*a")
	f:close()
	return s
end

local function report(label)
	local o = build.calcsTab.mainOutput
	print(string.format("%-28s TotalDPS=%-12.4f SkillTriggerRate=%s",
		label, o.TotalDPS or -1, tostring(o.SkillTriggerRate)))
end

local xmlA, xmlB = readFile(pathA), readFile(pathB)

-- steps 1-2: ground truth for both builds, with the workaround applied
-- (wipe before recalculating) so the printed values are the true ones
loadBuildFromXML(xmlA, "A"); wipeGlobalCache(); build.calcsTab:BuildOutput(); report("A (true values)")
loadBuildFromXML(xmlB, "B"); wipeGlobalCache(); build.calcsTab:BuildOutput(); report("B (true values)")
-- step 3: the bug -- reload A and recalculate DIRECTLY, as headless callers
-- do; the trigger data cached from B leaks into A's outputs
loadBuildFromXML(xmlA, "A"); build.calcsTab:BuildOutput(); report("A (direct recalc, DIRTY)")
-- step 4: the one-line mitigation restores correctness
--wipeGlobalCache(); 
build.calcsTab:BuildOutput(); report("A")
```
</details>

See issue for test builds.

```
#repo/src # luajit repro.lua builda.xml buildb.xml
Loading main script...
Unicode support detected
Loading passive tree data for version '3.28'...
Removing legacy alternate ascendancies from tree: Primalist, Warden, Warlock
Loading passive tree assets...
Loading passive tree sprite data for version '3.28'...
Processing tree...
Startup time: 0 ms
Uniques loaded
Rares loaded
A (true values)              TotalDPS=5.4331       SkillTriggerRate=0.0089994464747016
B (true values)              TotalDPS=35.0928      SkillTriggerRate=0.058127941857164
A (direct recalc, DIRTY)     TotalDPS=5.4331       SkillTriggerRate=0.0089994464747016
A                            TotalDPS=5.4331       SkillTriggerRate=0.0089994464747016
```
