### PR TITLE
Fix "Buy Similar" not working for items with 2 anoints

### DIFF
--- a/spec/System/TestCompareBuySimilar_spec.lua
+++ b/spec/System/TestCompareBuySimilar_spec.lua
@@ -105,6 +105,22 @@ Implicits: 1
 			assert.equal(-100, entries[1].value)
 			assert.equal(50, entries[2].value)
 		end)
+		it("does not combine options", function()
+			local lifelessDiamond = new("Item"):Item([[
+Test Subject
+Onyx Amulet
+Implicits: 2
+Allocates Adamant (enchant)
+Allocates Admonisher (enchant)
+Can have 3 additional Enchantment Modifiers]])
+			local entries = bs.addModEntries(lifelessDiamond,
+				{ { list = lifelessDiamond.enchantModLines, type = "enchant" }, { list = lifelessDiamond.explicitModLines, type = "explicit" } })
+			assert.equal(3, #entries)
+			assert.equal("enchant.stat_2954116742", entries[1].tradeIds[1])
+			assert.equal(49416, entries[1].value)
+			assert.equal("enchant.stat_2954116742", entries[2].tradeIds[1])
+			assert.equal(50858, entries[2].value)
+		end)
 	end)
 	describe("popup URL controls", function()
 		local originalCopy

--- a/src/Classes/CompareBuySimilar.lua
+++ b/src/Classes/CompareBuySimilar.lua
@@ -214,7 +214,7 @@ function M.addModEntries(item, modTypeSources)
 		for _, existingFilter in ipairs(modEntries) do
 			-- check if all result trade ids are equal
 			local sameHashes = #entry.tradeIds > 0 and tableDeepEquals(entry.tradeIds, existingFilter.tradeIds)
-			if sameHashes and existingFilter.type == entry.type then
+			if sameHashes and existingFilter.type == entry.type and not entry.isOption then
 				if entry.value then
 					local value = (entry.invert ~= existingFilter.invert) and -entry.value or entry.value or 0
 					existingFilter.value = (existingFilter.value or 0) + value


### PR DESCRIPTION
Fixes #10221 

### Description of the problem being solved:

Adds `and not entry.isOption`. I had already thought of this and even said options are avoided in a comment, but then I just didn't add the check

### Steps taken to verify a working solution:
- Test added
- Item search tested
-

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
