### PR TITLE
Add support for "Unhallowed Rite" Occultist Ascendancy node

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -708,6 +708,15 @@ local function doActorMisc(env, actor)
 			modDB:NewMod("Cost", "MORE", -effect, "Fanaticism", ModFlag.Cast)
 			modDB:NewMod("AreaOfEffect", "INC", effect, "Fanaticism", ModFlag.Cast)
 		end
+		if modDB:Flag(nil, "Condition:CanGainSpiritInfusion") then			
+			-- storing tags in local var to avoid repetition
+			local globalEffectTag = { type = "GlobalEffect", effectType = "Buff", effectName = "Spirit Infusion", unscalable = true }
+			local multiplierTag = { type = "Multiplier", var = "SpiritInfusion"--[[ , limitVar = "SpiritInfusionsMax" ]] }
+			
+			modDB:NewMod("EnergyShieldRechargeFaster", "INC", 30 , "Spirit Infusion", multiplierTag, globalEffectTag)
+			modDB:NewMod("Damage", "MORE", 10 , "Spirit Infusion", nil, KeywordFlag.Spell, { type = "SkillType", skillType = SkillType.Channel }, multiplierTag, globalEffectTag)
+			modDB:NewMod("Cost", "MORE", 20 , "Spirit Infusion", nil, KeywordFlag.Spell, { type = "SkillType", skillType = SkillType.Channel }, multiplierTag, globalEffectTag)
+		end
 		if modDB:Flag(nil, "UnholyMight") then
 			local effect = 1 + modDB:Sum("INC", nil, "BuffEffectOnSelf") / 100
 			modDB:NewMod("PhysicalDamageConvertToChaos", "BASE", m_floor(100 * effect), "Unholy Might")
@@ -957,6 +966,7 @@ local function doActorCharges(env, actor)
 	output.AfflictionChargesMax = m_max(modDB:Flag(nil, "MaximumFrenzyChargesEqualsMaximumAfflictionCharges") and output.FrenzyChargesMax or 0, 0)
 	output.BloodChargesMax = m_max(modDB:Sum("BASE", nil, "BloodChargesMax"), 0)
 	output.SpiritChargesMax = m_max(modDB:Sum("BASE", nil, "SpiritChargesMax"), 0)
+	output.SpiritInfusionsMax = modDB:Sum("BASE", nil, "SpiritInfusionsMax") + (modDB:Flag(nil, "Condition:CanGainSpiritInfusion") and 5 or 0)
 
 	-- Initialize Charges
 	output.PowerCharges = 0
@@ -972,6 +982,7 @@ local function doActorCharges(env, actor)
 	output.AfflictionCharges = 0
 	output.BloodCharges = 0
 	output.SpiritCharges = 0
+	output.SpiritInfusions = 0
 
 	-- Conditionally over-write Charge values
 	if modDB:Flag(nil, "MinimumFrenzyChargesIsMaximumFrenzyCharges") then
@@ -1036,6 +1047,8 @@ local function doActorCharges(env, actor)
 	end
 	output.BloodCharges = m_min(modDB:Override(nil, "BloodCharges") or output.BloodChargesMax, output.BloodChargesMax)
 	output.SpiritCharges = m_min(modDB:Override(nil, "SpiritCharges") or 0, output.SpiritChargesMax)
+	output.SpiritInfusions = m_min(modDB:Override(nil, "SpiritInfusion") or 0, output.SpiritInfusionsMax)
+
 
 	output.CrabBarriers = m_min(modDB:Override(nil, "CrabBarriers") or output.CrabBarriersMax, output.CrabBarriersMax)
 	if modDB:Flag(nil, "HaveMaximumPowerCharges") then
@@ -1069,6 +1082,7 @@ local function doActorCharges(env, actor)
 	modDB.multipliers["AfflictionCharge"] = output.AfflictionCharges
 	modDB.multipliers["BloodCharge"] = output.BloodCharges
 	modDB.multipliers["SpiritCharge"] = output.SpiritCharges
+	modDB.multipliers["SpiritInfusion"] = output.SpiritInfusions
 end
 
 function calcs.actionSpeedMod(actor)

