### PR TITLE
Add support for Runegraft of the Agile

### DIFF
--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -153,6 +153,15 @@ describe("TetsItemMods", function()
 
 		build.configTab.input.customMods = [[Gain Elusive on Critical Strike
 		Elusive's Effect on you is increased instead for the first 2 seconds
+		Elusive on you reduces in effect 50% slower
+		Elusive is removed from you at 20% Effect]]
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.near(244 / 3, build.calcsTab.mainOutput.ElusiveEffectMod, 10 ^ -9)
+
+		build.configTab.input.customMods = [[Gain Elusive on Critical Strike
+		Elusive's Effect on you is increased instead for the first 2 seconds
 		100% increased Elusive Effect
 		Elusive is removed from you at 100% Effect]]
 		build.configTab:BuildModList()
@@ -160,11 +169,11 @@ describe("TetsItemMods", function()
 
 		assert.are.near(1630 / 9, build.calcsTab.mainOutput.ElusiveEffectMod, 10 ^ -9)
 
-		build.configTab.input.overrideBuffElusive = 80
+		build.configTab.input.overrideBuffElusive = 220
 		build.configTab:BuildModList()
 		runCallback("OnFrame")
 
-		assert.are.equals(80, build.calcsTab.mainOutput.ElusiveEffectMod)
+		assert.are.equals(220, build.calcsTab.mainOutput.ElusiveEffectMod)
 	end)
 
 	it("Varunastra works with close combat support", function()

--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -135,6 +135,38 @@ describe("TetsItemMods", function()
 		assert.are_not.equals(nonElusiveCritMult, build.calcsTab.mainOutput.CritMultiplier)
 	end)
 
+	it("Runegraft of the Agile affects average Elusive effect", function()
+		build.skillsTab:PasteSocketGroup("Smite 20/0  1\n")
+		build.configTab.input.customMods = "Gain Elusive on Critical Strike"
+		build.configTab.input.buffElusive = true
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(50, build.calcsTab.mainOutput.ElusiveEffectMod)
+
+		build.configTab.input.customMods = [[Gain Elusive on Critical Strike
+		Elusive's Effect on you is increased instead for the first 2 seconds]]
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.near(730 / 9, build.calcsTab.mainOutput.ElusiveEffectMod, 10 ^ -9)
+
+		build.configTab.input.customMods = [[Gain Elusive on Critical Strike
+		Elusive's Effect on you is increased instead for the first 2 seconds
+		100% increased Elusive Effect
+		Elusive is removed from you at 100% Effect]]
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.near(1630 / 9, build.calcsTab.mainOutput.ElusiveEffectMod, 10 ^ -9)
+
+		build.configTab.input.overrideBuffElusive = 80
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.are.equals(80, build.calcsTab.mainOutput.ElusiveEffectMod)
+	end)
+
 	it("Varunastra works with close combat support", function()
 		build.itemsTab:CreateDisplayItemFromRaw([[Varunastra
 		Vaal Blade

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -8334,8 +8334,7 @@ c["Elusive also grants +40% to Critical Strike Multiplier for Skills Supported b
 c["Elusive has 50% chance to be removed from you at 100% effect"]={nil,"Elusive has 50% chance to be removed from you at 100% effect "}
 c["Elusive has 50% chance to be removed from you at 100% effect 50% increased Effect of your Marks while Elusive"]={nil,"Elusive has 50% chance to be removed from you at 100% effect 50% increased Effect of your Marks while Elusive "}
 c["Elusive is removed from you at 20% effect"]={{[1]={flags=0,keywordFlags=0,name="ElusiveEffectMinThreshold",type="OVERRIDE",value=20}},nil}
-c["Elusive on you reduces in effect 50% slower"]={nil,"Elusive on you reduces in effect 50% slower "}
-c["Elusive on you reduces in effect 50% slower Elusive is removed from you at 20% effect"]={nil,"Elusive on you reduces in effect 50% slower Elusive is removed from you at 20% effect "}
+c["Elusive on you reduces in effect 50% slower"]={{[1]={flags=0,keywordFlags=0,name="ElusiveEffectLossSlower",type="INC",value=50}},nil}
 c["Elusive's Effect on you is increased instead for the first 2 seconds"]={{[1]={flags=0,keywordFlags=0,name="ElusiveEffectIncreaseDuration",type="BASE",value=2}},nil}
 c["Endurance, Frenzy and Power Charges as you"]={nil,"Endurance, Frenzy and Power Charges as you "}
 c["Enemies Become Chilled as they Unfreeze, causing 30% reduced Action Speed"]={nil,"Enemies Become Chilled as they Unfreeze, causing 30% reduced Action Speed "}

--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -8336,8 +8336,7 @@ c["Elusive has 50% chance to be removed from you at 100% effect 50% increased Ef
 c["Elusive is removed from you at 20% effect"]={{[1]={flags=0,keywordFlags=0,name="ElusiveEffectMinThreshold",type="OVERRIDE",value=20}},nil}
 c["Elusive on you reduces in effect 50% slower"]={nil,"Elusive on you reduces in effect 50% slower "}
 c["Elusive on you reduces in effect 50% slower Elusive is removed from you at 20% effect"]={nil,"Elusive on you reduces in effect 50% slower Elusive is removed from you at 20% effect "}
-c["Elusive's Effect on you is increased instead for the first 2 seconds"]={nil,"Elusive's Effect on you is increased instead for the first 2 seconds "}
-c["Elusive's Effect on you is increased instead for the first 2 seconds Limited to 1 Runegraft of the Agile"]={nil,"Elusive's Effect on you is increased instead for the first 2 seconds Limited to 1 Runegraft of the Agile "}
+c["Elusive's Effect on you is increased instead for the first 2 seconds"]={{[1]={flags=0,keywordFlags=0,name="ElusiveEffectIncreaseDuration",type="BASE",value=2}},nil}
 c["Endurance, Frenzy and Power Charges as you"]={nil,"Endurance, Frenzy and Power Charges as you "}
 c["Enemies Become Chilled as they Unfreeze, causing 30% reduced Action Speed"]={nil,"Enemies Become Chilled as they Unfreeze, causing 30% reduced Action Speed "}
 c["Enemies Become Chilled as they Unfreeze, causing 30% reduced Action Speed 30% chance to Freeze Enemies which are Chilled"]={nil,"Enemies Become Chilled as they Unfreeze, causing 30% reduced Action Speed 30% chance to Freeze Enemies which are Chilled "}

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -775,7 +775,19 @@ local function doActorMisc(env, actor)
 			end
 			inc = inc + maxSkillInc
 			local elusiveEffectMod = (1 + inc / 100) * modDB:More(nil, "ElusiveEffect", "BuffEffectOnSelf") * 100
-			output.ElusiveEffectMod = (elusiveEffectMod + (modDB:Override(nil, "ElusiveEffectMinThreshold") or 0)) / 2
+			local elusiveEffectMinThreshold = modDB:Override(nil, "ElusiveEffectMinThreshold") or 0
+			local elusiveEffectIncreaseDuration = modDB:Sum("BASE", nil, "ElusiveEffectIncreaseDuration")
+			if elusiveEffectIncreaseDuration > 0 then
+				local elusiveEffectChangeRate = 20
+				local peakElusiveEffect = elusiveEffectMod + elusiveEffectChangeRate * elusiveEffectIncreaseDuration
+				local elusiveEffectDecreaseDuration = (peakElusiveEffect - elusiveEffectMinThreshold) / elusiveEffectChangeRate
+				local totalElusiveEffectDuration = elusiveEffectIncreaseDuration + elusiveEffectDecreaseDuration
+				local averageIncreaseEffect = (elusiveEffectMod + peakElusiveEffect) / 2
+				local averageDecreaseEffect = (peakElusiveEffect + elusiveEffectMinThreshold) / 2
+				output.ElusiveEffectMod = (averageIncreaseEffect * elusiveEffectIncreaseDuration + averageDecreaseEffect * elusiveEffectDecreaseDuration) / totalElusiveEffectDuration
+			else
+				output.ElusiveEffectMod = (elusiveEffectMod + elusiveEffectMinThreshold) / 2
+			end
 			-- if we want the max skill to not be noted as its own breakdown table entry, comment out below
 			modDB:NewMod("ElusiveEffect", "INC", maxSkillInc, "Max Skill Effect")
 			-- Override elusive effect if set.

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -777,9 +777,10 @@ local function doActorMisc(env, actor)
 			local elusiveEffectMod = (1 + inc / 100) * modDB:More(nil, "ElusiveEffect", "BuffEffectOnSelf") * 100
 			local elusiveEffectMinThreshold = modDB:Override(nil, "ElusiveEffectMinThreshold") or 0
 			local elusiveEffectIncreaseDuration = modDB:Sum("BASE", nil, "ElusiveEffectIncreaseDuration")
+			local peakElusiveEffect = elusiveEffectMod
 			if elusiveEffectIncreaseDuration > 0 then
-				local elusiveEffectChangeRate = 20
-				local peakElusiveEffect = elusiveEffectMod + elusiveEffectChangeRate * elusiveEffectIncreaseDuration
+				local elusiveEffectChangeRate = 20 / (1 + modDB:Sum("INC", nil, "ElusiveEffectLossSlower") / 100)
+				peakElusiveEffect = elusiveEffectMod + elusiveEffectChangeRate * elusiveEffectIncreaseDuration
 				local elusiveEffectDecreaseDuration = (peakElusiveEffect - elusiveEffectMinThreshold) / elusiveEffectChangeRate
 				local totalElusiveEffectDuration = elusiveEffectIncreaseDuration + elusiveEffectDecreaseDuration
 				local averageIncreaseEffect = (elusiveEffectMod + peakElusiveEffect) / 2
@@ -792,7 +793,7 @@ local function doActorMisc(env, actor)
 			modDB:NewMod("ElusiveEffect", "INC", maxSkillInc, "Max Skill Effect")
 			-- Override elusive effect if set.
 			if modDB:Override(nil, "ElusiveEffect") then
-				output.ElusiveEffectMod = m_min(modDB:Override(nil, "ElusiveEffect"), elusiveEffectMod)
+				output.ElusiveEffectMod = m_min(modDB:Override(nil, "ElusiveEffect"), peakElusiveEffect)
 			end
 			local effect = output.ElusiveEffectMod / 100
 			condList["Elusive"] = true

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5496,6 +5496,7 @@ local specialModList = {
 	["gain a random shrine buff every (%d+) seconds"] = { flag("Condition:CanHaveRegularShrines") },
 	["gain a random shrine buff for (%d+) seconds when you kill a rare or unique enemy"] = { flag("Condition:CanHaveRegularShrines") },
 	["(%d+)%% chance to gain elusive when you block while dual wielding"] = { flag("Condition:CanBeElusive", { type = "Condition", var = "DualWielding" }) },
+	["elusive on you reduces in effect (%d+)%% slower"] = function(num) return { mod("ElusiveEffectLossSlower", "INC", num) } end,
 	["elusive's effect on you is increased instead for the first (%d+) seconds"] = function(num) return { mod("ElusiveEffectIncreaseDuration", "BASE", num) } end,
 	["elusive is removed from you at (%d+)%% effect"] = function(num) return { mod("ElusiveEffectMinThreshold", "OVERRIDE", num) } end,
 	["nearby enemies have (%a+) resistance equal to yours"] = function(_, res) return { flag("Enemy"..(res:gsub("^%l", string.upper)).."ResistEqualToYours") } end,

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -5496,6 +5496,7 @@ local specialModList = {
 	["gain a random shrine buff every (%d+) seconds"] = { flag("Condition:CanHaveRegularShrines") },
 	["gain a random shrine buff for (%d+) seconds when you kill a rare or unique enemy"] = { flag("Condition:CanHaveRegularShrines") },
 	["(%d+)%% chance to gain elusive when you block while dual wielding"] = { flag("Condition:CanBeElusive", { type = "Condition", var = "DualWielding" }) },
+	["elusive's effect on you is increased instead for the first (%d+) seconds"] = function(num) return { mod("ElusiveEffectIncreaseDuration", "BASE", num) } end,
 	["elusive is removed from you at (%d+)%% effect"] = function(num) return { mod("ElusiveEffectMinThreshold", "OVERRIDE", num) } end,
 	["nearby enemies have (%a+) resistance equal to yours"] = function(_, res) return { flag("Enemy"..(res:gsub("^%l", string.upper)).."ResistEqualToYours") } end,
 	["for each nearby corpse, regenerate ([%d%.]+)%% life per second, up to ([%d%.]+)%%"] = function(num, _, limit) return { mod("LifeRegenPercent", "BASE", num, { type = "Multiplier", var = "NearbyCorpse", limit = tonumber(limit), limitTotal = true }) } end,


### PR DESCRIPTION
### Description of the problem being solved:

Runegraft of the Agile causes Elusive's effect to increase for the first 2 seconds before decaying normally, but PoB's average Elusive effect did not account for this growth phase.

This adds parsing for the Runegraft and calculates the time-weighted average when using average elusive calculation mode

### Steps taken to verify a working solution:

  - Added test coverage for normal and Runegraft Elusive averages.
  - Tested increased Elusive effect, removal thresholds, and manual overrides.
  - Regenerated ModCache and verified deterministic output.
  - Ran the full Busted suite: 296 successes, 0 failures, 0 errors.