### PR TITLE
Fix missing modifier controls on imported items

### DIFF
--- a/spec/System/TestItemMods_spec.lua
+++ b/spec/System/TestItemMods_spec.lua
@@ -841,6 +841,44 @@ describe("TetsItemMods", function()
 		assert.are.equals(0, calcCount)
 	end)
 
+	it("shows custom modifier controls when affix crafting is hidden", function()
+		build.itemsTab:CreateDisplayItemFromRaw([[
+			Rarity: RARE
+			Test Item
+			Iron Ring
+			Implicits: 1
+			Adds 1 to 4 Physical Damage to Attacks
+			{crafted}+8 to Strength
+		]])
+
+		local controls = build.itemsTab.controls
+		assert.is_falsy(build.itemsTab.displayItem.crafted)
+		assert.is_falsy(controls.displayItemSectionAffix:IsShown())
+		assert.is_true(controls.displayItemSectionCustom:IsShown())
+		assert.is_true(controls.displayItemAddCustom:IsShown())
+		assert.is_true(controls.displayItemCustomModifierRemove1:IsShown())
+	end)
+
+	it("shows affix controls for items crafted in Path of Building", function()
+		build.itemsTab:CreateDisplayItemFromRaw([[
+			Rarity: RARE
+			New Item
+			Cobalt Jewel
+			Crafted: true
+			Prefix: None
+			Prefix: None
+			Suffix: None
+			Suffix: None
+			Quality: 0
+			LevelReq: 0
+			Implicits: 0
+		]])
+
+		local controls = build.itemsTab.controls
+		assert.is_true(controls.displayItemSectionAffix:IsShown())
+		assert.is_true(controls.displayItemAffix1:IsShown())
+	end)
+
 	it("sorts crafted modifier replacements without retaining the selected modifier", function()
 		local item = new("Item", [[
 			Rarity: RARE

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -747,7 +747,9 @@ holding Shift will put it in the second.]])
 		end
 		return h
 	end})
-
+	self.controls.displayItemSectionAffix.shown = function()
+		return self.displayItem and self.displayItem.crafted
+	end
 	for i = 1, maxModCount do
 		local prev = self.controls["displayItemAffix"..(i-1)] or self.controls.displayItemSectionAffix
 		local drop, slider

--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -982,7 +982,7 @@ holding Shift will put it in the second.]])
 
 	-- Section: Custom modifiers
 	-- if either Custom or Crucible mod buttons are shown, create the control for the list of mods
-	self.controls.displayItemSectionCustom = new("Control", {"TOPLEFT",self.controls.displayItemSectionAffix,"BOTTOMLEFT"}, {0, 0, 0, function()
+	self.controls.displayItemSectionCustom = new("Control", {"TOPLEFT",self.controls.displayItemSectionAffix,"BOTTOMLEFT",true}, {0, 0, 0, function()
 		return (self.controls.displayItemAddCustom:IsShown() or self.controls.displayItemAddCrucible:IsShown()) and 28 + self.displayItem.customCount * 22 or 0
 	end})
 	self.controls.displayItemAddCustom = new("ButtonControl", {"TOPLEFT",self.controls.displayItemSectionCustom,"TOPLEFT"}, {0, 0, 120, 20}, "Add modifier...", function()


### PR DESCRIPTION
### Description of the problem being solved:

Affixes weren't hidden when the crafting controls went away

### Steps taken to verify a working solution:
-
-
-

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
