### PR TITLE
Fix retained text showing for non-cluster items

### DIFF
--- a/src/Classes/ItemsTab.lua
+++ b/src/Classes/ItemsTab.lua
@@ -2210,7 +2210,7 @@ function ItemsTabClass:UpdateAffixControl(control, item, affixType, outputTable,
 			t_insert(control.list, lastSeries)
 		end
 		-- cluster jewel mods retained after changing the cluster type
-		if retainedAffixes[modId] then
+		if retainedAffixes[modId] and item.clusterJewel then
 			lastSeries.label = "^8[Retained] " .. lastSeries.label
 		end
 		t_insert(lastSeries.modList, modId)


### PR DESCRIPTION
### Description of the problem being solved:

Seems I accidentally added this tiny bug in #10120. This started showing up for mods that weren't naturally spawning on the item. I think the UI might be a bit of an issue as the affix selector and custom mod split feels very weird. These mods can't spawn on the item naturally, but the item parser isn't able to differentiate them and so they get lumped in the affix controls

### Steps taken to verify a working solution:
-
-
-

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
