### PR TITLE
Fix crash when double clicking and dragging an item on small window sizes

### DIFF
--- a/src/Classes/ItemDBControl.lua
+++ b/src/Classes/ItemDBControl.lua
@@ -312,7 +312,7 @@ function ItemDBClass:Draw(viewPort)
 end
 
 function ItemDBClass:GetRowValue(column, index, item)
-	if column == 1 then
+	if item and column == 1 then
 		return colorCodes[item.rarity] .. item.name
 	end
 end
@@ -359,6 +359,10 @@ function ItemDBClass:OnSelClick(index, item, doubleClick)
 		self.itemsTab:AddUndoState()
 		self.itemsTab.build.buildFlag = true
 	elseif doubleClick then
+		-- disallow dragging after double click since the window can jump when
+		-- the display item tooltip is created, which might cause the drag item
+		-- to get stuck to the cursor
+		self.selDragging = false
 		self.itemsTab:CreateDisplayItemFromRaw(item.raw, true)
 		return false
 	end


### PR DESCRIPTION
Fixes #10129 

### Description of the problem being solved:

This fixes the possibility of a crash with a nil check on the method that is used for (I think) getting the drag text. But this also fixes the stuck drag issue by disallowing it on double click. With double clicks it was possible to start an invalid drag if the second click was outside the item. This happened when the window scrolls a lot to the right, or just naturally if you have low fps (debugger)

### Steps taken to verify a working solution:
- Issue seems to be fixed
- Drag still works (it doesn't even do anything in the item DB)

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
