### PR TITLE
Fix Penance Brand of Conduction hit rate incorrectly using activation frequency

### DIFF
--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -14013,7 +14013,11 @@ skills["PenanceBrandAltY"] = {
 	statDescriptionScope = "brand_skill_stat_descriptions",
 	castTime = 0.75,
 	preDamageFunc = function(activeSkill, output)
-		activeSkill.skillData.hitTimeOverride = activeSkill.skillData.repeatFrequency / (1 + activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "Speed", "BrandActivationFrequency") / 100) / activeSkill.skillModList:More(activeSkill.skillCfg, "BrandActivationFrequency")
+		-- Activating only spreads energy; damage is dealt once, when the brand detaches at the end
+		-- of its attached duration, so this brand hits once per cast rather than once per activation
+		activeSkill.skillData.brandActivationTime = activeSkill.skillData.repeatFrequency / (1 + activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "Speed", "BrandActivationFrequency") / 100) / activeSkill.skillModList:More(activeSkill.skillCfg, "BrandActivationFrequency")
+		activeSkill.skillData.hitTimeOverride = output.Duration or 0
+		activeSkill.skillData.hitTimeCappedByCastTime = true
 	end,
 	baseFlags = {
 		spell = true,

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -3322,7 +3322,11 @@ local skills, mod, flag, skill = ...
 #skill PenanceBrandAltY
 #flags spell area duration brand
 	preDamageFunc = function(activeSkill, output)
-		activeSkill.skillData.hitTimeOverride = activeSkill.skillData.repeatFrequency / (1 + activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "Speed", "BrandActivationFrequency") / 100) / activeSkill.skillModList:More(activeSkill.skillCfg, "BrandActivationFrequency")
+		-- Activating only spreads energy; damage is dealt once, when the brand detaches at the end
+		-- of its attached duration, so this brand hits once per cast rather than once per activation
+		activeSkill.skillData.brandActivationTime = activeSkill.skillData.repeatFrequency / (1 + activeSkill.skillModList:Sum("INC", activeSkill.skillCfg, "Speed", "BrandActivationFrequency") / 100) / activeSkill.skillModList:More(activeSkill.skillCfg, "BrandActivationFrequency")
+		activeSkill.skillData.hitTimeOverride = output.Duration or 0
+		activeSkill.skillData.hitTimeCappedByCastTime = true
 	end,
 #baseMod skill("radius", 28)
 #baseMod skill("showAverage", true)

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -2107,6 +2107,10 @@ function calcs.offence(env, actor, activeSkill)
 	local storedMainHandAccuracy = nil
 	local storedMainHandAccuracyVsEnemy = nil
 	local storedSustainedTraumaBreakdown = { }
+	-- Skills flagged hitTimeCappedByCastTime hit once per use, so their total hit rate is limited by
+	-- how fast those uses can be created. Brands need one use per attached brand, matching the
+	-- AttachedBrandCount factor applied to dpsMultiplier below
+	local hitInstancesPerUse = (activeSkill.skillTypes[SkillType.Brand] and not skillData.countsAttachedBrandsInDamage and output.AttachedBrandCount) or 1
 	-- Calculate how often you hit (speed, accuracy, block, etc)
 	for _, pass in ipairs(passList) do
 		globalOutput, globalBreakdown = output, breakdown
@@ -2402,10 +2406,15 @@ function calcs.offence(env, actor, activeSkill)
 		end
 		if skillData.hitTimeOverride and not skillData.triggeredOnDeath then
 			output.HitTime = skillData.hitTimeOverride
+			if skillData.hitTimeCappedByCastTime and output.Time then
+				-- Skill hits once per use, so it cannot hit more often than those uses can be created
+				output.HitTime = m_max(output.HitTime, output.Time * hitInstancesPerUse)
+			end
 			output.HitSpeed = 1 / output.HitTime
 			--Brands always have hitTimeOverride
 			if activeSkill.skillTypes[SkillType.Brand] and not skillModList:Flag(nil, "UnlimitedBrandDuration") then
