### PR TITLE
Fix character reimport resetting bandit and pantheon choices

### DIFF
--- a/spec/System/TestImport_spec.lua
+++ b/spec/System/TestImport_spec.lua
@@ -42,7 +42,7 @@ describe("TestImport", function()
 		assert.equals(build.spec.allocatedNotableCount, 29)
 	end)
 
-	it("preserves bandit and pantheon choices when the import omits them", function()
+	it("preserves quest choices only for account-name imports", function()
 		build.configTab.varControls.bandit:SetSel(2)
 		build.configTab.varControls.pantheonMajorGod:SetSel(4)
 		build.configTab.varControls.pantheonMinorGod:SetSel(9)
@@ -51,29 +51,29 @@ describe("TestImport", function()
 		importData.passives.bandit_choice = nil
 		importData.passives.pantheon_major = nil
 		importData.passives.pantheon_minor = nil
-		build.importTab:ImportPassiveTreeAndJewels(importData, true)
+		build.importTab.controls.siteAccountName.buf = "Test#0000"
+		build.importTab.controls.siteCharSelect.list = { { char = importData } }
+		build.importTab.controls.siteCharSelect.selIndex = 1
+		build.importTab.lastLeague = importData.league
+
+		local downloadPage = launch.DownloadPage
+		launch.DownloadPage = function(_, _, callback)
+			callback({ body = dkjson.encode(importData.passives) })
+		end
+		build.importTab:DownloadPassiveTree({ hostName = "", realmCode = "pc" })
+		launch.DownloadPage = downloadPage
 		runCallback("OnFrame")
 
 		assert.equals(build.configTab.input.bandit, "Oak")
 		assert.equals(build.configTab.input.pantheonMajorGod, "Solaris")
 		assert.equals(build.configTab.input.pantheonMinorGod, "Shakari")
-	end)
 
-	it("imports bandit and pantheon choices when they are present", function()
-		build.configTab.varControls.bandit:SetSel(2)
-		build.configTab.varControls.pantheonMajorGod:SetSel(4)
-		build.configTab.varControls.pantheonMinorGod:SetSel(9)
-
-		local importData = copyTable(sampleData)
-		importData.passives.bandit_choice = "Alira"
-		importData.passives.pantheon_major = "Lunaris"
-		importData.passives.pantheon_minor = "Abberath"
 		build.importTab:ImportPassiveTreeAndJewels(importData, true)
 		runCallback("OnFrame")
 
-		assert.equals(build.configTab.input.bandit, "Alira")
-		assert.equals(build.configTab.input.pantheonMajorGod, "Lunaris")
-		assert.equals(build.configTab.input.pantheonMinorGod, "Abberath")
+		assert.equals(build.configTab.input.bandit, "None")
+		assert.equals(build.configTab.input.pantheonMajorGod, "None")
+		assert.equals(build.configTab.input.pantheonMinorGod, "None")
 	end)
 
 	it("imports with correct jewels", function()

--- a/spec/System/TestImport_spec.lua
+++ b/spec/System/TestImport_spec.lua
@@ -16,7 +16,9 @@ describe("TestImport", function()
 		build.importTab:ImportPassiveTreeAndJewels(sampleData, true)
 		runCallback("OnFrame")
 
-		assert.equals(build.bandit, "None")
+		assert.equals(build.configTab.input.bandit, "None")
+		assert.equals(build.configTab.input.pantheonMajorGod, "TheBrineKing")
+		assert.equals(build.configTab.input.pantheonMinorGod, "Yugul")
 		assert.equals(build.characterLevel, 99)
 		-- iron will and CI
 		assert.equals(build.spec.allocatedKeystoneCount, 2)
@@ -39,6 +41,41 @@ describe("TestImport", function()
 
 		assert.equals(build.spec.allocatedNotableCount, 29)
 	end)
+
+	it("preserves bandit and pantheon choices when the import omits them", function()
+		build.configTab.varControls.bandit:SetSel(2)
+		build.configTab.varControls.pantheonMajorGod:SetSel(4)
+		build.configTab.varControls.pantheonMinorGod:SetSel(9)
+
+		local importData = copyTable(sampleData)
+		importData.passives.bandit_choice = nil
+		importData.passives.pantheon_major = nil
+		importData.passives.pantheon_minor = nil
+		build.importTab:ImportPassiveTreeAndJewels(importData, true)
+		runCallback("OnFrame")
+
+		assert.equals(build.configTab.input.bandit, "Oak")
+		assert.equals(build.configTab.input.pantheonMajorGod, "Solaris")
+		assert.equals(build.configTab.input.pantheonMinorGod, "Shakari")
+	end)
+
+	it("imports bandit and pantheon choices when they are present", function()
+		build.configTab.varControls.bandit:SetSel(2)
+		build.configTab.varControls.pantheonMajorGod:SetSel(4)
+		build.configTab.varControls.pantheonMinorGod:SetSel(9)
+
+		local importData = copyTable(sampleData)
+		importData.passives.bandit_choice = "Alira"
+		importData.passives.pantheon_major = "Lunaris"
+		importData.passives.pantheon_minor = "Abberath"
+		build.importTab:ImportPassiveTreeAndJewels(importData, true)
+		runCallback("OnFrame")
+
+		assert.equals(build.configTab.input.bandit, "Alira")
+		assert.equals(build.configTab.input.pantheonMajorGod, "Lunaris")
+		assert.equals(build.configTab.input.pantheonMinorGod, "Abberath")
+	end)
+
 	it("imports with correct jewels", function()
 		build.importTab:ImportPassiveTreeAndJewels(sampleData, true)
 		runCallback("OnFrame")

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -835,6 +835,10 @@ function ImportTabClass:DownloadPassiveTree(realm)
 				self.lastLeague = self.controls.siteCharSelectLeague:GetSelValueByKey("league")
 			end
 			local responseLua = dkjson.decode(response.body)
+			-- Account-name imports omit quest choices, so keep the build's current values.
+			responseLua.bandit_choice = responseLua.bandit_choice or self.build.configTab.input.bandit
+			responseLua.pantheon_major = responseLua.pantheon_major or self.build.configTab.input.pantheonMajorGod
+			responseLua.pantheon_minor = responseLua.pantheon_minor or self.build.configTab.input.pantheonMinorGod
 			-- modify response to be like the oauth API response
 			local charData = copyTable(charListData)
 			charData.passives = responseLua
@@ -1229,18 +1233,18 @@ function ImportTabClass:ImportPassiveTreeAndJewels(charData, deleteJewels)
 		end
 	end
 
-	-- Unauthenticated character imports omit these fields. In that case, preserve
-	-- the build's existing choices instead of replacing them with "None".
-	if charPassives.bandit_choice then
-		local bandit = charPassives.bandit_choice == "Eramir" and "None" or charPassives.bandit_choice
-		setSelByVal(self.build.configTab.varControls["bandit"], bandit)
-	end
-	if charPassives.pantheon_major then
-		setSelByVal(self.build.configTab.varControls["pantheonMajorGod"], charPassives.pantheon_major)
-	end
-	if charPassives.pantheon_minor then
-		setSelByVal(self.build.configTab.varControls["pantheonMinorGod"], charPassives.pantheon_minor)
-	end
+	local bandit = (charPassives.bandit_choice == "Eramir" or not charPassives.bandit_choice) and "None" or
+		charPassives.bandit_choice
+	setSelByVal(self.build.configTab.varControls["bandit"],
+		bandit)
+
+	local majorGod = charPassives.pantheon_major or "None"
+	setSelByVal(self.build.configTab.varControls["pantheonMajorGod"],
+		majorGod)
+
+	local minorGod = charPassives.pantheon_minor or "None"
+	setSelByVal(self.build.configTab.varControls["pantheonMinorGod"],
+		minorGod)
 
 	main:SetWindowTitleSubtext(string.format("%s (%s, %s, %s)", self.build.buildName, charData.name, charData.class,
 		charData.league))

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -1229,18 +1229,18 @@ function ImportTabClass:ImportPassiveTreeAndJewels(charData, deleteJewels)
 		end
 	end
 
-	local bandit = (charPassives.bandit_choice == "Eramir" or not charPassives.bandit_choice) and "None" or
-		charPassives.bandit_choice
-	setSelByVal(self.build.configTab.varControls["bandit"],
-		bandit)
-
-	local majorGod = charPassives.pantheon_major or "None"
-	setSelByVal(self.build.configTab.varControls["pantheonMajorGod"],
-		majorGod)
-
-	local minorGod = charPassives.pantheon_minor or "None"
-	setSelByVal(self.build.configTab.varControls["pantheonMinorGod"],
-		minorGod)
+	-- Unauthenticated character imports omit these fields. In that case, preserve
+	-- the build's existing choices instead of replacing them with "None".
+	if charPassives.bandit_choice then
+		local bandit = charPassives.bandit_choice == "Eramir" and "None" or charPassives.bandit_choice
+		setSelByVal(self.build.configTab.varControls["bandit"], bandit)
+	end
+	if charPassives.pantheon_major then
+		setSelByVal(self.build.configTab.varControls["pantheonMajorGod"], charPassives.pantheon_major)
+	end
+	if charPassives.pantheon_minor then
+		setSelByVal(self.build.configTab.varControls["pantheonMinorGod"], charPassives.pantheon_minor)
+	end
 
 	main:SetWindowTitleSubtext(string.format("%s (%s, %s, %s)", self.build.buildName, charData.name, charData.class,
 		charData.league))


### PR DESCRIPTION
When not authenticated, importing a character by account name resets the bandit and pantheon choices even if you had set them manually before.