### PR TITLE
Fix crash when a custom mod has an invalid support gem in it

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -511,4 +511,35 @@ describe("TestSkills", function()
 			assert.is_nil(build.calcsTab.mainOutput[test[3]])
 		end
 	end)
+
+	it("ignores invalid extra supports while allowing support name collisions", function()
+		build.skillsTab:PasteSocketGroup("Slot: Gloves\nFireball 20/0  1")
+		runCallback("OnFrame")
+		build.configTab.input.customMods = "Skills socketed in your gloves are supported by level 20 Arc"
+		build.configTab:BuildModList()
+		build.modFlag = true
+		build.buildFlag = true
+		assert.has_no.errors(function()
+			main:OnFrame()
+		end)
+		assert.are.equals(0, #build.calcsTab.mainEnv.player.mainSkill.supportList)
+
+		newBuild()
+		build.skillsTab:PasteSocketGroup("Slot: Gloves\nFireball 20/0  1")
+		build.configTab.input.customMods = "Skills socketed in your gloves are supported by level 20 Arcane Surge"
+		build.configTab:BuildModList()
+		main:OnFrame()
+		local arcaneSurge = build.calcsTab.mainEnv.player.mainSkill.supportList[1]
+		assert.are.equals("SupportArcaneSurge", arcaneSurge.grantedEffect.id)
+		assert.are.equals(20, arcaneSurge.level)
+
+		newBuild()
+		build.skillsTab:PasteSocketGroup("Slot: Gloves\nRain of Arrows 20/0  1")
+		build.configTab.input.customMods = "Skills socketed in your gloves are supported by level 20 Barrage"
+		build.configTab:BuildModList()
+		main:OnFrame()
+		local barrage = build.calcsTab.mainEnv.player.mainSkill.supportList[1]
+		assert.are.equals("SupportBarrage", barrage.grantedEffect.id)
+		assert.are.equals(20, barrage.level)
+	end)
 end)

--- a/src/Modules/CalcSetup.lua
+++ b/src/Modules/CalcSetup.lua
@@ -1525,14 +1525,13 @@ function calcs.initEnv(build, mode, override, specEnv)
 
 				local function addExtraSupports(value, grantedEffect, level)
 					local grantedEffect = grantedEffect or env.data.skills[value.skillId]
-					if value and grantedEffect then -- Only item ExtraSupport gems should be flagged as fromItem. Imbued gems do not pass this check
-						grantedEffect.fromItem = true
-					end
 					-- Some skill gems share the same name as support gems, e.g. Barrage.
 					-- Since a support gem is expected here, if the first lookup returns a skill, then
 					-- prepending "Support" to the skillId will find the support version of the gem.
 					if value and grantedEffect and not grantedEffect.support then
 						grantedEffect = env.data.skills["Support"..value.skillId]
+					end
+					if value and grantedEffect then -- Only item ExtraSupport gems should be flagged as fromItem. Imbued gems do not pass this check
 						grantedEffect.fromItem = true
 					end
 					if grantedEffect then


### PR DESCRIPTION
Fixes #10209

### Description of the problem being solved:

While entering 'Skills socketed in your gloves are supported by level 20 Arcane Surge' as a custom modifier, the intermediate text ending in 'Arc' was parsed as the Arc active skill. CalcSetup then attempted to resolve a non-existent 'SupportArc' granted effect and crashed when it tried to mark the missing effect as item-granted.

Extra supports now resolve a matching support effect before it is marked as item-granted. Invalid partial skill names are ignored, while valid support names and same-name collisions such as Barrage continue to resolve correctly.

### Steps taken to verify a working solution:
- Added a regression test for the incomplete 'Arc' modifier text and verified it neither crashes nor adds an invalid support
- Verified 'Arcane Surge' resolves to level 20 'SupportArcaneSurge'
- Verified 'Barrage' continues to resolve to level 20 'SupportBarrage'
- Confirmed the regression test fails on the latest version
- All tests passed

### Link to a build that showcases this PR:

