### PR TITLE
Fix Communion Support counting temporary minions

### DIFF
--- a/spec/System/TestOffence_spec.lua
+++ b/spec/System/TestOffence_spec.lua
@@ -13,6 +13,26 @@ describe("TestOffence", function()
 			string.format("%s: expected ~%.2f (within %.1f%%), got %.2f", msg, expected, tolerance * 100, actual))
 	end
 
+	it("counts only permanent minions for Communion", function()
+		build.skillsTab:PasteSocketGroup("Fireball 20/0  1\nCommunion 3/0  1")
+		build.skillsTab:PasteSocketGroup("Summon Reaper 20/0  1")
+		build.skillsTab:PasteSocketGroup("Summon Raging Spirit 20/0  1")
+		runCallback("OnFrame")
+
+		local modDB = build.calcsTab.calcsEnv.player.modDB
+		assert.is_true(modDB:Sum("BASE", nil, "Multiplier:SummonedMinion") > 1)
+		assert.are.equals(1, modDB:Sum("BASE", nil, "Multiplier:PermanentMinion"))
+		assert.is_true(build.calcsTab.calcsOutput.PhysicalMin > 0)
+
+		newBuild()
+		build.skillsTab:PasteSocketGroup("Fireball 20/0  1\nCommunion 3/0  1")
+		build.skillsTab:PasteSocketGroup("Summon Raging Spirit 20/0  1")
+		runCallback("OnFrame")
+
+		assert.are.equals(0, build.calcsTab.calcsEnv.player.modDB:Sum("BASE", nil, "Multiplier:PermanentMinion"))
+		assert.are.equals(0, build.calcsTab.calcsOutput.PhysicalMin or 0)
+	end)
+
 	it("parses more/less/increased/reduced minimum and maximum damage of every type", function()
 		build.itemsTab:CreateDisplayItemFromRaw([[
 		New Item

--- a/src/Data/SkillStatMap.lua
+++ b/src/Data/SkillStatMap.lua
@@ -21,6 +21,9 @@ return {
 	skill("durationTertiary", nil),
 	div = 1000,
 },
+["infinite_minion_duration"] = {
+	skillFlag = "permanentMinion",
+},
 ["spell_minimum_base_physical_damage"] = {
 	skill("PhysicalMin", nil),
 },

--- a/src/Data/Skills/sup_int.lua
+++ b/src/Data/Skills/sup_int.lua
@@ -4995,10 +4995,10 @@ skills["SupportMinionPact"] = {
 	statDescriptionScope = "gem_stat_descriptions",
 	statMap = {
 		["spell_minimum_added_physical_damage_per_active_permanent_minion"] = {
-			mod("PhysicalMin", "BASE", nil, 0, 0, { type = "Multiplier", var = "SummonedMinion" }),
+			mod("PhysicalMin", "BASE", nil, 0, 0, { type = "Multiplier", var = "PermanentMinion" }),
 		},
 		["spell_maximum_added_physical_damage_per_active_permanent_minion"] = {
-			mod("PhysicalMax", "BASE", nil, 0, 0, { type = "Multiplier", var = "SummonedMinion" }),
+			mod("PhysicalMax", "BASE", nil, 0, 0, { type = "Multiplier", var = "PermanentMinion" }),
 		},
 	},
 	qualityStats = {

--- a/src/Export/Skills/sup_int.txt
+++ b/src/Export/Skills/sup_int.txt
@@ -668,10 +668,10 @@ local skills, mod, flag, skill = ...
 #skill SupportMinionPact
 	statMap = {
 		["spell_minimum_added_physical_damage_per_active_permanent_minion"] = {
-			mod("PhysicalMin", "BASE", nil, 0, 0, { type = "Multiplier", var = "SummonedMinion" }),
+			mod("PhysicalMin", "BASE", nil, 0, 0, { type = "Multiplier", var = "PermanentMinion" }),
 		},
 		["spell_maximum_added_physical_damage_per_active_permanent_minion"] = {
-			mod("PhysicalMax", "BASE", nil, 0, 0, { type = "Multiplier", var = "SummonedMinion" }),
+			mod("PhysicalMax", "BASE", nil, 0, 0, { type = "Multiplier", var = "PermanentMinion" }),
 		},
 	},
 #mods

--- a/src/Modules/CalcPerform.lua
+++ b/src/Modules/CalcPerform.lua
@@ -1414,6 +1414,9 @@ function calcs.perform(env, skipEHP)
 					if not activeSkill.skillTypes[SkillType.Vaal] then
 						counts.nonVaal = m_max(count, counts.nonVaal or 0)
 					end
+					if activeSkill.skillFlags.permanentMinion then
+						counts.permanent = m_max(count, counts.permanent or 0)
+					end
 					minionCounts[key] = counts
 				end
 			end
@@ -1454,6 +1457,9 @@ function calcs.perform(env, skipEHP)
 		modDB:NewMod("Multiplier:SummonedMinion", "BASE", counts.total, "Config", { type = "Condition", var = "Combat" })
 		if counts.nonVaal then
 			modDB:NewMod("Multiplier:NonVaalSummonedMinion", "BASE", counts.nonVaal, "Config", { type = "Condition", var = "Combat" })
+		end
+		if counts.permanent then
+			modDB:NewMod("Multiplier:PermanentMinion", "BASE", counts.permanent, "Config", { type = "Condition", var = "Combat" })
 		end
 	end
 

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -1126,6 +1126,9 @@ Huge sets the radius to 11.
 	{ var = "multiplierNonVaalSummonedMinion", type = "count", label = "# of non-vaal skill Summoned Minions:", ifMult = "NonVaalSummonedMinion", tooltip = "Use this to override the count if you do not have all your minions summoned", apply = function(val, modList, enemyModList)
 		modList:NewMod("Multiplier:NonVaalSummonedMinion", "OVERRIDE", val, "Config", { type = "Condition", var = "Combat" })
 	end },
+	{ var = "multiplierPermanentMinion", type = "count", label = "# of Permanent Minions (if not maximum):", ifMult = "PermanentMinion", tooltip = "Use this to override the count if you do not have all your permanent minions summoned", apply = function(val, modList, enemyModList)
+		modList:NewMod("Multiplier:PermanentMinion", "OVERRIDE", val, "Config", { type = "Condition", var = "Combat" })
+	end },
 	{ var = "conditionOnConsecratedGround", type = "check", label = "Are you on Consecrated Ground?", tooltip = "In addition to allowing any 'while on Consecrated Ground' modifiers to apply,\nConsecrated Ground grants 5% ^xE05030Life ^7Regeneration to players and allies.", apply = function(val, modList, enemyModList)
 		modList:NewMod("Condition:OnConsecratedGround", "FLAG", true, "Config", { type = "Condition", var = "Combat" })
 		modList:NewMod("MinionModifier", "LIST", { mod = modLib.createMod("Condition:OnConsecratedGround", "FLAG", true, "Config", { type = "Condition", var = "Combat" }) })


### PR DESCRIPTION
Fixes #10005

### Description of the problem being solved:
Now only counts minions that have the permanentMinion skillFlag
Now stat map the infinite duration stat to grant the `permanentMinion` flag

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/gqr2b70t

### Before screenshot:
<img width="703" height="104" alt="image" src="https://github.com/user-attachments/assets/d78c797e-2e06-4e07-aaaf-5b6551e093ed" />

### After screenshot:
<img width="698" height="85" alt="image" src="https://github.com/user-attachments/assets/0ad4662b-5a5c-4454-8c41-d4127b77cce6" />
