### PR TITLE
Remove corrupted jewel mods from Subsume the Source mod list

### DIFF
--- a/src/Modules/Data.lua
+++ b/src/Modules/Data.lua
@@ -1300,6 +1300,13 @@ data.minionTagCrucibleUniques = {
 	["United in Dream"] = true,
 }
 
+local subsumeTheSourceMods = {}
+for modId, mod in pairs(data.itemMods.JewelAbyss) do
+	if mod.type ~="Corrupted" then
+		subsumeTheSourceMods[modId] = mod
+	end
+end
+
 local crimsonStormMods = {}
 for modId, mod in pairs(data.veiledMods) do
 	if mod.affix == "of the Order" then
@@ -1323,7 +1330,7 @@ dreadCaptainBase.base.tags.deepwater_sword = true
 data.rareLikeUniques = {
 	["subsume the source"] = {
 		validBases = data.itemBaseLists["Jewel: Abyss"],
-		affixes = data.itemMods.JewelAbyss,
+		affixes = subsumeTheSourceMods,
 		prefixLimit = 4,
 		suffixLimit = 0,
 		ignoreModType = true,


### PR DESCRIPTION
### Description of the problem being solved:

This fixes corrupted mods existing on subsume the source crafting. Despite it being cool, you can't get corrupt implicits on this item. This also fixes the issue where mods get duplicated when moving sliders as it is caused by them not having the prefix/suffix type, which means they're treated like custom mods and duped.

### Steps taken to verify a working solution:
-
-
-

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
<img width="842" height="560" alt="image" src="https://github.com/user-attachments/assets/7aca31f7-5b50-4dee-a096-2d8e05b0f16a" />