--- a/src/Modules/Calcs.lua
+++ b/src/Modules/Calcs.lua
@@ -677,6 +677,9 @@ function calcs.buildOutput(build, mode)
 		if build.calcsTab.mainEnv.multipliersUsed["SpiritCharge"] then
 			t_insert(combatList, s_format("%d Spirit Charges", output.SpiritCharges))
 		end
+		if build.calcsTab.mainEnv.multipliersUsed["SpiritInfusion"] then
+			t_insert(combatList, s_format("%d Spirit Infusions", output.SpiritInfusions))
+		end
 		if env.player.mainSkill.baseSkillModList:Flag(nil, "Cruelty") then
 			t_insert(combatList, "Cruelty")
 		end

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -948,6 +948,9 @@ Huge sets the radius to 11.
 	{ var = "overrideSpiritCharges", type = "countAllowZero", label = "# of Spirit Charges:", ifMult = "SpiritCharge", apply = function(val, modList, enemyModList)
 		modList:NewMod("SpiritCharges", "OVERRIDE", val, "Config", { type = "Condition", var = "Combat" })
 	end },
+	{ var = "overrideSpiritInfusion", type = "countAllowZero", label = "# of Spirit Infusions:", ifFlag = "Condition:CanGainSpiritInfusion", tooltip = "Each stack of Spirit Infusion grants:\n30% faster start of Energy Shield Recharge, \nChannelling Spells deal 10% more Damage and \nChannelling Spells have 20% more Cost", apply = function(val, modList, enemyModList)
+		modList:NewMod("SpiritInfusion", "OVERRIDE", val, "Config", { type = "Condition", var = "Combat" } )
+	end },
 	{ var = "minionsUsePowerCharges", type = "check", label = "Do your Minions use Power Charges?", ifFlag = "haveMinion", apply = function(val, modList, enemyModList)
 		modList:NewMod("MinionModifier", "LIST", { mod = modLib.createMod("UsePowerCharges", "FLAG", true, "Config", { type = "Condition", var = "Combat" }) }, "Config")
 	end },
@@ -1652,9 +1655,6 @@ Huge sets the radius to 11.
 	end },
 	{ var = "buffFanaticism", type = "check", label = "Do you have Fanaticism?", ifFlag = "Condition:CanGainFanaticism", tooltip = "This will enable the Fanaticism buff itself. (Grants 75% more cast speed, reduced skill cost, and increased area of effect)", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:Fanaticism", "FLAG", true, "Config", { type = "Condition", var = "Combat" }, { type = "Condition", var = "CanGainFanaticism" })
-	end },
-	{ var = "overrideSpiritInfusion", type = "countAllowZero", label = "# of Spirit Infusion stacks:", ifFlag = "Condition:CanGainSpiritInfusion", tooltip = "Each stack of Spirit Infusion grants:\n30% faster start of Energy Shield Recharge, \nChannelling Spells deal 10% more Damage and \nChannelling Spells have 20% more Cost", apply = function(val, modList, enemyModList)
-		modList:NewMod("SpiritInfusion", "OVERRIDE", val, "Config", { type = "Condition", var = "Combat" } )
 	end },
 	{ var = "conditionHitsAlwaysStun", type = "check", label = "Do your hits always stun?", ifFlag = "Condition:maceMasteryStunCullSpecced", tooltip = "This enables the conditional culling strike from the mace mastery.", apply = function(val, modList, enemyModList)
 		modList:NewMod("CullPercent", "MAX", 10, "Config", { type = "Condition", var = "Combat" }, {type = "Condition", var = "maceMasteryStunCullSpecced"})

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1653,6 +1653,9 @@ Huge sets the radius to 11.
 	{ var = "buffFanaticism", type = "check", label = "Do you have Fanaticism?", ifFlag = "Condition:CanGainFanaticism", tooltip = "This will enable the Fanaticism buff itself. (Grants 75% more cast speed, reduced skill cost, and increased area of effect)", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:Fanaticism", "FLAG", true, "Config", { type = "Condition", var = "Combat" }, { type = "Condition", var = "CanGainFanaticism" })
 	end },
+	{ var = "overrideSpiritInfusion", type = "countAllowZero", label = "# of Spirit Infusion stacks:", ifFlag = "Condition:CanGainSpiritInfusion", tooltip = "Each stack of Spirit Infusion grants:\n30% faster start of Energy Shield Recharge, \nChannelling Spells deal 10% more Damage and \nChannelling Spells have 20% more Cost", apply = function(val, modList, enemyModList)
+		modList:NewMod("SpiritInfusion", "OVERRIDE", val, "Config", { type = "Condition", var = "Combat" } )
+	end },
 	{ var = "conditionHitsAlwaysStun", type = "check", label = "Do your hits always stun?", ifFlag = "Condition:maceMasteryStunCullSpecced", tooltip = "This enables the conditional culling strike from the mace mastery.", apply = function(val, modList, enemyModList)
 		modList:NewMod("CullPercent", "MAX", 10, "Config", { type = "Condition", var = "Combat" }, {type = "Condition", var = "maceMasteryStunCullSpecced"})
 	end },

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2873,7 +2873,7 @@ local specialModList = {
 	["every second, inflict withered on nearby enemies for (%d+) seconds"] = { flag("Condition:CanWither") },
 	["nearby hindered enemies deal (%d+)%% reduced damage over time"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("DamageOverTime", "INC", -num) }, { type = "ActorCondition", actor = "enemy", var = "Hindered" }) } end,
 	["nearby chilled enemies deal (%d+)%% reduced damage with hits"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("Damage", "INC", -num) }, { type = "ActorCondition", actor = "enemy", var = "Chilled" }) } end,
