### PR TITLE
Only enable optimise sockets button when it will do something

### DIFF
--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -253,7 +253,7 @@ function SkillsTabClass:SkillsTab(build)
 		local maxSockets = (item.base.socketLimit or 0) - abyssalSocketCount
 		return maxSockets, abyssalSocketCount
 	end
-	self.controls.optimiseSockets = new("ButtonControl"):ButtonControl({ "LEFT", self.controls.socketsLabel, "RIGHT" }, { 4, 0, 120, 18 }, "^7Optimise Sockets", function()
+	self.controls.optimiseSockets = new("ButtonControl"):ButtonControl({ "LEFT", self.controls.socketsLabel, "RIGHT" }, { 4, 0, 120, 18 }, "Optimise Sockets", function()
 		local item, groupSlot = getSelectedItem()
 		if not item or not groupSlot or not item.base then
 			return
@@ -304,7 +304,7 @@ function SkillsTabClass:SkillsTab(build)
 						if not gem.matchesSocket then
 							return true
 						end
-						maxSockets -= 1
+						maxSockets = maxSockets - 1
 					end
 				end
 			end

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -243,6 +243,16 @@ function SkillsTabClass:SkillsTab(build)
 		local item = getSelectedItem()
 		return not not item
 	end
+	local function getSocketCounts(item)
+		local abyssalSocketCount = 0
+		for _, socket in ipairs(item.sockets) do
+			if socket.color == "A" then
+				abyssalSocketCount = abyssalSocketCount + 1
+			end
+		end
+		local maxSockets = (item.base.socketLimit or 0) - abyssalSocketCount
+		return maxSockets, abyssalSocketCount
+	end
 	self.controls.optimiseSockets = new("ButtonControl"):ButtonControl({ "LEFT", self.controls.socketsLabel, "RIGHT" }, { 4, 0, 120, 18 }, "^7Optimise Sockets", function()
 		local item, groupSlot = getSelectedItem()
 		if not item or not groupSlot or not item.base then
@@ -251,17 +261,10 @@ function SkillsTabClass:SkillsTab(build)
 
 		self.build.itemsTab:AddUndoState()
 
-		-- save count of abyssal sockets
-		local abyssalSocketCount = 0
-		for _, socket in ipairs(item.sockets) do
-			if socket.color == "A" then
-				abyssalSocketCount = abyssalSocketCount + 1
-			end
-		end
+		local maxSockets, abyssalSocketCount = getSocketCounts(item)
 
 		local groupCount = 0
 		item.sockets = {}
-		local maxSockets = (item.base.socketLimit or 0) - abyssalSocketCount
 		for _, group in ipairs(self.socketGroupList) do
 			local colours = { "R", "G", "B" }
 			if group.slot == groupSlot.slotName then
@@ -276,7 +279,6 @@ function SkillsTabClass:SkillsTab(build)
 				groupCount = groupCount + 1
 			end
 		end
-
 		for _ = 0, abyssalSocketCount - 1 do
 			groupCount = groupCount + 1
 			table.insert(item.sockets, { color = "A", group = groupCount })
@@ -288,6 +290,26 @@ function SkillsTabClass:SkillsTab(build)
 	self.controls.optimiseSockets.shown = function()
 		local item = getSelectedItem()
 		return item and (item.base.socketLimit ~= nil)
+	end
+	self.controls.optimiseSockets.enabled = function()
+		local item, groupSlot = getSelectedItem()
+		if not item or not groupSlot or not item.base then
+			return false
+		end
+		local maxSockets = getSocketCounts(item)
+		for _, group in ipairs(self.socketGroupList) do
+			if group.slot == groupSlot.slotName then
+				for _, gem in ipairs(group.gemList) do
+					if (gem.grantedEffect or (gem.gemData and gem.gemData.grantedEffect)) and maxSockets > 0 then
+						if not gem.matchesSocket then
+							return true
+						end
+						maxSockets -= 1
+					end
+				end
+			end
+		end
+		return false
 	end
 	self.controls.optimiseSockets.tooltipText = "Rebuild the item's sockets to match the groups assigned to it."
 	-- self.imbuedSupportBySlot is used by CalcSetup to add an ExtraSupport mod of the selected gem


### PR DESCRIPTION
Fixes #moxaj:

<img width="733" height="71" alt="image" src="https://github.com/user-attachments/assets/ad9bd011-bbb1-4ed4-b4e2-6e619c548834" />

### Description of the problem being solved:

This adds an `enabled` function to the optimise button. This should prevent it from lighting up when it won't do anything

### Steps taken to verify a working solution:
- Doesn't break with split groups
- Doesn't light up when count is over socket limit
- Lights up when necessary

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
