### PR TITLE
Update Item import API to support 3.29 changes

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -1631,13 +1631,15 @@ function ImportTabClass:ImportItem(itemData, slotName, ignoreWeaponSwap)
 		end
 	end
 	if itemData.implicitMods then
-		for _, line in ipairs(itemData.implicitMods) do
-			for line in line:gmatch("[^\n]+") do
+		for _, itemMod in ipairs(itemData.implicitMods) do
+			local modLine = itemMod.description or itemMod
+			for line in modLine:gmatch("[^\n]+") do
 				local modList, extra = modLib.parseMod(line)
 				t_insert(item.implicitModLines, { line = line, extra = extra, mods = modList or { } })
 			end
 		end
 	end
+	-- TODO: Remove once 3.29 releases https://www.pathofexile.com/developer/docs/changelog#3-29-0
 	if itemData.fracturedMods then
 		for _, line in ipairs(itemData.fracturedMods) do
 			for line in line:gmatch("[^\n]+") do
@@ -1647,10 +1649,14 @@ function ImportTabClass:ImportItem(itemData, slotName, ignoreWeaponSwap)
 		end
 	end
 	if itemData.explicitMods then
-		for _, line in ipairs(itemData.explicitMods) do
-			for line in line:gmatch("[^\n]+") do
+		for _, itemMod in ipairs(itemData.explicitMods) do
+			local modLine = itemMod.description or itemMod
+			for line in modLine:gmatch("[^\n]+") do
 				local modList, extra = modLib.parseMod(line)
-				t_insert(item.explicitModLines, { line = line, extra = extra, mods = modList or { } })
+				t_insert(item.explicitModLines, { line = line, extra = extra, mods = modList or { },
+					fractured = itemMod.fractured,
+					crafted = itemMod.crafted,
+					mutated = itemMod.mutated })
 			end
 		end
 	end
@@ -1662,6 +1668,7 @@ function ImportTabClass:ImportItem(itemData, slotName, ignoreWeaponSwap)
 			end
 		end
 	end
+	-- TODO: Remove once 3.29 releases https://www.pathofexile.com/developer/docs/changelog#3-29-0
 	if itemData.craftedMods then
 		for _, line in ipairs(itemData.craftedMods) do
 			for line in line:gmatch("[^\n]+") do
@@ -1670,6 +1677,7 @@ function ImportTabClass:ImportItem(itemData, slotName, ignoreWeaponSwap)
 			end
 		end
 	end
+	-- TODO: Remove once 3.29 releases https://www.pathofexile.com/developer/docs/changelog#3-29-0
 	if itemData.mutatedMods then
 		for _, line in ipairs(itemData.mutatedMods) do
 			for line in line:gmatch("[^\n]+") do


### PR DESCRIPTION
https://www.pathofexile.com/developer/docs/changelog#3-29-0 Item import API is changing in 3.29.  These changes in the PR should be backwards-compatible.  It remains to be seen if the TODO comments will hold for non-OAuth imported characters or not.