### PR TITLE
Fix missing range on item mod causing errors

### DIFF
--- a/src/Classes/Item.lua
+++ b/src/Classes/Item.lua
@@ -1088,6 +1088,7 @@ function ItemClass:ParseRaw(raw, rarity, highQuality)
 					if gameModeStage == "IMPLICIT" or gameModeStage == "EXPLICIT" or (gameModeStage == "FINDIMPLICIT" and (not data.itemBases[line]) and not (self.name == line) and not line:find("Two%-Toned") and not (self.base and (line == self.base.type or self.base.subType and line == self.base.subType .. " " .. self.base.type))) then
 						modLine.modList = { }
 						modLine.extra = line
+						modLine.range = main.defaultItemAffixQuality
 						t_insert(modLines, modLine)
 					elseif gameModeStage == "FINDEXPLICIT" then
 						gameModeStage = "DONE"


### PR DESCRIPTION
Fixes #9985

### Description of the problem being solved:
The item I commented with in the linked issue was causing issues because `Recover (29-31)% of Mana and Energy Shield when you Focus` needed to have a range applied first to have the explicit modifier magnitude scalar applied.  Since it was unparsed, it didn't get a range and failed.