### PR TITLE
Fix Soulwrest not granting Phantasmal Might damage

### DIFF
--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -4446,6 +4446,14 @@ skills["TriggeredSummonGhostOnKill"] = {
 	minionList = {
 		"SummonedPhantasm",
 	},
+	statMap = {
+		["phantasm_minimum_added_physical_damage_to_grant"] = {
+			mod("PhysicalMin", "BASE", nil, ModFlag.Spell, 0, { type = "PerStat", stat = "ActivePhantasmLimit" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Phantasmal Might", effectCond = "PhantasmalMight", allowTotemBuff = true })
+		},
+		["phantasm_maximum_added_physical_damage_to_grant"] = {
+			mod("PhysicalMax", "BASE", nil, ModFlag.Spell, 0, { type = "PerStat", stat = "ActivePhantasmLimit" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Phantasmal Might", effectCond = "PhantasmalMight", allowTotemBuff = true  })
+		},
+	},
 	baseFlags = {
 		spell = true,
 		minion = true,

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -1055,6 +1055,14 @@ local skills, mod, flag, skill = ...
 	minionList = {
 		"SummonedPhantasm",
 	},
+	statMap = {
+		["phantasm_minimum_added_physical_damage_to_grant"] = {
+			mod("PhysicalMin", "BASE", nil, ModFlag.Spell, 0, { type = "PerStat", stat = "ActivePhantasmLimit" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Phantasmal Might", effectCond = "PhantasmalMight", allowTotemBuff = true })
+		},
+		["phantasm_maximum_added_physical_damage_to_grant"] = {
+			mod("PhysicalMax", "BASE", nil, ModFlag.Spell, 0, { type = "PerStat", stat = "ActivePhantasmLimit" }, { type = "GlobalEffect", effectType = "Buff", effectName = "Phantasmal Might", effectCond = "PhantasmalMight", allowTotemBuff = true  })
+		},
+	},
 #mods
 
 #skill SummonSentinelOfRadiance


### PR DESCRIPTION
Fixes #10080

### Description of the problem being solved:
The flat phys damage stat wasn't mapped to the Phantasmal might buff
With the new Reliquarian node you can have the staff + get the phantasmal might effect

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/votuw00x

### Before screenshot:
<img width="546" height="71" alt="image" src="https://github.com/user-attachments/assets/dc5cef72-bf81-41ef-ab78-69812c44cc3e" />

### After screenshot:
<img width="551" height="71" alt="image" src="https://github.com/user-attachments/assets/e6758322-026b-4dbd-bda4-d97c403da792" />
