### PR TITLE
Disable array table alignment in formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,3 +2,4 @@
 trim_trailing_whitespace = false
 indent_style = tab
 max_line_length = 360
+align_array_table = false


### PR DESCRIPTION
This setting aligns the `=`'s in tables, but I don't think it makes much sense in this project since we use absolutely massive tables. It seems to always produce terrible results when adding anything to e.g. `ModParser.lua` or similar files.
