### PR TITLE
Fix double click adding item twice

### DIFF
--- a/src/Classes/ControlHost.lua
+++ b/src/Classes/ControlHost.lua
@@ -40,6 +40,7 @@ function ControlHostClass:ProcessControlsInput(inputEvents, viewPort)
 	local processedImbuedControl
 	for id, event in ipairs(inputEvents) do
 		if event.type == "KeyDown" then
+			local prevSelControl = self.selControl
 			if self.selControl then
 				processedImbuedControl = self.selControl.imbuedSelect and self.selControl.dropped and event.key:match("BUTTON")
 				self:SelectControl(self.selControl:OnKeyDown(event.key, event.doubleClick))
@@ -52,7 +53,8 @@ function ControlHostClass:ProcessControlsInput(inputEvents, viewPort)
 				self:SelectControl()
 				if isMouseInRegion(viewPort) then
 					local mOverControl = self:GetMouseOverControl()
-					if mOverControl and mOverControl.OnKeyDown then
+					-- Skip the control that just handled this event and released focus, otherwise it would process the same click twice
+					if mOverControl and mOverControl ~= prevSelControl and mOverControl.OnKeyDown then
 						self:SelectControl(mOverControl:OnKeyDown(event.key, event.doubleClick))
 						inputEvents[id] = nil
 					end


### PR DESCRIPTION
### Description of the problem being solved:

Fixes display item being added twice, which feels especially bad with sorting options enabled, because it runs the whole sorting process twice. Fix is from claude

### Steps taken to verify a working solution:
- No double click in debugger
- Item mods don't require two clicks to disable

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
