### PR TITLE
Preserve influences on fetched trade items

### DIFF
--- a/spec/System/TestTradeQueryRequests_spec.lua
+++ b/spec/System/TestTradeQueryRequests_spec.lua
@@ -194,6 +194,49 @@ Strict-Transport-Security: max-age=63115200; includeSubDomains; preload]]
 	end)
 
 	describe("FetchResultBlock", function()
+		it("preserves item influences in reconstructed item strings", function()
+			local response = dkjson.encode({
+				result = {
+					{
+						id = "influenced",
+						listing = {
+							price = { amount = 1, currency = "chaos", type = "~price" },
+							whisper = "hi",
+							account = { name = "seller" },
+						},
+						item = {
+							rarity = "Rare",
+							name = "Test Subject",
+							typeLine = "Astral Plate",
+							influences = {
+								shaper = true,
+								elder = true,
+								warlord = true,
+								hunter = true,
+								crusader = true,
+								redeemer = true,
+							},
+							searing = true,
+							tangled = true,
+						},
+					},
+				},
+			})
+			local fetchedItems
+			requests.requestQueue.fetch = { }
+			requests:FetchResultBlock("test", function(items)
+				fetchedItems = items
+			end)
+
+			local request = table.remove(requests.requestQueue.fetch, 1)
+			request.callback(response)
+
+			local item = new("Item"):Item(fetchedItems[1].item_string)
+			for _, influenceInfo in ipairs(itemLib.influenceInfo.all) do
+				assert.is_true(item[influenceInfo.key], influenceInfo.display)
+			end
+		end)
+
 		it("reads weighted sums from current and legacy pseudo mods", function()
 			local function makeTradeEntry(id, pseudoMods)
 				return {

--- a/src/Classes/TradeQueryRequests.lua
+++ b/src/Classes/TradeQueryRequests.lua
@@ -7,6 +7,17 @@
 local dkjson = require "dkjson"
 local utils = LoadModule("Modules/Utils")
 
+local tradeInfluenceApiKeys = {
+	shaper = "shaper",
+	elder = "elder",
+	adjudicator = "warlord",
+	basilisk = "hunter",
+	crusader = "crusader",
+	eyrie = "redeemer",
+	cleansing = "searing",
+	tangle = "tangled",
+}
+
 ---@class TradeQueryRequests
 local TradeQueryRequestsClass = newClass("TradeQueryRequests")
 
@@ -358,6 +369,12 @@ function TradeQueryRequestsClass:FetchResultBlock(url, callback)
 				end
 				for _, modLine in ipairs(item.explicitMods) do
 					t_insert(rawLines, processLine(modLine))
+				end
+				for _, influenceInfo in ipairs(itemLib.influenceInfo.all) do
+					local apiKey = tradeInfluenceApiKeys[influenceInfo.key]
+					if apiKey and ((item.influences and item.influences[apiKey]) or item[apiKey]) then
+						t_insert(rawLines, influenceInfo.display .. " Item")
+					end
 				end
 				if item.duplicated then
 					t_insert(rawLines, "Mirrored")


### PR DESCRIPTION
### Description

Trader reconstructs fetched item text from the trade API response. That reconstruction omitted influence fields, so influenced results were displayed and imported without their influence markers.

Preserve all historical and Eldritch influence markers while rebuilding fetched items. This keeps the parsing correction from #10073 while restoring the influence information that the previous decoded item text carried automatically.

### Validation

- Added regression coverage that round-trips every supported item influence through the fetched-item reconstruction.
- Manually verified Elder influence is retained when requested through both the Influence dropdown and a required stat.