-	["gain spirit infusion every (%d+)%.?(%d?) seconds? while channelling a spell"] = function(_,_) return { flag("Condition:CanGainSpiritInfusion") } end,
+	["gain spirit infusion every ?(%d?)%.?(%d?) seconds? while channelling a spell"] = function(_,_) return { flag("Condition:CanGainSpiritInfusion") } end,
 	-- Pathfinder
 	["always poison on hit while using a flask"] = { mod("PoisonChance", "BASE", 100, { type = "Condition", var = "UsingFlask" }) },
 	["poisons you inflict during any flask effect have (%d+)%% chance to deal (%d+)%% more damage"] = function(num, _, more) return { mod("Damage", "MORE", tonumber(more) * num / 100, nil, 0, KeywordFlag.Poison, { type = "Condition", var = "UsingFlask" }) } end,

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -2873,6 +2873,7 @@ local specialModList = {
 	["every second, inflict withered on nearby enemies for (%d+) seconds"] = { flag("Condition:CanWither") },
 	["nearby hindered enemies deal (%d+)%% reduced damage over time"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("DamageOverTime", "INC", -num) }, { type = "ActorCondition", actor = "enemy", var = "Hindered" }) } end,
 	["nearby chilled enemies deal (%d+)%% reduced damage with hits"] = function(num) return { mod("EnemyModifier", "LIST", { mod = mod("Damage", "INC", -num) }, { type = "ActorCondition", actor = "enemy", var = "Chilled" }) } end,
+	["gain spirit infusion every (%d+)%.?(%d?) seconds? while channelling a spell"] = function(_,_) return { flag("Condition:CanGainSpiritInfusion") } end,
 	-- Pathfinder
 	["always poison on hit while using a flask"] = { mod("PoisonChance", "BASE", 100, { type = "Condition", var = "UsingFlask" }) },
 	["poisons you inflict during any flask effect have (%d+)%% chance to deal (%d+)%% more damage"] = function(num, _, more) return { mod("Damage", "MORE", tonumber(more) * num / 100, nil, 0, KeywordFlag.Poison, { type = "Condition", var = "UsingFlask" }) } end,


### PR DESCRIPTION
### Description of the problem being solved:
This adds support for the new 3.29 Ascendancy Notable "Unhallowed Rite", which provides "Spirit Infusions"

> Added a new Notable, Unhallowed Rite, which requires either Vile Bastion or Forbidden Power. Unhallowed Rite causes you to gain Spirit Infusion every second while Channelling a Spell. Each stack of Spirit Infusion grants 30% faster start of Energy Shield Recharge, Channelling Spells deal 10% more Damage and Channelling Spells have 20% more Cost. Maximum of 5 stacks. You lose one stack every 0.5 seconds if you have not gained a stack in the past 4 seconds.

