### PR TITLE
Fix Sirus Meteor not dealing Chaos Damage

### DIFF
--- a/src/Modules/CalcDefence.lua
+++ b/src/Modules/CalcDefence.lua
@@ -1750,9 +1750,12 @@ function calcs.buildDefenceEstimations(env, actor)
 					local gainAsPercent = enemyDB:Sum("BASE", enemyCfg, (damageType.."DamageGainAs"..damageTypeTo)) / 100
 					local conversionPercent = conversions[damageTypeTo] / 100
 					local skillConversionPercent = conversions[damageTypeTo.."skill"] / 100
-					if skillConversionPercent > 0 and damageType == "Physical" and damageTypeTo ~= "Chaos" then
-						local physBonus = 1 + data.monsterPhysConversionMultiTable[env.enemyLevel] / 100
-						conversionPercent = conversionPercent + skillConversionPercent * physBonus
+					if skillConversionPercent > 0 then
+						if damageType == "Physical" and damageTypeTo ~= "Chaos" then
+							local physBonus = 1 + data.monsterPhysConversionMultiTable[env.enemyLevel] / 100
+							skillConversionPercent = skillConversionPercent * physBonus
+						end
+						conversionPercent = conversionPercent + skillConversionPercent
 					end
 					if gainAsPercent > 0 or conversionPercent > 0 then
 						enemyDamageConversion[damageTypeTo] = enemyDamageConversion[damageTypeTo] or { }


### PR DESCRIPTION
### Description of the problem being solved:
In my PR ages ago to apply the conversion multiplier to enemy skills, I accidentally made chaos conversion not work on enemy skills instead of just not applying the damage bonus to it

### Before screenshot:
<img width="1029" height="218" alt="image" src="https://github.com/user-attachments/assets/45711367-fdb7-426c-96e3-326bb719f3ad" />


### After screenshot:
<img width="1031" height="236" alt="image" src="https://github.com/user-attachments/assets/998b5571-75a0-4025-a53f-38399e9de780" />
