### PR TITLE
Fix implicit selector not having a slider

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -965,7 +965,7 @@ holding Shift will put it in the second.]])
 		return self.displayItem and self.displayItem.rangeLineList[1] ~= nil and not (main.showAllItemAffixes and self.displayItem.rarity == "UNIQUE")
 	end
 	local function getSelectedModLine()
-		return self.controls.displayItemRangeLine:GetSelValue() and self.controls.displayItemRangeLine:GetSelValue().modLine or nil
+		return self.displayItem and self.displayItem.rangeLineList[self.controls.displayItemRangeLine.selIndex] or nil
 	end
 	local box = new("CheckBoxControl", { "LEFT", self.controls.displayItemRangeLine, "RIGHT", true }, { 0, 0, 18 }, nil)
 	box.changeFunc = function(val)
@@ -1012,7 +1012,7 @@ holding Shift will put it in the second.]])
 		self:UpdateCustomControls()
 	end)
 	slider.shown = function()
-		local modLine = not main.showAllItemAffixes and self.displayItem and self.displayItem.rarity == "UNIQUE" and self.displayItem.rangeLineList[self.controls.displayItemRangeLine.selIndex]
+		local modLine = self.displayItem and not (main.showAllItemAffixes and self.displayItem.rarity == "UNIQUE") and self.displayItem.rangeLineList[self.controls.displayItemRangeLine.selIndex]
 		if modLine then
 			-- it's possible for the range to change while this slider is
 			-- hidden, so correct the slider to show the same value


### PR DESCRIPTION
Fixes https://www.reddit.com/r/pathofexile/comments/1v4wozd/path_of_building_just_got_329_update/ozfsx8i/

### Description of the problem being solved:

The function that gets the selected modline was returning a copy of the modline table instead of the original reference

### Steps taken to verify a working solution:
- rare Implicit slider works
- unique with "show all bla bla" option unchecked seems to work

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