**Comments:** 
- I'm quoting the outdated patch notes here, but base on most recent tree data the wording is actually `Gain Spirit Infusion every **0.5 seconds**` rather than `"every second"`, but the mod pattern handles both cases correctly
- I have implemented the infusions like a type of "Charge". That seemed the most fitting, even if it isn't technically called "Charge". Crab Barriers are apparently also "Charges", so ... 🦀 🤷 🦀 
- I left the default value for the Spirit Infusion config empty, which means it won't show up as a damage increase unless you set the config. It could have been set to `5`, but then it would always show up as 50% more damage for channelling spells, which I think is also misleading. Feel free to add the default value if you prefer.


### Steps taken to verify a working solution:
- Mod gets parsed
- Config Option for Spirit Infusions shows up if you have the mod
- Config Option disappears/ gets marked as invalid if you don't have the mod
- Damage buff applies to channelling spells and scales with infusions
- Damage buff also applies to ailments from channelled spells, as well as hit damage *(the mod wording specifies "spells deal more damage" not "more spell damage"
- Cost multiplier applies to channelling spells and scales with infusions
- Faster recharge applies and scales with infusions
- Buff appears in Calcs screen `Combat Buffs` with correct number
- Infusion buffs are limited by maximum of 5 stacks
- Damage and Cost mods do not apply to non-channelling spells
- Damage and Cost mods do not apply to channelling attacks
- Effects do not apply if the mod gets disabled

### Limitations:
The actual line for the mod in the data file is `"Gain [SpiritInfusion|Spirit Infusion] every 0.5 seconds while Channelling a Spell"`, which contains the new keyword highlighting syntax. This PR assumes that the mod line of the nod gets parsed properly. It **does not** implement the actual sanitizing of that string, as that is something then should probably be handled centrally for all passive node mods.

### Link to a build that showcases this PR:
```
eNrNHGtv2zjyc_MrCB_u2zax7NhJg6QLx3Ee2KTx2Wl796mgJdrmlhZdikriPdx_vyGpdyyHsoTDdYGtTM4MhzPDeZG757-_rhh6JiKg3L9oOYftFiK-yz3qLy5aX5-uP562fv98cD7Gcvk4vwwpUzOfDz6c62_EyDNhgNdCOHCJ7w0ZDoIveEUuWl-4T1rIXWKBXUnEvYIchJI_cA9mpQhhVmKxIPJbvHz3Byy_xr5cEu4_4D-5uOFeTCkZp35ufIZ9j8pkvZSBqQtEW2iFqT_l7k8ibwQP15rZZ0peDB93D-PHyVMLdvThfMzwhoipxBIF8K-L1gAEgxfklkpAwSwE-K7TOTztd3qto50ol6EI5BVewac16nRNiJdAH5eBATd5yO5hvwx2LMhoPieupM9kKKgcLrHvphyV4lWFfQiZpGtGiUjgncPejh0UiDvtdhnwE5eYXY2nKazT6R92273dCDxVWSnp71QuLxmIsgp5hXS38KkkVbHGnAbc32crWZzS3QxDxuBsWsFOSEDEM5Y0z085bb6aUb-aoAaC4Me5Mb8J9mgYPBApSJCxkFKbesA-HvIg1eHpLsgxEeB7ZA6h_Q7ClLgc3FUWpduxWGQ7aulq93RO7CErbSRCqMrNfvsYTW3hKhPej6EJeFY7yCkPmSWkTN1XZ8fZ-ZUFdDpOGeQVebWjlwXcQe_Ol3b0soBOr1fO3zOXOka-JxntiEa34_SsnB52Op-czkn75KQ8oo2Xm4C6mD3gV7oKV-D3n_BPkq7X32Gpi6X0wZ2VoXZPylCvqSDVsYaceXtgLTEPStFOd51DCyFAmHfPFOyd79od7q--0J49kx30dyJM4MipjGXGiCVGukR0cG2CuFlqQfxovY3ddu4JcZc3kL9NsCR2rj2B6u0Wq4K1EqsC3CLWniVCBSEpxBIhHX7ahVRRTCOfiMVmuqSEedWgY8aGeG3hTZWYs9hW4s4vV8lisqgVRfIdC88u5lTl6RkHWQ_r9HeLy4DbGSaB1BUQPFJIptvl1QD_U9UCrBraQKx4KCwVboCtNhBHB1MmTYgXunbRKClpLhnUdbbbSLCAT8YqoQ6kxO7PK-4trIWmF6mEkedvGq7X4EOUNdgSUIEPEnuaSXU-9i2gH8GUrU60ipH2C6TQ1gskUd9-lQKK_V5U5K6wmRTceolEoQ_gLFYQBHTZ_sBTT1Oa6V1DLWdVmGlAywJxzF-A86VquQTVoCHDSbOaUlYE8f_aWNPPgVstMPK9UKijYL1GEWPbMk90BY40CK6wxCggWLjLe9DyRauV-XWNGZuBC9Cjupd0TZkk4grmFH3FA_KidPobFhT70tGdpsJgJ1b6-ZFuoKmvIffndIGw6dLoH1MiFaBmMBlB1NMkJZWMqOx9jkMmNdCH8zt_HUrk68aXik2CeuBIqKDyzp-HJgb54WpGRNLKySO5YSD5CqwT5BpIoft_f1MRFBkyKKaDiAp9qH3YAwGpgi1AL0uIKUj5KZ_oJgTCSHuxgx0EDHI57jYmV0mfqWxvvRgNjMElS_BBRETIxCerjXJ7Y5JB6JYjKMMgsYpTDOe9NfKBLUXsdI6dd1Bzbilhsf0OVhyhEwU7n04_2axU5PD0U_89tEwMSGTethD6HsKI2pwxxknbZp3KzKkdWVtEYn-34BH4C5jrNYOZqcoPQG8rOHre5WbA2CZjL-8wkOSICULbOe6-g6Tb6RnFHdswrbqQRBBPszvkIYQkwuYVLDuJtrYCy2PtpZs9DCdZcJ8TCG6liLbrALrGPUPuKwVmT3QBUVNJ1t4lZZvtFjhTl0NUMhZnZWSp_kdqubzl2ptplKZzxibYz0rnZId0pkuIlhV4XSclylu_e7xjnYAuKHuc66QFltPZQWG586Mkkur4a36pzydByDdKXtBfnK_-qWO5-vpX8nVvbrm6EBmX_EUlGFcUkjvIYFwSxHdZJluYSljRRPi71ZoLicir-muMhdxctOaYBcRMDzFzA81YLsLRwP0xC-dzdT2VRuLR9fVo-HT3bRTtJYsS_KSM_TC7fbvrKdFVlU4epgoSjjwMAelwFpi5i5bavZ68IhJTBsJzQc94HRAvy3Oe2m16ULK0NJ3MnAUlKL9dQZXOsoRGr0RI2H06a0FKX_y8YcfwovIile5ZEYqCT5aUKQOHOJCmq2BBRZ3tPBE1YrcVsB_MCsKNx2w2oDb-tFmr4CSDLUKRMBeA36Jz6kYwdlqPnVVONq4Lqba7saKhL93y-NGQBbK5Rstjx2M2UtV3dwWpRmM29kVcvMljR0MWyElXKk8gGea-vmq2oDRiZECZKioLmv3CfW3scG5SAAuCD-B3TMFaIPioUoZkxoISnBJBZ6EsHufsuI2sdI88JyY9YrMX3QfOopoRG7nmeqM5b5SbsXNqBRJmxAI1zpOyyGbMUgVRPZATfzRmI4Q4Ic3tPx60OSTa3Q6eOfXeeoo3k3UJ6lZeA3ypZl19MsXunRVFSMWCn4XzEo_tif4VkigqN1uo6HTFjog6cvUoqJNXj8IT9V0ZCmJFYPImHZkUk5ASzKSplAvW8eCe-EkDam8Kpk22N7pOiG2wlf-_InOd0W4JAOmUZSzZTusaMmGVbmBpezLKaU1l6F-BdBsgpbe43SPtJ64o9G6VWglF41SiG-S3_jKasPZOZYQgL7i1TUBLKSWd7VuCmXrYxFk9gm-u0OsQU7dz4Rr7XkzucVveX1kNXAZAU3dtr9QlYF0Z6pr6LaGEL6hQowrx_AuHrEmRVqPxD122Rl1j1X5IGsbqB1pBlULEJkrcVN9av4y883RR67JQTd_iYAlHcoXTJ5gdqCCh8gSM3ulpV1W8uk2LxWaQPvBUVHzKco8-I8pS1dLpe87OadSf_jq51x8fllKug7Ojo5eXl8M1lks-J69Q7h-6fHW0Bjqwm4-6ov2oSB0N4M_lYqD_aEJHMaVz86gziHoCj1HTO4iKfSUFLUUlJvWhK3CE12vgONYXAngoMXGUIjHY0hQq_IH3rBzBE9h1kKvZdd0UoADc2A1ZBZebq_H0WmWEhSdyqk1wTxZQDymwzGq6ZQ9jUUfBV8KPn8e08nTjvkKK9I8Qq5Cu5awbEZBlGAxV5sEyg_v7VmwRptRPrxHigegWIRKhGkTEV-8_YttDEG9Z6JE7P7qFSthXL2kHKXV9GcHwTG0k27833fsitDbmZOUP58B1cWGtdmVH36kP1vkoZupkhL7ehG52GDs300jPP5t7lQLWgqzUyAOR2MMSH91JkOqREu2RZga-MtCGjRvGZ5g5OWaUzSSM5-A6b-A0yK-MiqK30Z2kbWXWbljyUPB9bFb6I90kxuwPH7CD7SqIYVAMlNFDEd9CGUWUrRrZKv7_vcCzwjYdoVrSvmTYgxw7FGKzXdQaAMUQGTnnMC2EbBJEL-b5_9jqdWx5owI9uk0JJtlqwPJ1R3wG0UxuV0V2PqOI7LCFHrLgjRt69Bk3uU3A0t1oxUgUHNR3FBt2dbTDgJgnud8JXnNfY5jzYXrQQCUbTSYgEbk5Q5PBZHTwhbwgBXAw8FVbnLrRLfBMGe3BUOC5JN4ZUgsdjAWZ09czpP4Ljh0_puHc5kcUJc9Qp30QpQhn6OYj_HOgo-6E_DpDJ-2Du9WaUZeqWefg3xIvgrN1dHH7w9NZ22-E6Xcb6UD0VwyXAvyG9an6j9Nu_x3xOYqvgJHJ_9Bc8BVSiTd6oXKJ5JIGyEgVwdeQ-5C9gECQ5AgjqBg9AB8Z4lrBD9zTty7xGwChfqiHgfHbW21oiVoyrwV2KxGOJOMAK43ZtlvRncIl9zbItIzQYLYJAtiKESaCDFGBj2eQiEVXHaVkwIbBnxcp9CpQuOSQd9dhYSuBKhxEanLQ9AWvi4SOq3BCmCzi96sz0inScCrQ0A2WSlyXrVrfDLp1tditzUJ_HzuoIf4yYXYrq7DaESg9zE4DAug0dZiqnMpbAkFf1jmOZbpozDdUMk8VECtpY5s3acgo9pJiXYVuPeFOU7qoHTH6TcnEQrhOcUsV1h6sQkZk5YO0x-72s7XKLruq4irAT1T14FRF6FRF6NY81b3aYa5TObz0mvEkvZpb7zYQnnoN0Oju64caWPu4dlRsKCx0m3KB_do76td153Xz9iaSvvqKbeJ49Cv7hup5TaemtI-bMeD6dtdrQO2NZRJVpVp7905TnHebSusak6VTO8buLZzK568-r8dNyX8bK6YVZRqQ6pISe2Sqn8Z-J-pZdmDuNnU78vPB-VHx_yzzX1CdsRU=
```

### After screenshot:
mod parsing:
<img width="697" height="67" alt="image" src="https://github.com/user-attachments/assets/0e84e025-c3de-4c24-9cb5-a5b582c6d738" />

config option (set to 6, but only 5 apply due to limit):
<img width="367" height="362" alt="image" src="https://github.com/user-attachments/assets/d871c3cc-0328-413a-bc83-cb23ceebcadc" />

Combat Buff:
<img width="710" height="171" alt="image" src="https://github.com/user-attachments/assets/52be43f0-2b94-44d7-aae2-0fe58c5d3ea0" />

Damage buff effect:
<img width="708" height="361" alt="image" src="https://github.com/user-attachments/assets/bad144d8-b468-4bc4-85dd-f8508a36e44b" />

Energy Shield recharge effect:
<img width="538" height="250" alt="image" src="https://github.com/user-attachments/assets/37e0d6b2-114f-4491-a9f8-2c5fed0df021" />

Cost effect:
<img width="708" height="222" alt="image" src="https://github.com/user-attachments/assets/97fa6252-0efc-4f86-8ec8-8f218a8cd231" />