```
eNq1XF1z4rgSfZ79FS7eJ4D5SLKV7BYhySRVyYQLmZl7n7aELUA7QuLacjLsr7_dkm0wQUbG3DzMgt3ntNSSWqclaq_-_LXk3huNYibFdaN91mp4VAQyZGJ-3fj2ev_5ovHnH79djYhavMxuEsbxzR-_fbrSn72Akzj-Spb0ujEJgKLhvTH6_ixDePD4PHoZvza8JWFiIoOfVH2JZLICLw1vSkTI1HXjqxS04XH6Rrl-rkg0p-p71p7OX9CeFRFqQaV4Jn_L6IsMM1T-nInC82BBIhIoGj0h7SBR0rRHRQm8JXFARTjctFuDoEefrkacrGk0UUR5Mfxz3RhAYMicPjAF_SI8Aeu23-qfdf1eo1kKuUmiWN2SJXx0hk5WlIYb67PO9p8NNIro3WxGA8Xe6DBiarggItj4tDqravuccMVWnNFoq4VWxMMH8narZTN-lYrw29FkY9tvXZz1-unfeTlObsbG6uEHU4sbDtE9wsvjXDBFC0C_2zpr-ZcX3W670-qXOf0I9i-64PWy32u3zi_PO2XgkWSxFDUCc0SjhwnnsMC3kdaojmlMozeiWLGRVvuhXE6ZKA6CYzgGESUvMzPRxyRkSfxMVUTjrbl4YcM-E0GGMt5ME79VZjqiESQIVUAcAkxoICGnFJz0z_qbv3MHj_t5rK6f2Iy6W1bqVQqo2prj-nE3cbWrTHxcg8aQs90sJzLhjpYqcph-t_SXg9WjcJnKY_rfbcN2r2f3-iaV2boP9ELnlbuHUW7ZuTjz_cu2f946P7fva6PFOmYB4c_kF1smS9gbXslPuvHXL5lV84USkI9s0I51Yd2ziFZHDSUPj0AtiIytsIuyNeMQBJAFwe9o-ygCt4X4TUQ6NW-piX4pYAzLA3XLlFNHxMZFushcNnrjak5F6m_t1p0nSoPFFxCRY6KoW07eaJrysKKtU1jRcE9Ye46ACkFCoCVIZ5dloIphuhM0mq8nC0Z5WM06a9iQrBwyH4Z5G-0U7qK7SjNmG1oxJD9IFLrtD1Xb9Ebi7Qzb7peHy5i7TUwKuhYAId0R3C17xSD_xnqBV4MNoqVMIscBN8ZOHch2B1MsjWmYBG67UV723HAoLl27kaOgnZxXgg6UIsHPWxnOnYOmnVRCFNs3SVYryCE4G1wJcOMDZc62ZMnnvoP1C0xlpxWNe6S7g421s4N813f3sgNx7wvu3BU6szF3dpEP6DMkiyVsArrMf5Zblb51cKAYc6qstGGx3rOvN_kOLV_gOUtczRoUzkbVWJsSUfHP2pm_YO7k4E6ESYRLwdnHLmKfm1e2hEQax7dEES9MFfF3EjEiVFufTO089PXDmJIoWDzBfLgnnE8hPVw3tp_CN-S_aurTMvz0VSoao0t8mn25eo0o9Ui27gPk1s3CL17Ak1jR6IHEi3sZLcnmeMwvHGc9hhgE8I61DonWg-IrwXjDEzKkMeiWi4tOB0_mkHhtpmiMTYeimm6dvvmXDXPEZ7ixTZ-uvo2f9IdPC6VW8e_N5vv7-9mKqIWc0V-wrZwFctlcAQh68zn-yTj_jLTNAfzdzAf6TxM1M6YrczwYN803XFsRg4aasWliFHQUMUz4YYKksRcv5PsTnZNg_YUuofkzwmOKIzUjCVfw7MmcKwqMWlZ-bL__V0I4U2sdtjT6yDyhyoyujNAqvlnDysrODwsP71Fl7JxsYKswbxu71_UKAz54ekpHNHXgsTAb5fShRwUK8DBzhMemg02jdIt2ng0JD2LTVC6hzV845BhYEUzAnAmhYEgzSDr4nEwxHMbppytonaeHBwcXN4IpzOHGbjPSs1moND1Blun03LUGx_C1nWG2H_p54NDViEQmtm9mGRVdz-kSHzxTRUJYiM1HBYFuYrSbur_waWP8363BC2Qi0jHLvOSxSSeVYUgnVDoIelKZyYQfH5c4aB79hf9BjnU2p_QiHkoxY_N0opgv6UzRrPmTwtA-ilWivKmUnBKRhULog-ckpoVk3DyImCazGaQAxWagmLRKcsMMooAIOknAjSsihMQM8RUuAMw3DJvzIiAIkH8ikNshHvaL0NHfN7GQfP2M27gDAiJX3GecIB92jhQFG0ZAwX1II08kyymNdGGXAqmgy_WW5nEH7eqYEmRnx92WLClBdXPUKtf0t4DRQrEEd94qujMXD2UdK7Zuc3VQoUsASu9DSkC-323vj-FhbL99eXFZAKclSxV_xWqkDNrOg7LMr0bw1J5GNJxgoTDEnDShfFapATjTjogTpsXDsIvL_sd5dhjW-eBqRIU7IB_DA6i8R5MFyAEdw9jdCwbugIPz4pRMK07J-ZiIA4OdAWM2Z_xlpvM2tPBAFmm32t1iK7OTgLJB6hajh_uvU9s28_AOgQ-wS8p3CPs9h9eOUxlPE1xSyGasAgla9_Bg7WllsYGGYkyXIGHCm_WA83WFXLtV9brkscDs1aBlVET4K5vDLozLNQMPQXHLJRRpsNPSSJ8SeIopTvG4XKvHXZ1kNFUmTLWcpSEIMW8NKciba2HmkYh6sZGG8HK6NuLK81se7NBGpezxbDRLLi-0aDHfstLhO6PvRndCwXPLQM7D7hig7jRb4D9SZlq4Y779W8sm_PSftGggehijrGLR8gekcqyY0FIDNCyqLrJaQVGRa21Yqu-D8A2nyytsu3FRMKEE0603G_PH1YTh-ss8TgsxYxmrSP8A4e7-_m74-vj9Lp89LA7-QsGAV_opZEL1iRFEdhqbj9cNjIgejFvQkozHKBE5J6uYbtqOMi1VghxwJWza6iHfwCxcD8Udbi_T3S8K8k3Mf0C4I0at7crfl1CBWn3Xuw2eFFmZRqBX40N9M-3G00wshG1UeNduJzLHY0MoKc1pqyXgG62xlwV1grUv-LIEC_qdcKvn9O2BSCis1yAvoMTG1VQ-c7C6M1YlcQkCkJ3BumTabKupvRz6xws2AvPSDja_I7DOD_O2JKr6NwzWqJq3dvgtDYi17-alHZwf4Euhf4SznyW3KmH6KoWe5LD2BozjOZx1ZO84zU3shC8o9dKTExvTM2SrzKR04URsmih7NtiyKImVvk60RAjf2aHmyszSB3xXkoUK10iWgG7b2KnM9Ys1H5ZBzdZvjd-2Mtg_BOnlhiX8W3XE_iBk9zuW_m-Lvv2LROffwZtkoTnltyyXHbOyhAHCoT6NvrqoT7N7l1GfESRj_NM63ulbO_wblMpMrfewGMHkRIKLqh4Drq16DK9MBCqJ6NEE411Bs8GOy6VMfv6-F1w4Y7FkjvQ45mgGcwZ0NFwXcUejdf6HYkAL7bINILcp6UjhTK8e10Ql4hYCewIq3cX9SWkTqUpcZlvdG7XKjCZZpD-2KcsnxuQAEeiChxLl6caU3_U9UMLxB5yS1yP88KOiOmT4e4VkRUSY0b3s0_ubcXCMnlQxcOoLrlv8WUTdGOqjmY9E9nZBNZwWmlf6wqCsEjaH92iWXfIkMTW_DvxByUoK_RhvS0w1agytRsVbHC5VWqYaM8_3Ju9k5Q2m6zgm3DO3XF4PYMrcdLTMx9H02_gprbwrEPWPIdrhaJ-Awz8BR-cEHN3qHFW6P1gmnKoKgAcK6U4d0bEKkBsZrr1Mvjqj8otCdzdSVbEfQz6tFFwN8KsCjpg17b1LqX0qIv9URCfrWvdYomPTVJVpRbk6VTbsnoqocyoi_1RER83O-ptF-wQ7V_sk0_EUa-P_tVD7pyKqEt0vEZlV64NBVJlJunY8yZi3K6aEOnNmH75XE9-vHLXuCeRM7wQc_cpypc7Y7WfwazN0ajN0azP0ajP0j5N1tRaTncY_DU3nNDTd09D0TkPTryyl6wzSfga_NkOnNkO3NkOvNkO_apVSb73sIfDrEnTqEnTrEvTqEvRr7qB1FYBfE9-pvINXV0p-ZcSBVl010_Mnfcilz7b--O2qufv_YvgfdYIJ6w==
```
### Before screenshot:
<img width="1366" height="689" alt="Screenshot_20260814_013815" src="https://github.com/user-attachments/assets/a8f66e2b-fc00-4111-885f-add4136247d6" />

### After screenshot:
<img width="686" height="291" alt="Screenshot_20260814_013843" src="https://github.com/user-attachments/assets/77ad761f-348b-464a-acfe-59fcd0da2c5e" />
