### PR TITLE
Fix: trade window init only lists leagues from the last fetched realm

### DIFF
--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -1353,12 +1353,12 @@ function TradeQueryClass:UpdateRealms()
 	end
 
 	-- use trade leagues api to get trade leagues including private leagues is valid.
+	self.allLeagues = {}
 	for _, realmId in pairs (self.realmIds) do
 		self.tradeQueryRequests:FetchLeagues(realmId, function(leagues, errMsg)
 			if errMsg then
 				self:SetNotice(self.controls.pbNotice, "Using Fallback Error while fetching league list: "..errMsg)
 			end
-			self.allLeagues = {}
 			for _, league in ipairs(leagues) do
 				if not self.allLeagues[realmId] then self.allLeagues[realmId] = {} end
 				t_insert(self.allLeagues[realmId], league)


### PR DESCRIPTION
### Description of the problem being solved:

Each iteration is wiping the accumulator.
Only the last iteration survives.

Bug very hard to notice in practice because:
1. All realms have (AFAICT) the same leagues as PC (which is the default selected in the UI)
2. The UI is self-healing: re-fetches any missing realms when changing selected realm [[1]](https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/78951a2e7d23bc0bb78e4a2ff777b82e1e54dc1f/src/Classes/TradeQuery.lua#L427)

### Steps taken to verify a working solution:
I used debug logs™

#### Before

```
callback realm='pc' - Start
keys={}
callback realm='pc' - End
keys={pc=[Standard,Hardcore,Ruthless,Hardcore Ruthless]}

callback realm='sony' - Start
keys={pc=[Standard,Hardcore,Ruthless,Hardcore Ruthless]}
callback realm='sony' - End
keys={sony=[Standard,Hardcore,Ruthless,Hardcore Ruthless]}

callback realm='xbox' - Start
keys={sony=[Standard,Hardcore,Ruthless,Hardcore Ruthless]}
callback realm='xbox' - End
keys={xbox=[Standard,Hardcore,Ruthless,Hardcore Ruthless]}
```

After

```
callback realm='xbox' - Start
keys={}
callback realm='xbox' - End
keys={xbox=[Standard,Hardcore,Ruthless,Hardcore Ruthless]}

callback realm='pc' - Start
keys={xbox=[Standard,Hardcore,Ruthless,Hardcore Ruthless]}
callback realm='pc' - End
keys={xbox=[Standard,Hardcore,Ruthless,Hardcore Ruthless]  pc=[Standard,Hardcore,Ruthless,Hardcore Ruthless]}

callback realm='sony' - Start
keys={xbox=[Standard,Hardcore,Ruthless,Hardcore Ruthless]  pc=[Standard,Hardcore,Ruthless,Hardcore Ruthless]}
callback realm='sony' - End
keys={sony=[Standard,Hardcore,Ruthless,Hardcore Ruthless]  xbox=[Standard,Hardcore,Ruthless,Hardcore Ruthless]  pc=[Standard,Hardcore,Ruthless,Hardcore Ruthless]}
```