### PR TITLE
Add support for crabs

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -662,6 +662,7 @@ c["+2 to maximum number of Skeletons"]={{[1]={flags=0,keywordFlags=0,name="Activ
 c["+2 to maximum number of Spectres"]={{[1]={flags=0,keywordFlags=0,name="ActiveSpectreLimit",type="BASE",value=2}},nil}
 c["+2 to maximum number of Summoned Golems"]={{[1]={flags=0,keywordFlags=0,name="ActiveGolemLimit",type="BASE",value=2}},nil}
 c["+2 to maximum number of Summoned Mirage Archers"]={{[1]={flags=0,keywordFlags=0,name="MirageArcherMaxCount",type="BASE",value=2}},nil}
+c["+2 to maximum number of Summoned Totems"]={{[1]={flags=0,keywordFlags=0,name="ActiveTotemLimit",type="BASE",value=2}},nil}
 c["+2% Chance to Block Attack Damage"]={{[1]={flags=0,keywordFlags=0,name="BlockChance",type="BASE",value=2}},nil}
 c["+2% Chance to Block Attack Damage while Dual Wielding"]={{[1]={[1]={type="Condition",var="DualWielding"},flags=0,keywordFlags=0,name="BlockChance",type="BASE",value=2}},nil}
 c["+2% Chance to Block Attack Damage while Dual Wielding or holding a Shield"]={{[1]={[1]={type="Condition",varList={[1]="DualWielding",[2]="UsingShield"}},flags=0,keywordFlags=0,name="BlockChance",type="BASE",value=2}},nil}
@@ -6241,6 +6242,7 @@ c["63% increased Effect of Non-Damaging Ailments inflicted by Summoned Skitterbo
 c["63% increased Effect of Shrine Buffs on you"]={{[1]={flags=0,keywordFlags=0,name="ShrineBuffEffect",type="INC",value=63}},nil}
 c["63% increased Global Critical Strike Chance"]={{[1]={[1]={type="Global"},flags=0,keywordFlags=0,name="CritChance",type="INC",value=63}},nil}
 c["63% increased Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalDamage",type="INC",value=63}},nil}
+c["63% increased Totem Duration"]={{[1]={flags=0,keywordFlags=0,name="TotemDuration",type="INC",value=63}},nil}
 c["63% reduced Trap Duration"]={{[1]={flags=0,keywordFlags=0,name="TrapDuration",type="INC",value=-63}},nil}
 c["65% increased Armour"]={{[1]={flags=0,keywordFlags=0,name="Armour",type="INC",value=65}},nil}
 c["65% increased Chaos Damage"]={{[1]={flags=0,keywordFlags=0,name="ChaosDamage",type="INC",value=65}},nil}
@@ -6359,6 +6361,7 @@ c["75% increased Ignite Duration on Enemies"]={{[1]={flags=0,keywordFlags=0,name
 c["75% increased Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalDamage",type="INC",value=75}},nil}
 c["75% increased Projectile Speed"]={{[1]={flags=0,keywordFlags=0,name="ProjectileSpeed",type="INC",value=75}},nil}
 c["75% increased Spell Critical Strike Chance per Raised Spectre"]={{[1]={[1]={stat="ActiveSpectreLimit",type="PerStat"},flags=2,keywordFlags=0,name="CritChance",type="INC",value=75}},nil}
+c["75% increased Totem Duration"]={{[1]={flags=0,keywordFlags=0,name="TotemDuration",type="INC",value=75}},nil}
 c["75% increased Unveiled Modifier magnitudes"]={{},nil}
 c["75% increased maximum Mana"]={{[1]={flags=0,keywordFlags=0,name="Mana",type="INC",value=75}},nil}
 c["75% more Main Hand attack speed"]={{[1]={[1]={type="Condition",var="MainHandAttack"},[2]={skillType=1,type="SkillType"},flags=1,keywordFlags=0,name="Speed",type="MORE",value=75}},nil}
@@ -12093,6 +12096,7 @@ c["Socketed Red Gems get 10% Physical Damage as Extra Fire Damage"]={{[1]={[1]={
 c["Socketed Skill Gems get a 80% Cost & Reservation Multiplier"]={{[1]={[1]={slotName="{SlotName}",type="SocketedIn"},flags=0,keywordFlags=0,name="ExtraSkillMod",type="LIST",value={mod={flags=0,keywordFlags=0,name="SupportManaMultiplier",type="MORE",value=-20}}}},nil}
 c["Socketed Skills deal Double Damage"]={{[1]={[1]={slotName="{SlotName}",type="SocketedIn"},flags=0,keywordFlags=0,name="ExtraSkillMod",type="LIST",value={mod={flags=0,keywordFlags=0,name="DoubleDamageChance",type="BASE",value=100}}}},nil}
 c["Socketed Slam Gems are Supported by Level 25 Earthbreaker"]={{[1]={[1]={slotName="{SlotName}",type="SocketedIn"},flags=0,keywordFlags=0,name="ExtraSupport",type="LIST",value={level=25,skillId="SupportEarthbreaker"}}},nil}
+c["Socketed Spells are Supported by level 20 Crab Totem"]={{[1]={[1]={slotName="{SlotName}",type="SocketedIn"},flags=0,keywordFlags=0,name="ExtraSupport",type="LIST",value={level=20,skillId="SupportCrabTotem"}}},nil}
 c["Socketed Support Gems can also Support Skills from Equipped Body Armour"]={{[1]={flags=0,keywordFlags=0,name="LinkedSupport",type="LIST",value={targetSlotName="Body Armour"}}},nil}
 c["Socketed Support Gems can also Support Skills from your Main Hand"]={{[1]={flags=0,keywordFlags=0,name="LinkedSupport",type="LIST",value={targetSlotName="Weapon 1"}}},nil}
 c["Socketed Travel Skills deal 80% more Damage"]={{[1]={[1]={keyword="travel",slotName="{SlotName}",type="SocketedIn"},flags=0,keywordFlags=0,name="ExtraSkillMod",type="LIST",value={mod={flags=0,keywordFlags=0,name="Damage",type="MORE",value=80}}}},nil}
@@ -12361,6 +12365,8 @@ c["Totems fire 2 additional Projectiles"]={{[1]={flags=0,keywordFlags=16384,name
 c["Totems gain +16% to all Elemental Resistances"]={{[1]={flags=0,keywordFlags=0,name="TotemElementalResist",type="BASE",value=16}},nil}
 c["Totems gain +20% to all Elemental Resistances"]={{[1]={flags=0,keywordFlags=0,name="TotemElementalResist",type="BASE",value=20}},nil}
 c["Totems gain +25% to Chaos Resistance"]={{[1]={flags=0,keywordFlags=0,name="TotemChaosResist",type="BASE",value=25}},nil}
+c["Totems have 100% increased Movement Speed"]={nil,"Totems have 100% increased Movement Speed "}
+c["Totems have 100% increased Movement Speed 200% increased Spell Damage"]={nil,"Totems have 100% increased Movement Speed 200% increased Spell Damage "}
 c["Totems have 15% additional Physical Damage Reduction"]={nil,"Totems have 15% additional Physical Damage Reduction "}
 c["Totems have 15% additional Physical Damage Reduction Totems gain +25% to Chaos Resistance"]={nil,"Totems have 15% additional Physical Damage Reduction Totems gain +25% to Chaos Resistance "}
 c["Totems have 40% additional Physical Damage Reduction"]={nil,"Totems have 40% additional Physical Damage Reduction "}

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -13447,8 +13447,8 @@ skills["ManaInfusedStaff"] = {
 			mod("SpellBlockChance", "MORE", nil, 0, 0, { type = "GlobalEffect", effectType = "Buff" }),
 		},
 		["skill_has_added_lightning_damage_equal_to_%_of_maximum_mana"] = {
-			skill("LightningMin", nil, { type = "PercentStat", stat = "Mana", percent = 1 }),
-			skill("LightningMax", nil, { type = "PercentStat", stat = "Mana", percent = 1 }),
+			skill("LightningMin", "BASE", nil, 0, 0, { type = "PercentStat", stat = "Mana", percent = 1 }),
+			skill("LightningMax", "BASE", nil, 0, 0, { type = "PercentStat", stat = "Mana", percent = 1 }),
 		},
 	},
 	baseFlags = {

--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -5770,6 +5770,48 @@ skills["SupportTriggerFireSpellOnHit"] = {
 		[1] = { cooldown = 0.25, levelRequirement = 1, storedUses = 1, },
 	},
 }
+skills["SupportCrabTotem"] = {
+	name = "Crab Totem",
+	hidden = true,
+	color = 1,
+	support = true,
+	requireSkillTypes = { SkillType.Spell, SkillType.Totemable, SkillType.AND, },
+	addSkillTypes = { SkillType.Trappable, SkillType.Mineable, SkillType.SummonsTotem, SkillType.ReservationBecomesCost, SkillType.SupportedByCrabTotem, },
+	excludeSkillTypes = { SkillType.InbuiltTrigger, SkillType.Channel, SkillType.SupportedBySpellTotem, },
+	ignoreMinionTypes = true,
+	statDescriptionScope = "gem_stat_descriptions",
+	fromItem = true,
+	addFlags = {
+		totem = true,
+	},
+	statMap = {
+		["support_crab_totem_damage_+%_final"] = {
+			mod("Damage", "MORE", nil),
+		},
+		["support_crab_totem_cast_speed_+%_final"] = {
+			mod("Speed", "MORE", nil, ModFlag.Cast),
+		},
+	},
+	constantStats = {
+		{ "base_totem_duration", 8000 },
+		{ "base_totem_range", 60 },
+		{ "support_crab_totem_cast_speed_+%_final", -40 },
+		{ "totem_art_variation", 12 },
+		{ "totem_placement_range_+%", -75 },
+	},
+	stats = {
+		"support_crab_totem_damage_+%_final",
+		"totem_support_gem_level",
+		"base_skill_is_totemified",
+		"is_totem",
+	},
+	notMinionStat = {
+		"totem_support_gem_level",
+	},
+	levels = {
+		[20] = { -50, 70, levelRequirement = 0, manaMultiplier = 100, statInterpolation = { 1, 1, }, },
+	},
+}
 skills["EnemyExplode"] = {
 	name = "On Kill Monster Explosion",
 	hidden = true,

--- a/src/Data/Uniques/staff.lua
+++ b/src/Data/Uniques/staff.lua
@@ -785,5 +785,17 @@ Implicits: 2
 Reflects 1 to 150 Lightning Damage to Melee Attackers
 {variant:1,2}20% chance for Energy Shield Recharge to start when you Block
 {variant:3}(25-35)% chance for Energy Shield Recharge to start when you Block
-]],
+]], [[
+The Crustacean's Call
+Primordial Staff
+Source: Drops from Velka, the Tide Witch.
+Requires Level 58, 99 Str, 99 Int
+Implicits: 1
++25% Chance to Block Spell Damage
+Socketed Spells are Supported by level 20 Crab Totem
+Totems have 100% increased Movement Speed
+(150-200)% increased Spell Damage
+(50-75)% increased Totem Duration
++2 to maximum number of Summoned Totems
+]]
 }

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -1476,6 +1476,21 @@ local skills, mod, flag, skill = ...
 	},
 #mods
 
+#skill SupportCrabTotem Crab Totem
+	fromItem = true,
+	addFlags = {
+		totem = true,
+	},
+	statMap = {
+		["support_crab_totem_damage_+%_final"] = {
+			mod("Damage", "MORE", nil),
+		},
+		["support_crab_totem_cast_speed_+%_final"] = {
+			mod("Speed", "MORE", nil, ModFlag.Cast),
+		},
+	},
+#mods
+
 skills["EnemyExplode"] = {
 	name = "On Kill Monster Explosion",
 	hidden = true,

--- a/src/Export/Uniques/staff.lua
+++ b/src/Export/Uniques/staff.lua
@@ -780,5 +780,17 @@ LocalIncreaseSocketedGemLevelUnique___3
 AttackerTakesLightningDamageUnique___1
 {variant:1,2}EnergyShieldRechargeOnBlockUnique__1[20,20]
 {variant:3}EnergyShieldRechargeOnBlockUnique__1
-]],
+]], [[
+The Crustacean's Call
+Primordial Staff
+Source: Drops from Velka, the Tide Witch.
+Requires Level 58, 99 Str, 99 Int
+Implicits: 1
+StaffSpellBlockPercent3
+SupportedByCrabTotemSupportUnique__1
+TotemMovementVelocityUnique__1
+SpellDamageOnWeaponUniqueStaff38
+TotemDurationUniqueStaff38
+AdditionalTotemsUniqueStaff38
+]]
 }