-				output.BrandTicks = m_floor(output.Duration * output.HitSpeed)
+				-- Brands that don't hit on every activation track their activation interval separately
+				output.BrandTicks = m_floor(output.Duration / (skillData.brandActivationTime or output.HitTime))
 			end
 		elseif skillData.hitTimeMultiplier and output.Time and not skillData.triggeredOnDeath then
 			output.HitTime = output.Time * skillData.hitTimeMultiplier
@@ -2473,6 +2482,10 @@ function calcs.offence(env, actor, activeSkill)
 		end
 		if skillData.hitTimeOverride and not skillData.triggeredOnDeath then
 			output.HitTime = skillData.hitTimeOverride
+			if skillData.hitTimeCappedByCastTime and output.Time then
+				-- Skill hits once per use, so it cannot hit more often than those uses can be created
+				output.HitTime = m_max(output.HitTime, output.Time * hitInstancesPerUse)
+			end
 			output.HitSpeed = 1 / output.HitTime
 		elseif skillData.hitTimeMultiplier and output.Time and not skillData.triggeredOnDeath then
 			output.HitTime = output.Time * skillData.hitTimeMultiplier
@@ -2488,7 +2501,21 @@ function calcs.offence(env, actor, activeSkill)
 	if breakdown then
 		if skillData.hitTimeOverride and not skillData.triggeredOnDeath then
 			breakdown.HitSpeed = { }
-			t_insert(breakdown.HitSpeed, s_format("1 / %.2f ^8(hit time override)", output.HitTime))
+			if skillData.hitTimeCappedByCastTime and output.Time then
+				local useType = isAttack and "attack" or "cast"
+				t_insert(breakdown.HitSpeed, "Skill only hits once per use:")
+				t_insert(breakdown.HitSpeed, s_format("%.2fs ^8(base hit time)", skillData.hitTimeOverride))
+				if hitInstancesPerUse > 1 then
+					t_insert(breakdown.HitSpeed, s_format("%.2fs ^8(%s time x %d attached brands)", output.Time * hitInstancesPerUse, useType, hitInstancesPerUse))
+				else
+					t_insert(breakdown.HitSpeed, s_format("%.2fs ^8(%s time)", output.Time, useType))
+				end
+				t_insert(breakdown.HitSpeed, s_format("= %.2fs ^8(hit time, higher of the two)", output.HitTime))
+				t_insert(breakdown.HitSpeed, s_format(""))
+				t_insert(breakdown.HitSpeed, s_format("1 / %.2f ^8(hit time)", output.HitTime))
+			else
+				t_insert(breakdown.HitSpeed, s_format("1 / %.2f ^8(hit time override)", output.HitTime))
+			end
 			t_insert(breakdown.HitSpeed, s_format("= %.2f", output.HitSpeed))
 		elseif skillData.hitTimeMultiplier and output.Time and not skillData.triggeredOnDeath then
 			breakdown.HitTime = { }


### PR DESCRIPTION
Fixes #10124 & #7288 .

### Description of the problem being solved:
Penance Brand of Conduction only deals damage when the brand detaches at the end of its attached duration, but its preDamageFunc was a copy of Penance Brand of Dissipation's, which pulses on every activation. So as pboc activates every 100ms, this reported a hit rate of 10+ per second instead of once per brand, which essentially inflated the dps calculation by a few orders of magnitude.

### Steps taken to verify a working solution:
- Check pboc dps with faster casting and more duration

