### PR TITLE
Prevents legacy Talisman bases from being anointed

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -62,6 +62,7 @@ end
 
 local function isAnointable(item)
 	return item and item.base and not item.base.cannotBeAnointed
+	    and item.base.subType ~= "Talisman"
 		and (item.canBeAnointed or item.base.type == "Amulet")
 end
 


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:
Since `3.29`, talismans can no longer be anointed. This mr sets talisman base type to `cannotBeAnointed`

### Steps taken to verify a working solution:
- Added talisman to check anoint option and warning

### Link to a build that showcases this PR:

### Before screenshot:
<img width="596" height="643" alt="image" src="https://github.com/user-attachments/assets/64ae988f-805a-4c27-9f9a-c17c43247526" />

### After screenshot:
<img width="597" height="653" alt="image" src="https://github.com/user-attachments/assets/3c098d61-a6bc-4b4a-a421-4cf32426798b" />