--- a/src/Modules/ModParser.lua
+++ b/src/Modules/ModParser.lua
@@ -3307,6 +3307,7 @@ local specialModList = {
 	["trigger (.+) on critical strike"] = function( _, skill) return triggerExtraSkill(skill, 1, {noSupports = true, onCrit = true}) end,
 	["triggers? (.+) when you take a critical strike"] = function( _, skill) return triggerExtraSkill(skill, 1, {noSupports = true}) end,
 	["socketed [%a+]* ?gems a?r?e? ?supported by level (%d+) (.+)"] = function(num, _, support) return extraSupport(support, num) end,
+	["socketed [%a+]* ?spells a?r?e? ?supported by level (%d+) (.+)"] = function(num, _, support) return extraSupport(support, num, nil) end,
 	["skills from equipped (.+) are supported by level (%d+) (.+)"] = function(_, slot, level, support) return extraSupport(support, level, slot) end,
 	["socketed support gems can also support skills from y?o?u?r? ?e?q?u?i?p?p?e?d? ?([%a%s]+)"] = function (_, itemSlotName)
 		local targetItemSlotName = "Body Armour"


### PR DESCRIPTION
### Description of the problem being solved:

Adds "The Crustacean's Call" and its support. This seems to just be a spell totem with different variables and a different mod wording.

### Steps taken to verify a working solution:
- Output damage and cast rate match stats
- Skill becomes a totem

### Link to a build that showcases this PR:
https://poe.ninja/poe1/builds/allflame?items=The+Crustacean%27s+Call&class=Hierophant&min-level=90
### Before screenshot:

### After screenshot:
<img width="409" height="198" alt="image" src="https://github.com/user-attachments/assets/63028576-da63-41f7-a690-2d674914ae29" />
<img width="990" height="958" alt="image" src="https://github.com/user-attachments/assets/e2fc02ff-aedd-4377-8999-1ded426bd200" />
