### PR TITLE
Exit if bad trade leagues JSON

### DIFF
--- a/src/Classes/TradeQueryRequests.lua
+++ b/src/Classes/TradeQueryRequests.lua
@@ -380,6 +380,7 @@ function TradeQueryRequestsClass:FetchLeagues(realm, callback)
 				local json_data = dkjson.decode(response.body)
 				if not json_data or json_data.error then
 					errMsg = json_data and json_data.error or "Failed to parse trade leagues JSON"
+					return callback({"Standard", "Hardcore"}, errMsg)
 				end
 				local leagues = {}
 				for _, value in pairs(json_data.result) do

--- a/src/Classes/TradeQueryRequests.lua
+++ b/src/Classes/TradeQueryRequests.lua
@@ -379,7 +379,11 @@ function TradeQueryRequestsClass:FetchLeagues(realm, callback)
 				end
 				local json_data = dkjson.decode(response.body)
 				if not json_data or json_data.error then
-					errMsg = json_data and json_data.error or "Failed to parse trade leagues JSON"
+					local apiError = json_data and json_data.error
+					errMsg = apiError or "Failed to parse trade leagues JSON"
+					if type(apiError) == "table" then
+						errMsg = apiError.message or (apiError.code and tostring(apiError.code)) or "Failed to parse trade leagues JSON"
+					end
 					return callback({"Standard", "Hardcore"}, errMsg)
 				end
 				local leagues = {}


### PR DESCRIPTION
### Description of the problem being solved:

Code should not continue here, if bad JSON received, since next block expects good JSON.
This also makes clearer the source of an error.

I copy-pasted the same return as the one a little above.

### Steps taken to verify a working solution:

This was part of a (discarded) fix I had for pre-OAuth version; now, it's no longer as easy to hit this spot.
But I believe the code flow makes sense.