### PR TITLE
Fix base radius of Cleave + Vaal Cleave

### DIFF
--- a/src/Data/Skills/act_str.lua
+++ b/src/Data/Skills/act_str.lua
@@ -1803,7 +1803,7 @@ skills["Cleave"] = {
 	castTime = 1,
 	statMap = {
 		["cleave_+1_base_radius_per_nearby_enemy_up_to_10"] = {
-			skill("radiusExtra", nil, { type = "Multiplier", var = "NearbyEnemies", limit = 10, limitTotal = true })
+			mod("AreaOfEffect", "BASE", nil, 0, 0, { type = "Multiplier", var = "NearbyEnemies", limit = 10, limitTotal = true })
 		},
 	},
 	baseFlags = {
@@ -1975,7 +1975,7 @@ skills["VaalCleave"] = {
 	castTime = 1,
 	statMap = {
 		["cleave_+1_base_radius_per_nearby_enemy_up_to_10"] = {
-			skill("radiusExtra", nil, { type = "Multiplier", var = "NearbyEnemies", limit = 10, limitTotal = true })
+			mod("AreaOfEffect", "BASE", nil, 0, 0, { type = "Multiplier", var = "NearbyEnemies", limit = 10, limitTotal = true })
 		},
 		["vaal_cleave_executioner_damage_against_enemies_on_low_life_+%"] = {
 			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "ActorCondition", actor = "enemy", var = "LowLife" }, { type = "SkillName", skillName = "Cleave", includeTransfigured = true }, { type = "GlobalEffect", effectType = "Buff", effectName = "Vaal Cleave", unscalable = true } ),

--- a/src/Export/Skills/act_str.txt
+++ b/src/Export/Skills/act_str.txt
@@ -358,7 +358,7 @@ local skills, mod, flag, skill = ...
 #flags attack melee area
 	statMap = {
 		["cleave_+1_base_radius_per_nearby_enemy_up_to_10"] = {
-			skill("radiusExtra", nil, { type = "Multiplier", var = "NearbyEnemies", limit = 10, limitTotal = true })
+			mod("AreaOfEffect", "BASE", nil, 0, 0, { type = "Multiplier", var = "NearbyEnemies", limit = 10, limitTotal = true })
 		},
 	},
 #baseMod skill("radius", 20)
@@ -382,7 +382,7 @@ local skills, mod, flag, skill = ...
 #flags attack area duration melee
 	statMap = {
 		["cleave_+1_base_radius_per_nearby_enemy_up_to_10"] = {
-			skill("radiusExtra", nil, { type = "Multiplier", var = "NearbyEnemies", limit = 10, limitTotal = true })
+			mod("AreaOfEffect", "BASE", nil, 0, 0, { type = "Multiplier", var = "NearbyEnemies", limit = 10, limitTotal = true })
 		},
 		["vaal_cleave_executioner_damage_against_enemies_on_low_life_+%"] = {
 			mod("Damage", "MORE", nil, 0, bit.bor(KeywordFlag.Hit, KeywordFlag.Ailment), { type = "ActorCondition", actor = "enemy", var = "LowLife" }, { type = "SkillName", skillName = "Cleave", includeTransfigured = true }, { type = "GlobalEffect", effectType = "Buff", effectName = "Vaal Cleave", unscalable = true } ),


### PR DESCRIPTION
Fixes #10027

### Description of the problem being solved:
The skills had 2 stats mapped to the radiusExtra skill mod so it would randomly choose 1 of them on launch.
Now uses a base mod for the nearby enemy mod so that it always works properly


### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/2pr30f0t

### Before screenshot:
<img width="230" height="37" alt="image" src="https://github.com/user-attachments/assets/f2939187-0c2c-4051-919b-a0fed10f676d" />

### After screenshot:
<img width="238" height="39" alt="image" src="https://github.com/user-attachments/assets/26d5c9e1-93eb-4905-968a-7e42e6c53e71" />
