### PR TITLE
Fix crash from equipping Quivers and Shields that grant a skills

### DIFF
--- a/spec/System/TestTriggers_spec.lua
+++ b/spec/System/TestTriggers_spec.lua
@@ -1504,6 +1504,23 @@ describe("TestTriggers", function()
 		assert.is_falsy(build.calcsTab.mainEnv.player.mainSkill.skillFlags.weapon2Attack)
 	end)
 
+	it("Use the equipped bow for Void Shot granted by Voidfletcher", function()
+		build.itemsTab:CreateDisplayItemFromRaw("Test Bow\nShort Bow")
+		build.itemsTab:AddDisplayItem()
+		runCallback("OnFrame")
+
+		build.itemsTab:CreateDisplayItemFromRaw([[Voidfletcher
+		Ornate Quiver
+		Consumes a Void Charge to Trigger Level 20 Void Shot when you fire Arrows with a Non-Triggered Skill]])
+		build.itemsTab:AddDisplayItem()
+		runCallback("OnFrame")
+
+		local mainSkill = build.calcsTab.mainEnv.player.mainSkill
+		assert.are.equals("Void Shot", mainSkill.activeEffect.grantedEffect.name)
+		assert.is_true(mainSkill.skillFlags.weapon1Attack)
+		assert.is_falsy(mainSkill.skillFlags.weapon2Attack)
+	end)
+
 	it("Trigger Ghostly Artillery with a projectile attack", function()
 		equipDreadCaptainsCutlass()
 		build.skillsTab:PasteSocketGroup("Lancing Steel 20/0  1\n")

--- a/src/Data/Skills/other.lua
+++ b/src/Data/Skills/other.lua
@@ -1925,6 +1925,7 @@ skills["FieryImpactHeistMaceImplicit"] = {
 		attack = true,
 		area = true,
 		melee = true,
+		forceSourceWeapon = true,
 	},
 	constantStats = {
 		{ "skill_physical_damage_%_to_convert_to_fire", 60 },
@@ -5953,6 +5954,7 @@ skills["GhostCannons"] = {
 		attack = true,
 		projectile = true,
 		area = true,
+		forceSourceWeapon = true,
 	},
 	constantStats = {
 		{ "skill_physical_damage_%_to_convert_to_fire", 50 },

--- a/src/Export/Skills/other.txt
+++ b/src/Export/Skills/other.txt
@@ -533,7 +533,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill FieryImpactHeistMaceImplicit
-#flags attack area melee
+#flags attack area melee forceSourceWeapon
 	fromItem = true,
 #mods
 
@@ -1564,7 +1564,7 @@ local skills, mod, flag, skill = ...
 #mods
 
 #skill GhostCannons Ghostly Artillery
-#flags attack projectile area
+#flags attack projectile area forceSourceWeapon
 	fromItem = true,
 #mods
 

--- a/src/Modules/CalcActiveSkill.lua
+++ b/src/Modules/CalcActiveSkill.lua
@@ -278,8 +278,8 @@ function calcs.buildActiveSkillModList(env, activeSkill)
 		activeSkill.weapon2Flags = 0
 	else
 		-- Set weapon flags
-		if skillFlags.attack and activeSkill.socketGroup and activeSkill.socketGroup.sourceItem then
-			-- Item-granted attacks use the weapon that grants the skill
+		if skillFlags.forceSourceWeapon and activeSkill.socketGroup and activeSkill.socketGroup.sourceItem then
+			-- Some item-granted attacks must use the weapon that grants the skill
 			local sourceSlot = activeSkill.socketGroup.slot or ""
 			skillFlags.forceMainHand = sourceSlot:match("^Weapon 1") ~= nil
 			skillFlags.forceOffHand = sourceSlot:match("^Weapon 2") ~= nil


### PR DESCRIPTION
Fixes #10114

### Description of the problem being solved:
The logic added for Ghostly Artillery was too general and causing issues for granted skills that don't care about the item that grants it
Now tags skills that come from the granted item

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/yqyp3y0x

### Before screenshot:
<img width="844" height="350" alt="image" src="https://github.com/user-attachments/assets/8e1f585d-db9c-4f9b-ab2f-a491ad39cd73" />