### PR TITLE
Update Spirit Infusion buffs and maximum stacks

### DIFF
--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -711,11 +711,11 @@ local function doActorMisc(env, actor)
 		if modDB:Flag(nil, "Condition:CanGainSpiritInfusion") then			
 			-- storing tags in local var to avoid repetition
 			local globalEffectTag = { type = "GlobalEffect", effectType = "Buff", effectName = "Spirit Infusion", unscalable = true }
-			local multiplierTag = { type = "Multiplier", var = "SpiritInfusion"--[[ , limitVar = "SpiritInfusionsMax" ]] }
+			local multiplierTag = { type = "Multiplier", var = "SpiritInfusion" }
 			
-			modDB:NewMod("EnergyShieldRechargeFaster", "INC", 30 , "Spirit Infusion", multiplierTag, globalEffectTag)
-			modDB:NewMod("Damage", "MORE", 10 , "Spirit Infusion", nil, KeywordFlag.Spell, { type = "SkillType", skillType = SkillType.Channel }, multiplierTag, globalEffectTag)
-			modDB:NewMod("Cost", "MORE", 20 , "Spirit Infusion", nil, KeywordFlag.Spell, { type = "SkillType", skillType = SkillType.Channel }, multiplierTag, globalEffectTag)
+			modDB:NewMod("EnergyShieldRechargeFaster", "INC", 15 , "Spirit Infusion", multiplierTag, globalEffectTag)
+			modDB:NewMod("Damage", "MORE", 5 , "Spirit Infusion", nil, KeywordFlag.Spell, { type = "SkillType", skillType = SkillType.Channel }, multiplierTag, globalEffectTag)
+			modDB:NewMod("Cost", "MORE", 10 , "Spirit Infusion", nil, KeywordFlag.Spell, { type = "SkillType", skillType = SkillType.Channel }, multiplierTag, globalEffectTag)
 		end
 		if modDB:Flag(nil, "UnholyMight") then
 			local effect = 1 + modDB:Sum("INC", nil, "BuffEffectOnSelf") / 100
@@ -980,7 +980,7 @@ local function doActorCharges(env, actor)
 	output.AfflictionChargesMax = m_max(modDB:Flag(nil, "MaximumFrenzyChargesEqualsMaximumAfflictionCharges") and output.FrenzyChargesMax or 0, 0)
 	output.BloodChargesMax = m_max(modDB:Sum("BASE", nil, "BloodChargesMax"), 0)
 	output.SpiritChargesMax = m_max(modDB:Sum("BASE", nil, "SpiritChargesMax"), 0)
-	output.SpiritInfusionsMax = modDB:Sum("BASE", nil, "SpiritInfusionsMax") + (modDB:Flag(nil, "Condition:CanGainSpiritInfusion") and 5 or 0)
+	output.SpiritInfusionsMax = modDB:Sum("BASE", nil, "SpiritInfusionsMax") + (modDB:Flag(nil, "Condition:CanGainSpiritInfusion") and 10 or 0)
 
 	-- Initialize Charges
 	output.PowerCharges = 0

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -954,7 +954,7 @@ Huge sets the radius to 11.
 	{ var = "overrideSpiritCharges", type = "countAllowZero", label = "# of Spirit Charges:", ifMult = "SpiritCharge", apply = function(val, modList, enemyModList)
 		modList:NewMod("SpiritCharges", "OVERRIDE", val, "Config", { type = "Condition", var = "Combat" })
 	end },
-	{ var = "overrideSpiritInfusion", type = "countAllowZero", label = "# of Spirit Infusions:", ifFlag = "Condition:CanGainSpiritInfusion", tooltip = "Each stack of Spirit Infusion grants:\n30% faster start of Energy Shield Recharge, \nChannelling Spells deal 10% more Damage and \nChannelling Spells have 20% more Cost", apply = function(val, modList, enemyModList)
+	{ var = "overrideSpiritInfusion", type = "countAllowZero", label = "# of Spirit Infusions:", ifFlag = "Condition:CanGainSpiritInfusion", tooltip = "Each stack of Spirit Infusion grants:\n15% faster start of Energy Shield Recharge, \nChannelling Spells deal 5% more Damage and \nChannelling Spells have 10% more Cost\nMaximum 10 stacks", apply = function(val, modList, enemyModList)
 		modList:NewMod("SpiritInfusion", "OVERRIDE", val, "Config", { type = "Condition", var = "Combat" } )
 	end },
 	{ var = "minionsUsePowerCharges", type = "check", label = "Do your Minions use Power Charges?", ifFlag = "haveMinion", apply = function(val, modList, enemyModList)


### PR DESCRIPTION
Stats granted by Spirit infusion were changed in latest patch update
- Max stacks `5` -> 10
- Dmg `10%` -> 5%
- Faster Start of Energy Shield Recharge `30%` -> 15%
- Cost `20%` -> 10%

### After screenshot:
<img width="708" height="176" alt="image" src="https://github.com/user-attachments/assets/8506557e-cda2-4d91-8d30-2eace9994eb3" />
<img width="708" height="190" alt="image" src="https://github.com/user-attachments/assets/a93bb6ba-6710-4162-a932-f90705d8a85e" />
<img width="537" height="251" alt="image" src="https://github.com/user-attachments/assets/d5c334ae-6001-4a5c-949a-4ef9f659fdf5" />
<img width="707" height="222" alt="image" src="https://github.com/user-attachments/assets/518f6111-9605-4fd2-99f0-e25b96f094ed" />
