### PR TITLE
Fix Raise Spider count not granting Attack Speed

### DIFF
--- a/spec/System/TestDefence_spec.lua
+++ b/spec/System/TestDefence_spec.lua
@@ -702,6 +702,27 @@ describe("TestDefence", function()
 			assert.is_true(build.calcsTab.calcsOutput.TotalMinionLife > 0)
 		end)
 
+		it("keeps invulnerable minion limits available to limitStat", function()
+			build.itemsTab:CreateDisplayItemFromRaw([[
+			Test Item
+			Fiend Dagger
+			100% chance to Trigger Level 1 Raise Spiders on Kill
+			]])
+			build.itemsTab:AddDisplayItem()
+			build.skillsTab:PasteSocketGroup("Reave 20/0  1")
+			runCallback("OnFrame")
+
+			build.configTab.input.raiseSpidersSpiderCount = 5
+			build.configTab:BuildModList()
+			runCallback("OnFrame")
+
+			local env = build.calcsTab.calcsEnv
+			local mainSkill = env.player.mainSkill
+			assert.are.equals(20, build.calcsTab.calcsOutput.ActiveSpiderLimit)
+			assert.are.equals(5, env.player.modDB:Sum("BASE", nil, "Multiplier:RaisedSpider"))
+			assert.are.equals(10, mainSkill.skillModList:Sum("INC", mainSkill.skillCfg, "Speed"))
+		end)
+
 		it("counts the same Minion type from different skills separately", function()
 			build.itemsTab:CreateDisplayItemFromRaw("Test Bow\nShort Bow")
 			build.itemsTab:AddDisplayItem()

--- a/spec/System/TestDefence_spec.lua
+++ b/spec/System/TestDefence_spec.lua
@@ -692,14 +692,14 @@ describe("TestDefence", function()
 			assert.is_true(build.calcsTab.calcsOutput.TotalMinionLife > 0)
 		end)
 
-		it("does not count invulnerable Minions for Companionship", function()
+		it("counts invulnerable Minions for Companionship's condition", function()
 			build.skillsTab:PasteSocketGroup("Animate Guardian 20/0  1\nCompanionship 3/0  1")
 			build.skillsTab:PasteSocketGroup("Summon Skitterbots 20/0  1")
 			runCallback("OnFrame")
 
-			assert.are.equals(1, build.calcsTab.calcsEnv.player.modDB:Sum("BASE", nil, "Multiplier:SummonedMinion"))
-			assert.are.equals(15, build.calcsTab.calcsOutput.MinionAllyDamageMitigation)
-			assert.is_true(build.calcsTab.calcsOutput.TotalMinionLife > 0)
+			assert.is_true(build.calcsTab.calcsEnv.player.modDB:Sum("BASE", nil, "Multiplier:SummonedMinion") > 1)
+			assert.are.equals(0, build.calcsTab.calcsOutput.MinionAllyDamageMitigation)
+			assert.is_nil(build.calcsTab.calcsOutput.TotalMinionLife)
 		end)
 
 		it("keeps invulnerable minion limits available to limitStat", function()

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1396,9 +1396,9 @@ function calcs.perform(env, skipEHP)
 				hasGuaranteedBonechill = true
 			end
 		end
-		-- Count active, damageable minions. Skills without a limit contribute one minion.
+		-- Count active minions. Skills without a limit contribute one minion.
 		local minionList = activeSkill.minionList
-		if not activeSkill.skillFlags.disable and not activeSkill.skillTypes[SkillType.MinionsAreUndamagable] and minionList and minionList[1] then
+		if not activeSkill.skillFlags.disable and minionList and minionList[1] then
 			local grantedEffect = activeSkill.activeEffect.grantedEffect
 			for _, minionType in ipairs(minionList) do
 				local minionData = env.data.minions[minionType]


### PR DESCRIPTION
Fixes #10041

### Description of the problem being solved:
The change to have a count for minions for Companionship was also the function that was setting the limit output for all minion types.
Cause Spiders have the MinionsAreUndamageable skilltype, they were being excluded
I got rid of that check as its no longer needed

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/7sr2av0t
### Before screenshot:
<img width="239" height="59" alt="image" src="https://github.com/user-attachments/assets/4b80f277-531c-4ac5-be43-96904c4299a6" />

### After screenshot:
<img width="627" height="64" alt="image" src="https://github.com/user-attachments/assets/089a5fea-fa5a-4a1b-a094-97ee68a86ff8" />
