### PR TITLE
Prevent formatter config from messing up modparser.lua

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,4 @@ trim_trailing_whitespace = false
 indent_style = tab
 max_line_length = 360
 align_array_table = false
+align_continuous_rect_table_field = false


### PR DESCRIPTION
### Description of the problem being solved:

I recommended disabling `align_array_table` earlier due to it messing the one-line style of formatting that PoB has for massive tables. This seems to similarly break ModParser.lua tables and so it should probably be disabled too.

### Steps taken to verify a working solution:
- Doesn't mess up formatting after enabling

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
