### PR TITLE
Fix file sort not using folder name when determining the sort order of builds

### DIFF
--- a/src/Modules/BuildListHelpers.lua
+++ b/src/Modules/BuildListHelpers.lua
@@ -146,21 +146,20 @@ local function SortList(list, sortMode)
 		if a_is_folder and not b_is_folder then return true end
 		if not a_is_folder and b_is_folder then return false end
 
+		local aPathName = (a.subPath or "") .. (a.folderName or a.fileName or "")
+		local bPathName = (b.subPath or "") .. (b.folderName or b.fileName or "")
+
 		if sortMode == "EDITED" then
 			local modA = a.modified or 0
 			local modB = b.modified or 0
 			if modA ~= modB then
 				return modA > modB
 			end
-			if a_is_folder then
-				return naturalSortCompare(a.folderName, b.folderName)
-			else
-				return naturalSortCompare(a.fileName, b.fileName)
-			end
+			return naturalSortCompare(aPathName, bPathName)
 		end
 
 		if a_is_folder then
-			return naturalSortCompare(a.folderName, b.folderName)
+			return naturalSortCompare(aPathName, bPathName)
 		else
 			if sortMode == "CLASS" then
 				local a_has_class = a.className ~= nil
@@ -178,16 +177,16 @@ local function SortList(list, sortMode)
 				elseif a_has_asc and b_has_asc and a.ascendClassName ~= b.ascendClassName then
 					return a.ascendClassName < b.ascendClassName
 				end
-				return naturalSortCompare(a.fileName, b.fileName)
+				return naturalSortCompare(aPathName, bPathName)
 			elseif sortMode == "LEVEL" then
 				if a.level and not b.level then return false
 				elseif not a.level and b.level then return true
 				elseif a.level and b.level then
 					if a.level ~= b.level then return a.level < b.level end
 				end
-				return naturalSortCompare(a.fileName, b.fileName)
+				return naturalSortCompare(aPathName, bPathName)
 			else
-				return naturalSortCompare(a.fileName, b.fileName)
+				return naturalSortCompare(aPathName, bPathName)
 			end
 		end
 	end)


### PR DESCRIPTION
Fixes # .

### Description of the problem being solved:

Sorting the build list across sub dirs only compared fileName and ignored subPath. This caused files from different sub dirs to get mixed together out of order.

### Steps taken to verify a working solution:
-
-
-

### Link to a build that showcases this PR:

### Before screenshot:

<img width="932" height="314" alt="image" src="https://github.com/user-attachments/assets/1cda09ba-2e8b-405a-843c-c8947a849b30" />


### After screenshot:

<img width="932" height="302" alt="image" src="https://github.com/user-attachments/assets/fae7a681-cc45-4165-8e43-08b6268039bd" />
