### PR TITLE
Fix some unique wand implicits and last mod of Eclipse Solaris

### DIFF
--- a/src/Data/ModCache.lua
+++ b/src/Data/ModCache.lua
@@ -6933,7 +6933,6 @@ c["Adds 22 to 396 Lightning Damage"]={{[1]={flags=0,keywordFlags=0,name="Lightni
 c["Adds 22 to 41 Fire Damage to Spells"]={{[1]={flags=0,keywordFlags=131072,name="FireMin",type="BASE",value=22},[2]={flags=0,keywordFlags=131072,name="FireMax",type="BASE",value=41}},nil}
 c["Adds 22 to 42 Fire Damage"]={{[1]={flags=0,keywordFlags=0,name="FireMin",type="BASE",value=22},[2]={flags=0,keywordFlags=0,name="FireMax",type="BASE",value=42}},nil}
 c["Adds 22 to 44 Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalMin",type="BASE",value=22},[2]={flags=0,keywordFlags=0,name="PhysicalMax",type="BASE",value=44}},nil}
-c["Adds 22 to 45 Cold Damage to Spells and Attacks"]={{[1]={flags=0,keywordFlags=196608,name="ColdMin",type="BASE",value=22},[2]={flags=0,keywordFlags=196608,name="ColdMax",type="BASE",value=45}},nil}
 c["Adds 22 to 45 Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalMin",type="BASE",value=22},[2]={flags=0,keywordFlags=0,name="PhysicalMax",type="BASE",value=45}},nil}
 c["Adds 220 to 270 Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalMin",type="BASE",value=220},[2]={flags=0,keywordFlags=0,name="PhysicalMax",type="BASE",value=270}},nil}
 c["Adds 225 to 600 Lightning Damage to Unarmed Melee Hits"]={{[1]={flags=16777476,keywordFlags=0,name="LightningMin",type="BASE",value=225},[2]={flags=16777476,keywordFlags=0,name="LightningMax",type="BASE",value=600}},nil}