### Link to a build that showcases this PR:
```shell
eNq1XFtT47gSfmZ_hSvvQ8gV2ILdCgEGqsiQQ5iZs09TwlYS7chWVpYD2V9_uiX5kgwJUpwDVYwsd3_qbkmtltSeiz_fYh4sqUyZSC4breOTRkCTUEQsmV02vj7ffjpr_PnHbxdjouaP06uMcXzzx29HF7ockDSkSTTkJE2_kJheNr6IhDaCBUnUnIpkRP4W8rOIfqlnyVr9C0kipvKncE4kCRWVD3RJ-SBTYiQiwFYyg7cxYclEhD-p-ixFtgChGwFHQl1aMvpqqO9H48en50agiJxR9S1XsfMDVAxLgSchVDdAo6OLMScrKieKqCCFP5eNARiGzOgdUwBMeAbkvX7v-LR92ms0d7JcZTJV1ySGojPrZEFpVFC3js_P-sXP6TYmkG2T7-y8U_x2t_GNJb2ZTmmo2JIOJVPDOUnCUtb-Nj5f2lHGFVtwRmVFwt4ObTbAWycn24ifhSL8ejyp0J62jru9Tu_8rAu_u_lE2acnH1FWG9lKPMw4h7nhRPtEUyqXRMHQc8MW8QtLaDRYztxHoqTkcWo6-YlELEtHVEmaFgDt460mupIwIQdKkXAe0wTYkxnV3AVzZyfrMwt_lg1tHbwjkpChSMueaJ_vIh1TCd5GrXGcfMAwoaEAB1Vl6Z0e91ud4sehxfdxtjb9wKbUndJLK8vgK81-etxMXOm8gfcT6AncqRvlRGTckVKVnqm9Y8L-UyXsb5051_TNAe4-UW6NVglbrdb2VpcCnYmjS7u5G5cT-ey43T5vtU9PTk_bW53JeL5KWUj4iLyxOIvBTz-Tn7Rsr79j-M3mKgHHuI21s9U93DJJ_bmGgkd7cM2JSLeyne2aXA5GgCU6_B1p75PQbcZ-TaReIyore38nwxPMI4w9Xjh15CibsLPRZdE1Tc1oYttbuanzQGk4_wyRGzRVDad2uu_SY-82LNI6GRYJ3zFsz5HBw0zIuMVMxzvXOG9D3SRUzlaTOaM88qPORRuShYObRENXuZ0Mvt6c16ipsnob5TuRkdty4ivVkqRVP9vq7zaYIXcbnJRTCgwR3QiBT7bH8OJvjOC5H9tAxiKTjl1uiJ0UyNcIs-15olEWuq1JxUbkisO-zlWNggvk5NyLVUe2P69FNHM2mm7Ei2Ndvkm2WIAfwdHgCoDLH2wUWCWK-dR3oH6Eoew0p3GldG-gpHZuoFj73VvZYHHXBddvD2VKcucmig4dgbPAbZHeeI9EZe-9tXNgb7jHTlWzvb_9tIiTn4zzIIUpGsLLRpDi85hIpR_MtKQJjrdAb8wCMQ2GEG9vTE1HecbiFWw1xwOV1MEfVKghsvp463grafLvyhl_jdypgRtQXKIxnNvY5HivmWcWg-tO02uiSJBSIsP5A4wr3QPF0y3h_AWcDtZGNlr_RiQjiWrpg6uNynY-mi6a-qQNS8-S0oDkPiVECi0APgQxSRUsYWaQpthMyDOsuiPp_FbImJRnYG2UDLddRK4G5QnefXTZSBhvBImIKED0zs5ge1w940OKk0agQJDKgRrs2s2JmnmNMh1dfH160IWjuVKL9Pdm8_X19XhB1FxM6RssWcehiJsLYAJtPulh-wlhmwP4uZoN9I8GauZIF-bUL22aJ5y3koGgpheaaAVtLzQTFvTcSHOD4cOEKmvrKcm4-kzj_2SEM7XSuzCYRhLr0qsVzKz8uHGt8hajkfI4Rk_MdC5e0bsbuufVAk03eHgwbx7ojIQrBLhsTAlPabX1B3NsmWDv5Fsr26VW3IBFeTfbyoCTF2QyB6GDUjmtGcx12ABEufAsgUEQwa7DuovqGWqFdUh4mBbtHF2AaJtI_6wZCpmws61vMcdFXP0FQ4fEdnDu9DuhyBLTFzMaI9KIKhLBBGreK7BVEw3W1LJBqdpKruJnLl4Ib-XiVSvbeaU9FUaJl2ZWvStz01dr29u3esYN4S8sV1XNzYugeOOmbDGEStz6yr4r6rsK28G5U-MH9HLgD00flgpjfVC-8NRXR4owmQr-Aym9Ju3eOo-EpO_pjPX76wwBtaQk_T9ovSavdZVmJlk3aT2LdpXGRWLxPkbmgL7hPxhArHLz6EVIK2FcHayL1wxWGVh9Q3R1RibjZZEsd7JZSs3Z3ndKFiLR1bi6aDEsoXVvO2nB73GhtOVhY6ffB61g8koWweBllaaEB2ZhCACIKWP9E1Mcv8DiAb6y-QvQHeUxsGwg9D0QdorS9gC6EtEqMPusOjA75ekcRp7uoeTpHkaeg_VXzwMIZuOSpnW66n2ETm2EvbqnxiR6X4r-AaToHADjENboHQBjD3u0a_u3KyFUrZ65olzVEuAd_nZN_s6hLLlXl9QwxjaM9gEwOgfA6B4Ao3cAjH7tFbx-DNCujdCpjdCtjeDTG7ewd__p5_glmfq7gz18qQfLIM44Vd6G22PU7he7eK-rvt7eg_4JtoFextUMbV-GzqHCs0OEFO1DLR4HA-rVXc9rA3TrAnTqArTrAtSPV3v7jtJ9x0FtiVuH2T31DgNzoL1l3eCyW5O_V5P_YGH-waLcrncM0Pbm6Hhz-EvV845MPtDjomnPn_QhmD7bwtIXoSgWjrA2f7gYimTKZvaAyzzYIy4NVdSsHdWPOQnpXPCISisYTWi8Km43x5hdlGTxC5XFRdJWLrx59WLAu2AvhjxCyen7rfOz8w94ilSInKl10uq6SJbf0uZ8efrNdqvheWdJf9Z1sJd_I5t31c6ca1fPhcV3cKVsxvjjVN-PThTRF5GFEbezTeYwrSeYueBGj7eS9BqkMukGBUfvI30kK1LXXdSJixTvG2S_I5yLVzAkTN6YOkm6KBJZfhW3-5H5bfp7Tn96cuKgX56DUXSyi3rrmpmeeKIxrNDR1WrA-cqtWwq870zNqaSRRhriBcKE8qlPT0HNZk-1291dYygUMpx7DCLdznpmj2tb69PKjzc0XnUBo0IS_sxmVGoDOfVY4Wn2kFdP5k2-s_P-B2w250lwrnPlq8Mx5xxmqRLxSERsCn2v85UCxRSnmL6rb4Q3r2_NlZW5wXmH26xkxfqj1zLzpJctvNM1dy3JIsuXR3279cMI90v_r1HGLA1_vGTTKX5Ng7kkUn8SdHN7ezN8vv92Y1kmVN_oBmn2kpriZeMbo6_6ZumaKsI4bkzxfspcPHGgwusyzskiLS_htqNpvrvSJSFW5dED6eaNSrwA_U5kKBm1cpVPPlDxAr03zF1M7rJIY4gRUn_djCaYgIiZJAZKf57iAWQy2vCC94koi2EdowcKekarCxa9eO_jBeG25bzsawmFyRMw52GMh3jPWB05mFhh63zsEoaZJOGqGDa54_fAuOLajghgix7MY8FSDJL0-LBlH6vOEpb3Z172YL-mIbG626IHc5F1KxKddIsoRZ0X0heR6EEOc2_AOKbO2Z694bSs8AB8xIXTpjoZpBG4q6LCb-JI9pKp3BtUn31spb8D0BbSJQ9Wk-muddAlHy-0lvutDbpW4wFlMqatP_RjNaGvtV8eB_t0QX48GpVlHyPk-xCtf_7gM0m0_x0sBYuMb9DTZbPSy2HA6lwfRmcb14fZTD-uj6h35ba_87IH-1cI9JlafYCiI6DdE64eAs62egjPLAlVJuneAE9FQPO0Gct8wFkksOq1On9w5y_yWvdGMNm3e7Prze_e3Nr_Q9SsU5DKBaCs8RnNAoJCCDhsGlYtrInKkjKjqxaUVnHDKW0FczGXXWgdrfYBonEf9iu50p_YCl_nC3HBXRF57otUpOffUcLVfCwErwf4y9eAdcDwE6NsQZIoh3tcj_e3wH7UDUKlgKkzxK_xS6a6NtR7WQegQi7YctqNpk5Px63frjTBf4XIs5475um_-ogWS3_pkkmZnyhpD2svdDJiMAHMQbTEufAMPVvNpsakVmJDCQ59ThYLmlSVvWhu_vcV_wNurX2d
```
### Before screenshot:

### After screenshot:
