### PR TITLE
Preserve main skill selection across character reimports

### DIFF
--- a/spec/System/TestImportReimport_spec.lua
+++ b/spec/System/TestImportReimport_spec.lua
@@ -55,6 +55,22 @@ describe("TestImportReimport", function()
 		}
 	end
 
+	local function pasteSocketGroups(mainSocketGroup, ...)
+		for _, lines in ipairs({ ... }) do
+			build.skillsTab:PasteSocketGroup(table.concat(lines, "\n") .. "\n")
+		end
+		build.mainSocketGroup = mainSocketGroup
+		runCallback("OnFrame")
+	end
+
+	local function makeImportItemWithGems(itemTypeLine, inventoryId, ...)
+		local socketedItems = { }
+		for index, gemName in ipairs({ ... }) do
+			socketedItems[index] = makeSocketedGemEntry(index - 1, gemName:match(" Support$") ~= nil, gemName, 20)
+		end
+		return makeImportItem(itemTypeLine, inventoryId, socketedItems, "test-import-item-" .. inventoryId)
+	end
+
 	local function reimportSocketedItemsWithOptions(itemTypeLine, inventoryId, socketedItems, clearItems)
 		build.importTab:ImportItemsAndSkills(buildImportPayload({
 			makeImportItem(itemTypeLine, inventoryId, socketedItems),
@@ -226,6 +242,52 @@ Blight 20/0  1
 		assert.is_true(groupsBySlot.Helmet.includeInFullDPS)
 		assert.are.equal(2, groupsBySlot.Helmet.mainActiveSkill)
 		assert.is_false(groupsBySlot.Gloves.enabled)
+	end)
+
+	it("preserves the main socket group when supports change", function()
+		pasteSocketGroups(1,
+			{ "Slot: Body Armour", "Cleave 20/0  1", "Added Fire Damage 20/0 DISABLED 1" }
+		)
+
+		build.importTab:ImportItemsAndSkills(buildImportPayload({
+			makeImportItemWithGems("Rawhide Gloves", "Gloves", "Cleave"),
+			makeImportItemWithGems("Plate Vest", "BodyArmour", "Cleave", "Faster Attacks Support"),
+		}), false, true, true)
+		runCallback("OnFrame")
+
+		local mainSocketGroup = build.skillsTab.socketGroupList[build.mainSocketGroup]
+		assert.are.equal("Body Armour", mainSocketGroup.slot)
+		assert.is_true(mainSocketGroup.gemList[2].enabled)
+	end)
+
+	it("preserves a support-granted main skill when supports change", function()
+		pasteSocketGroups(1,
+			{ "Slot: Body Armour", "Cleave 20/0  1", "Prismatic Burst 20/0  1", "Added Fire Damage 20/0  1" }
+		)
+		build.skillsTab.socketGroupList[1].mainActiveSkill = 2
+
+		build.importTab:ImportItemsAndSkills(buildImportPayload({
+			makeImportItemWithGems("Plate Vest", "BodyArmour", "Cleave", "Prismatic Burst Support", "Faster Attacks Support"),
+		}), false, true, true)
+		runCallback("OnFrame")
+
+		local mainSocketGroup = build.skillsTab.socketGroupList[build.mainSocketGroup]
+		assert.are.equal("PrismaticBurst", mainSocketGroup.displaySkillList[mainSocketGroup.mainActiveSkill].activeEffect.grantedEffect.id)
+	end)
+
+	it("guesses a new main socket group when the previous main skill is gone", function()
+		pasteSocketGroups(1,
+			{ "Slot: Body Armour", "Cleave 20/0  1" },
+			{ "Slot: Boots", "Frostblink 20/0  1" }
+		)
+
+		build.importTab:ImportItemsAndSkills(buildImportPayload({
+			makeImportItemWithGems("Iron Greaves", "Boots", "Frostblink"),
+			makeImportItemWithGems("Rawhide Gloves", "Gloves", "Fireball", "Added Fire Damage Support"),
+		}), false, true, true)
+		runCallback("OnFrame")
+
+		assert.are.equal("Gloves", build.skillsTab.socketGroupList[build.mainSocketGroup].slot)
 	end)
 
 	it("preserves skill part selection when reimporting items and skills", function()

--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -1267,6 +1267,22 @@ local function getSocketGroupReimportKey(socketGroup)
 	}, SOCKET_GROUP_REIMPORT_KEY_SEPARATOR)
 end
 
+local function findSocketGroupBySkillId(socketGroupList, skillId, preferredSlot)
+	local fallbackIndex
+	for index, socketGroup in ipairs(socketGroupList) do
+		for _, gem in ipairs(socketGroup.gemList) do
+			if gem.skillId == skillId then
+				if socketGroup.slot == preferredSlot then
+					return index
+				end
+				fallbackIndex = fallbackIndex or index
+				break
+			end
+		end
+	end
+	return fallbackIndex
+end
+
 local function snapshotSocketGroupReimportState(socketGroup, isMainGroup)
 	local gemStates = { }
 	for gemIndex, gem in ipairs(socketGroup.gemList) do
@@ -1390,7 +1406,18 @@ function ImportTabClass:ImportItemsAndSkills(charData, clearItems, clearSkills, 
 	local mainSkillEmpty = #self.build.skillsTab.socketGroupList == 0
 	local skillOrder
 	local preservedSocketGroupStateByKey
+	local preservedMainSkillId
+	local preservedMainGroupSlot
+	local preservedMainGrantedEffectId
 	if clearSkills then
+		local mainSocketGroup = self.build.skillsTab.socketGroupList[self.build.mainSocketGroup]
+		local mainActiveSkill = mainSocketGroup and mainSocketGroup.displaySkillList
+			and mainSocketGroup.displaySkillList[mainSocketGroup.mainActiveSkill or 1]
+		local mainActiveEffect = mainActiveSkill and mainActiveSkill.activeEffect
+		local srcInstance = mainActiveEffect and mainActiveEffect.srcInstance
+		preservedMainSkillId = srcInstance and srcInstance.skillId
+		preservedMainGroupSlot = mainSocketGroup and mainSocketGroup.slot
+		preservedMainGrantedEffectId = mainActiveEffect and mainActiveEffect.grantedEffect and mainActiveEffect.grantedEffect.id
 		skillOrder = { }
 		preservedSocketGroupStateByKey = { }
 		for _, socketGroup in ipairs(self.build.skillsTab.socketGroupList) do
@@ -1472,6 +1499,15 @@ function ImportTabClass:ImportItemsAndSkills(charData, clearItems, clearSkills, 
 		end
 		if restoredMainSocketGroup then
 			self.build.mainSocketGroup = restoredMainSocketGroup
+		elseif not mainSkillEmpty then
+			local matchingMainSocketGroup = preservedMainSkillId
+				and findSocketGroupBySkillId(self.build.skillsTab.socketGroupList, preservedMainSkillId, preservedMainGroupSlot)
+			if matchingMainSocketGroup then
+				self.build.mainSocketGroup = matchingMainSocketGroup
+				self.build.skillsTab.socketGroupList[matchingMainSocketGroup].pendingMainGrantedEffectId = preservedMainGrantedEffectId
+			else
+				self.build.mainSocketGroup = self:GuessMainSocketGroup()
+			end
 		end
 	end
 	if mainSkillEmpty then

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1773,6 +1773,17 @@ function calcs.initEnv(build, mode, override, specEnv)
 					env.player.modDB:AddMod(modLib.setSource(value.value, groupCfg.slotName or ""))
 				end
 
+				-- Reimport can defer a support-granted selection until this MAIN skill list exists.
+				-- Consume it once, then clear it below.
+				if index == env.mainSocketGroup and env.mode == "MAIN" and group.pendingMainGrantedEffectId then
+					for activeSkillIndex, activeSkill in ipairs(socketGroupSkillList) do
+						if activeSkill.activeEffect.grantedEffect.id == group.pendingMainGrantedEffectId then
+							group.mainActiveSkill = activeSkillIndex
+							break
+						end
+					end
+				end
+
 				if index == env.mainSocketGroup and #socketGroupSkillList > 0 then
 					-- Select the main skill from this socket group
 					local activeSkillIndex
@@ -1790,6 +1801,7 @@ function calcs.initEnv(build, mode, override, specEnv)
 			end
 
 			if env.mode == "MAIN" then
+				group.pendingMainGrantedEffectId = nil
 				-- Create display label for the socket group if the user didn't specify one
 				if group.label and group.label:match("%S") then
 					group.displayLabel = group.label


### PR DESCRIPTION
Fixes #10199.

### Description of the problem being solved:

When a character reimport changes the composition of the previous main socket group, that group no longer matches the exact restoration key. If the rebuilt groups have different indexes, `mainSocketGroup` can retain its previous index and select an unrelated skill. This can make DPS-based item sorting appear alphabetical because candidates are evaluated against the wrong main skill; this PR does not change item sorting itself.

The exact restoration path remains unchanged for groups that still match. Otherwise, the previous main group is located by its source skill, preferring its previous equipment slot. Its selected granted active effect is then restored after the new skill list is built, including effects granted by supports. If the source skill no longer exists, the existing main-group guess is used.

If multiple changed groups in the same equipment slot contain the same source skill, this fallback cannot unambiguously identify the previous group and selects the first match. Exact group matches remain preferred.

### Steps taken to verify a working solution:

- Added regression coverage for changed supports, reordered groups, the same source skill in another slot, and removal of the previous main skill.
- Added regression coverage for preserving a support-granted active skill using Prismatic Burst Support.
- Manual UI reproduction was not performed because the issue only provides a saved build, not the account and character context needed to replay the same reimport. The deterministic system tests exercise the affected `ImportItemsAndSkills` restoration path directly.
- Screenshots are not applicable because there is no visual change.

### Link to a build that showcases this PR:

The build code is available in #10199, but a saved build alone cannot demonstrate this reimport-only change.

### Before screenshot:

Not applicable; there is no visual change.

### After screenshot:

Not applicable; there is no visual change.