@@ -7078,7 +7077,6 @@ c["Adds 4 to 50 Lightning Damage to Attacks"]={{[1]={flags=0,keywordFlags=65536,
 c["Adds 4 to 7 Fire Damage to Attacks with this Weapon per 10 Strength"]={{[1]={[1]={type="Condition",var="{Hand}Attack"},[2]={skillType=1,type="SkillType"},[3]={div=10,stat="Str",type="PerStat"},flags=0,keywordFlags=65536,name="FireMin",type="BASE",value=4},[2]={[1]={type="Condition",var="{Hand}Attack"},[2]={skillType=1,type="SkillType"},[3]={div=10,stat="Str",type="PerStat"},flags=0,keywordFlags=65536,name="FireMax",type="BASE",value=7}},nil}
 c["Adds 4 to 7 Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalMin",type="BASE",value=4},[2]={flags=0,keywordFlags=0,name="PhysicalMax",type="BASE",value=7}},nil}
 c["Adds 4 to 7 Physical Damage to Attacks"]={{[1]={flags=0,keywordFlags=65536,name="PhysicalMin",type="BASE",value=4},[2]={flags=0,keywordFlags=65536,name="PhysicalMax",type="BASE",value=7}},nil}
-c["Adds 4 to 76 Lightning Damage to Spells and Attacks"]={{[1]={flags=0,keywordFlags=196608,name="LightningMin",type="BASE",value=4},[2]={flags=0,keywordFlags=196608,name="LightningMax",type="BASE",value=76}},nil}
 c["Adds 4 to 8 Cold Damage to Attacks"]={{[1]={flags=0,keywordFlags=65536,name="ColdMin",type="BASE",value=4},[2]={flags=0,keywordFlags=65536,name="ColdMax",type="BASE",value=8}},nil}
 c["Adds 4 to 8 Fire Damage to Attacks"]={{[1]={flags=0,keywordFlags=65536,name="FireMin",type="BASE",value=4},[2]={flags=0,keywordFlags=65536,name="FireMax",type="BASE",value=8}},nil}
 c["Adds 4 to 8 Physical Damage"]={{[1]={flags=0,keywordFlags=0,name="PhysicalMin",type="BASE",value=4},[2]={flags=0,keywordFlags=0,name="PhysicalMax",type="BASE",value=8}},nil}

--- a/src/Data/Uniques/wand.lua
+++ b/src/Data/Uniques/wand.lua
@@ -384,8 +384,8 @@ Source: Drops in Tul Breach or from unique{Tul, Creeping Avalanche}
 Upgrade: Upgrades to unique{Tulfall} using currency{Blessing of Tul}
 Implicits: 3
 {variant:1,2}(15-19)% increased Spell Damage
-{variant:3}Adds (14-29) to (42-47) Cold Damage to Spells and Attacks
 {variant:4}(31-35)% increased Spell Damage
+{variant:3}Adds (14-29) to (42-47) Cold Damage to Spells and Attacks
 {variant:3,4}Adds (120-140) to (150-170) Cold Damage to Spells
 {variant:1,2}(10-15)% increased Cast Speed
 {variant:1,2}50% chance to gain a Power Charge on Killing a Frozen Enemy
@@ -405,8 +405,8 @@ League: Breach
 Source: Upgraded from unique{Tulborn} using currency{Blessing of Tul}
 Implicits: 3
 {variant:1,2}(35-39)% increased Spell Damage
-{variant:3}Adds (14-29) to (42-47) Cold Damage to Spells and Attacks
 {variant:4}(31-35)% increased Spell Damage
+{variant:3}Adds (14-29) to (42-47) Cold Damage to Spells and Attacks
 {variant:1,2}(10-15)% increased Cast Speed
 {variant:3,4}(10-20)% increased Cast Speed
 {variant:1}50% chance to gain a Power Charge on Killing a Frozen Enemy
@@ -428,8 +428,8 @@ League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
 Implicits: 3
 {variant:1}(35-39)% increased Spell Damage
-{variant:2}Adds (14-29) to (42-47) Cold Damage to Spells and Attacks
 {variant:3}(31-35)% increased Spell Damage
+{variant:2}Adds (14-29) to (42-47) Cold Damage to Spells and Attacks
 (15-25)% increased Cast Speed
 Lose all Power Charges on reaching Maximum Power Charges
 Gain a Frenzy Charge on reaching Maximum Power Charges

--- a/src/Data/Uniques/wand.lua
+++ b/src/Data/Uniques/wand.lua
@@ -93,7 +93,7 @@ Implicits: 4
 {variant:6}(15-20)% increased Light Radius
 Nearby Enemies are Blinded
 (120-140)% increased Critical Strike Chance against Blinded Enemies
-Adds 2 to 5 Fire Damage to Attacks for every 1% your Light Radius is above base value
+{variant:6}Adds 2 to 5 Fire Damage to Attacks for every 1% your Light Radius is above base value
 ]],[[
 Corona Solaris
 Crystal Wand
@@ -182,7 +182,6 @@ Minions deal (50-70)% increased Damage
 +3 to maximum number of Summoned Phantasms
 ]],[[
 Moonsorrow
-Imbued Wand
 {variant:1,2,3,4}Imbued Wand
 {variant:5}Kinetic Wand
 Variant: Pre 2.0.0
@@ -247,6 +246,7 @@ Piscator's Vigil
 Variant: Pre 2.3.0
 Variant: Pre 2.6.0
 Variant: Pre 3.21.0
+Variant: Pre 3.27.0
 Variant: Current
 Implicits: 4
 {variant:1}(16-19)% increased Spell Damage
@@ -263,13 +263,15 @@ Attacks with this Weapon have (100-115)% increased Elemental Damage
 The Poet's Pen
 {variant:1}Carved Wand
 {variant:2}Somatic Wand
-Implicits: 1
+Variant: Pre 3.27.0
+Variant: Current
+Implicits: 2
 {variant:1}(11-15)% increased Spell Damage
+{variant:2}Cannot roll Caster Modifiers
 +1 to Level of Socketed Skill Gems per 25 Player Levels
 Trigger a Socketed Spell when you Attack with this Weapon, with a 0.25 second Cooldown
 Adds 3 to 5 Physical Damage to Attacks with this Weapon per 3 Player Levels
 (8-12)% increased Attack Speed
-{variant:2}Cannot roll Caster Modifiers
 ]],[[
 Reverberation Rod
 Spiraled Wand
@@ -337,8 +339,8 @@ Variant: Pre 3.21.0
 Variant: Pre 3.29.0
 Variant: Current
 Implicits: 2
-{variant:1,2}(35-39)% increased Spell Damage
-{variant:3,4}Adds (3-5) to (70-82) Lightning Damage to Spells and Attacks
+{variant:1,2,4}(35-39)% increased Spell Damage
+{variant:3}Adds (3-5) to (70-82) Lightning Damage to Spells and Attacks
 {variant:1,2,3}(30-40)% increased Spell Damage
 {variant:1,2,3}Adds (26-35) to (95-105) Lightning Damage to Spells
 {variant:4}+1 to Maximum Power Charges
@@ -372,41 +374,45 @@ Adds 1 to (35-45) Lightning Damage
 ]],[[
 Tulborn
 {variant:1,2}Spiraled Wand
-{variant:3}Opal Wand
+{variant:3,4}Opal Wand
 Variant: Pre 3.16.0
 Variant: Pre 3.21.0
+Variant: Pre 3.29.0
 Variant: Current
 League: Breach
 Source: Drops in Tul Breach or from unique{Tul, Creeping Avalanche}
 Upgrade: Upgrades to unique{Tulfall} using currency{Blessing of Tul}
-Implicits: 2
+Implicits: 3
 {variant:1,2}(15-19)% increased Spell Damage
 {variant:3}Adds (14-29) to (42-47) Cold Damage to Spells and Attacks
-{variant:3}Adds (120-140) to (150-170) Cold Damage to Spells
+{variant:4}(31-35)% increased Spell Damage
+{variant:3,4}Adds (120-140) to (150-170) Cold Damage to Spells
 {variant:1,2}(10-15)% increased Cast Speed
 {variant:1,2}50% chance to gain a Power Charge on Killing a Frozen Enemy
-{variant:3}Gain a Power Charge on Killing a Frozen Enemy
+{variant:3,4}Gain a Power Charge on Killing a Frozen Enemy
 {variant:1,2}Adds 10 to 20 Cold Damage to Spells per Power Charge
-{variant:3}Cold Exposure you inflict applies an extra -12% to Cold Resistance
+{variant:3,4}Cold Exposure you inflict applies an extra -12% to Cold Resistance
 +(20-25) Mana gained on Killing a Frozen Enemy
 ]],[[
 Tulfall
 {variant:1,2}Tornado Wand
-{variant:3}Opal Wand
+{variant:3,4}Opal Wand
 Variant: Pre 3.16.0
 Variant: Pre 3.21.0
+Variant: Pre 3.29.0
 Variant: Current
 League: Breach
 Source: Upgraded from unique{Tulborn} using currency{Blessing of Tul}
-Implicits: 2
+Implicits: 3
 {variant:1,2}(35-39)% increased Spell Damage
 {variant:3}Adds (14-29) to (42-47) Cold Damage to Spells and Attacks
+{variant:4}(31-35)% increased Spell Damage
 {variant:1,2}(10-15)% increased Cast Speed
-{variant:3}(10-20)% increased Cast Speed
+{variant:3,4}(10-20)% increased Cast Speed
 {variant:1}50% chance to gain a Power Charge on Killing a Frozen Enemy
-{variant:2,3}Gain a Power Charge on Killing a Frozen Enemy
+{variant:2,3,4}Gain a Power Charge on Killing a Frozen Enemy
 {variant:1,2}Adds 15 to 25 Cold Damage to Spells per Power Charge
-{variant:3}Adds 50 to 70 Cold Damage to Spells per Power Charge
+{variant:3,4}Adds 50 to 70 Cold Damage to Spells per Power Charge
 Lose all Power Charges on reaching Maximum Power Charges
 Gain a Frenzy Charge on reaching Maximum Power Charges
 {variant:1}(10-15)% increased Cold Damage per Frenzy Charge
@@ -414,15 +420,16 @@ Gain a Frenzy Charge on reaching Maximum Power Charges
 ]],[[
 Replica Tulfall
 {variant:1}Tornado Wand
-{variant:2}Opal Wand
+{variant:2,3}Opal Wand
 Variant: Pre 3.21.0
 Variant: Pre 3.29.0
 Variant: Current
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
-Implicits: 2
+Implicits: 3
 {variant:1}(35-39)% increased Spell Damage
-{variant:2,3}Adds (14-29) to (42-47) Cold Damage to Spells and Attacks
+{variant:2}Adds (14-29) to (42-47) Cold Damage to Spells and Attacks
+{variant:3}(31-35)% increased Spell Damage
 (15-25)% increased Cast Speed
 Lose all Power Charges on reaching Maximum Power Charges
 Gain a Frenzy Charge on reaching Maximum Power Charges
@@ -437,16 +444,16 @@ Twyzel
 Variant: Pre 2.3.0
 Variant: Pre 2.27.0
 Variant: Current
-Implicits: 2
+Implicits: 3
 {variant:1}(11-14)% increased Spell Damage
 {variant:2}(17-21)% increased Spell Damage
+{variant:3}Cannot roll Caster Modifiers
 {variant:1,2}Socketed Gems fire an additional Projectile
 {variant:1,2}(80-120)% increased Physical Damage
 {variant:3}(80-140)% increased Physical Damage
 Adds (5-8) to (13-17) Physical Damage
 (5-10)% increased Attack Speed
 (10-20)% increased Critical Strike Chance
-{variant:3}Cannot roll Caster Modifiers
 {variant:3}Attacks fire (1-2) additional Projectile when in Off Hand
 {variant:3}Attacks have (40-60)% increased Area of Effect when in Main Hand
 ]],[[

--- a/src/Export/Uniques/wand.lua
+++ b/src/Export/Uniques/wand.lua
@@ -93,7 +93,7 @@ Implicits: 4
 {variant:6}LightRadiusUnique__1
 DisplayBlindAuraUnique__1
 CriticalChanceAgainstBlindedEnemiesUnique__1
-AddedFireDamageFromLightRadiusUnique__1
+{variant:6}AddedFireDamageFromLightRadiusUnique__1
 ]],[[
 Corona Solaris
 Crystal Wand
@@ -177,7 +177,6 @@ ExtraRagingSpiritsUnique__1
 ExtraMaximumPhantasmsUnique__1
 ]],[[
 Moonsorrow
-Imbued Wand
 {variant:1,2,3,4}Imbued Wand
 {variant:5}Kinetic Wand
 Variant: Pre 2.0.0
@@ -242,6 +241,7 @@ Piscator's Vigil
 Variant: Pre 2.3.0
 Variant: Pre 2.6.0
 Variant: Pre 3.21.0
+Variant: Pre 3.27.0
 Variant: Current
 Implicits: 4
 {variant:1}SpellDamageOnWeaponImplicitWand15[16,19]
@@ -258,13 +258,15 @@ ThisWeaponsWeaponElementalDamageUniqueWand6
 The Poet's Pen
 {variant:1}Carved Wand
 {variant:2}Somatic Wand
-Implicits: 1
+Variant: Pre 3.27.0
+Variant: Current
+Implicits: 2
 {variant:1}SpellDamageOnWeaponImplicitWand3
+{variant:2}KineticWandImplicit
 SocketedGemLevelPer25PlayerLevelsUnique__1
 TriggerSocketedSpellOnAttackUnique__1
 AddsPhysicalDamagePer3PlayerLevelsUnique__1_
 LocalIncreasedAttackSpeedUnique__24
-{variant:2}KineticWandImplicit
 ]],[[
 Reverberation Rod
 Spiraled Wand
@@ -332,8 +334,8 @@ Variant: Pre 3.21.0
 Variant: Pre 3.29.0
 Variant: Current
 Implicits: 2
-{variant:1,2}SpellDamageUniqueWand1[35,39]
-{variant:3,4}AddedLightningDamageSpellsAndAttacksImplicit3
+{variant:1,2,4}SpellDamageUniqueWand1[35,39]
+{variant:3}AddedLightningDamageSpellsAndAttacksImplicit3
 {variant:1,2,3}SpellDamageUniqueWand1
 {variant:1,2,3}SpellAddedLightningDamageUnique__5
 {variant:4}IncreasedMaximumPowerChargesUnique__5
@@ -364,41 +366,45 @@ PowerChargeOnKillChanceUnique__1
 ]],[[
 Tulborn
 {variant:1,2}Spiraled Wand
-{variant:3}Opal Wand
+{variant:3,4}Opal Wand
 Variant: Pre 3.16.0
 Variant: Pre 3.21.0
+Variant: Pre 3.29.0
 Variant: Current
 League: Breach
 Source: Drops in Tul Breach or from unique{Tul, Creeping Avalanche}
 Upgrade: Upgrades to unique{Tulfall} using currency{Blessing of Tul}
-Implicits: 2
+Implicits: 3
 {variant:1,2}SpellDamageOnWeaponImplicitWand5
 {variant:3}AddedColdDamageSpellsAndAttacksImplicit3
+{variant:4}SpellDamageOnWeaponImplicitWand14
 {variant:1,2}IncreasedCastSpeedUnique__20
-{variant:3}SpellAddedColdDamageUnique__7
+{variant:3,4}SpellAddedColdDamageUnique__7
 {variant:1,2}GainPowerChargeOnKillingFrozenEnemyUnique__1[50,50]
-{variant:3}GainPowerChargeOnKillingFrozenEnemyUnique__1
+{variant:3,4}GainPowerChargeOnKillingFrozenEnemyUnique__1
 {variant:1,2}AddedColdDamagePerPowerChargeUnique__1
-{variant:3}ColdExposureAdditionalResistanceUnique__1
+{variant:3,4}ColdExposureAdditionalResistanceUnique__1
 GainManaOnKillingFrozenEnemyUnique__1
 ]],[[
 Tulfall
 {variant:1,2}Tornado Wand
-{variant:3}Opal Wand
+{variant:3,4}Opal Wand
 Variant: Pre 3.16.0
 Variant: Pre 3.21.0
+Variant: Pre 3.29.0
 Variant: Current
 League: Breach
 Source: Upgraded from unique{Tulborn} using currency{Blessing of Tul}
-Implicits: 2
+Implicits: 3
 {variant:1,2}SpellDamageOnWeaponImplicitWand16
 {variant:3}AddedColdDamageSpellsAndAttacksImplicit3
+{variant:4}SpellDamageOnWeaponImplicitWand14
 {variant:1,2}IncreasedCastSpeedUniqueWand3[10,15]
-{variant:3}IncreasedCastSpeedUniqueWand3
+{variant:3,4}IncreasedCastSpeedUniqueWand3
 {variant:1}GainPowerChargeOnKillingFrozenEnemyUnique__1[50,50]
-{variant:2,3}GainPowerChargeOnKillingFrozenEnemyUnique__1
+{variant:2,3,4}GainPowerChargeOnKillingFrozenEnemyUnique__1
 {variant:1,2}AddedColdDamagePerPowerChargeUnique__2[15,15][25,25]
-{variant:3}AddedColdDamagePerPowerChargeUnique__2
+{variant:3,4}AddedColdDamagePerPowerChargeUnique__2
 LosePowerChargesOnMaxPowerChargesUnique__2
 WhenReachingMaxPowerChargesGainAFrenzyChargeUnique__1
 {variant:1}IncreasedColdDamagePerFrenzyChargeUnique__1[10,15]
@@ -406,15 +412,16 @@ WhenReachingMaxPowerChargesGainAFrenzyChargeUnique__1
 ]],[[
 Replica Tulfall
 {variant:1}Tornado Wand
-{variant:2}Opal Wand
+{variant:2,3}Opal Wand
 Variant: Pre 3.21.0
 Variant: Pre 3.29.0
 Variant: Current
 League: Heist
 Source: Steal from a unique{Curio Display} during a Grand Heist
-Implicits: 2
+Implicits: 3
 {variant:1}SpellDamageOnWeaponImplicitWand16
-{variant:2,3}AddedColdDamageSpellsAndAttacksImplicit3
+{variant:2}AddedColdDamageSpellsAndAttacksImplicit3
+{variant:3}SpellDamageOnWeaponImplicitWand14
 IncreasedCastSpeedUnique__22
 LosePowerChargesOnMaxPowerChargesUnique__1
 WhenReachingMaxPowerChargesGainAFrenzyChargeUnique__1
@@ -429,16 +436,16 @@ Twyzel
 Variant: Pre 2.3.0
 Variant: Pre 2.27.0
 Variant: Current
-Implicits: 2
+Implicits: 3
 {variant:1}SpellDamageOnWeaponImplicitWand6[11,14]
 {variant:2}SpellDamageOnWeaponImplicitWand6
+{variant:3}KineticWandImplicit
 {variant:1,2}SocketedGemsAdditionalProjectilesUniqueWand9
 {variant:1,2}LocalIncreasedPhysicalDamagePercentUniqueWand9[80,120]
 {variant:3}LocalIncreasedPhysicalDamagePercentUniqueWand9
 LocalAddedPhysicalDamageUniqueWand9
 LocalIncreasedAttackSpeedUniqueWand9
 LocalCriticalStrikeChanceUniqueWand9
-{variant:3}KineticWandImplicit
 {variant:3}MainHandAdditionalProjectilesWhileInOffHandUnique__1
 {variant:3}OffHandAreaOfEffectWhileInMainHandUnique__1
 ]],[[


### PR DESCRIPTION
Fixes https://github.com/PathOfBuildingCommunity/PathOfBuilding/issues/10239

### Description of the problem being solved:

- Piscator's Vigil - missing variant for 3.27 implicit change
- Poet's Pen - missing variant for 3.27 implicit change and implicit misplaced
- Shimmeron - Tornado Wand base type's implicit changed in 3.29
- Tulborn, Tulfall and Replica Tulfall - Opal Wand base type's implicit changed in 3.29
- Twyzel - misplaced implicit mod
- Eclipse Solaris - Light Radius based Added Fire Damage mod added in 3.27 is not limited to latest variant


### Steps taken to verify a working solution:
Tried locally