### PR TITLE
Fix The Unblinking Eye increased evasion not applying to attacks with arcane might

### DIFF
--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -608,6 +608,13 @@ function calcs.offence(env, actor, activeSkill)
 			end
 		end
 	end
+	if skillModList:Flag(nil, "EvasionAppliesToSpellDamage") then
+		-- The Unblinking Eye evasion rating to spell damage conversion
+		for i, value in ipairs(skillModList:Tabulate("INC", { }, "Evasion")) do
+			local mod = value.mod
+			skillModList:NewMod("Damage", mod.type, mod.value, mod.source, ModFlag.Spell, mod.keywordFlags, unpack(mod))
+		end
+	end
 	if skillModList:Flag(nil, "SpellDamageAppliesToAttacks") or skillModList:Flag(skillCfg, "SpellDamageAppliesToAttacks") then
 		-- Spell Damage conversion from Crown of Eyes, Kinetic Bolt, and the Wandslinger notable
 		local multiplier = (skillModList:Max(skillCfg, "ImprovedSpellDamageAppliesToAttacks") or 100) / 100
@@ -640,13 +647,6 @@ function calcs.offence(env, actor, activeSkill)
 		for i, value in ipairs(skillModList:Tabulate("INC", { }, "ProjectileSpeed")) do
 			local mod = value.mod
 			skillModList:NewMod("Damage", mod.type, mod.value, mod.source, bor(ModFlag.Bow, ModFlag.Hit), mod.keywordFlags, unpack(mod))
-		end
-	end
-	if skillModList:Flag(nil, "EvasionAppliesToSpellDamage") then
-		-- The Unblinking Eye evasion rating to spell damage conversion
-		for i, value in ipairs(skillModList:Tabulate("INC", { }, "Evasion")) do
-			local mod = value.mod
-			skillModList:NewMod("Damage", mod.type, mod.value, mod.source, ModFlag.Spell, mod.keywordFlags, unpack(mod))
 		end
 	end
 	if skillModList:Flag(nil, "ClawDamageAppliesToUnarmed") then


### PR DESCRIPTION
Fixes #10151 .

### Description of the problem being solved:
Fixed The Unblinking Eye's evasion% -> spell damage% not working for attacks with arcane might (spell damage% -> attack damage%)

### Steps taken to verify a working solution:


### Link to a build that showcases this PR:
https://pobb.in/2v30KT95PC4G

### Before screenshot:
<img width="565" height="213" alt="image" src="https://github.com/user-attachments/assets/db77fd46-68ae-4d4e-9816-652ae616d0d5" />
<img width="542" height="184" alt="image" src="https://github.com/user-attachments/assets/1fde1eab-06ba-439a-8fbe-82211c169181" />

### After screenshot:
<img width="560" height="208" alt="image" src="https://github.com/user-attachments/assets/2cc51009-18df-45ad-9c9b-ccc8d53c84b7" />
