### PR TITLE
Fix Reap of Butchery base AoE radius

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -11151,7 +11151,6 @@ skills["ReapAltX"] = {
 		duration = true,
 	},
 	baseMods = {
-		skill("radius", 25),
 		skill("debuff", true),
 	},
 	qualityStats = {

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -2169,7 +2169,6 @@ local skills, mod, flag, skill = ...
 			-- Display only
 		},
 	},
-#baseMod skill("radius", 25)
 #baseMod skill("debuff", true)
 #mods
 


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:

Gem has a base radius of 3.2.

https://poedb.tw/us/Reap_of_Butchery

### Steps taken to verify a working solution:
- I verified stats properly display 3.2 as base radius

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
