### PR TITLE
Fix Mana-Infused Staff damage calculation

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -13447,8 +13447,8 @@ skills["ManaInfusedStaff"] = {
 			mod("SpellBlockChance", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
 		},
 		["skill_has_added_lightning_damage_equal_to_%_of_maximum_mana"] = {
-			mod("LightningMin", "BASE", nil, 0, 0, { type = "PercentStat", stat = "Mana", percent = 1 }),
-			mod("LightningMax", "BASE", nil, 0, 0, { type = "PercentStat", stat = "Mana", percent = 1 }),
+			skill("LightningMin", nil, { type = "PercentStat", stat = "Mana", percent = 1 }),
+			skill("LightningMax", nil, { type = "PercentStat", stat = "Mana", percent = 1 }),
 		},
 	},
 	baseFlags = {

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -3214,8 +3214,8 @@ local skills, mod, flag, skill = ...
 			mod("SpellBlockChance", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
 		},
 		["skill_has_added_lightning_damage_equal_to_%_of_maximum_mana"] = {
-			mod("LightningMin", "BASE", nil, 0, 0, { type = "PercentStat", stat = "Mana", percent = 1 }),
-			mod("LightningMax", "BASE", nil, 0, 0, { type = "PercentStat", stat = "Mana", percent = 1 }),
+			skill("LightningMin", "BASE", nil, 0, 0, { type = "PercentStat", stat = "Mana", percent = 1 }),
+			skill("LightningMax", "BASE", nil, 0, 0, { type = "PercentStat", stat = "Mana", percent = 1 }),
 		},
 	},
 #mods


### PR DESCRIPTION
Fixes #10014

### Description of the problem being solved:
I was making the damage gained from mana an added damage mod instead of using it for base damage


### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/arq5l50x
### Before screenshot:
<img width="322" height="302" alt="image" src="https://github.com/user-attachments/assets/30e46dbb-8252-4cd0-893b-eb82e930bfe5" />

### After screenshot:
<img width="330" height="286" alt="image" src="https://github.com/user-attachments/assets/36f37634-ec08-454d-a6c2-71386c6325d0" />
