### PR TITLE
Fix crash when last saved league doesn't exist anymore

### DIFF
--- a/src/Classes/ImportTab.lua
+++ b/src/Classes/ImportTab.lua
@@ -129,7 +129,8 @@ local function addOAuthControls(self)
 					self.controls.charSelectLeague:SetSel(i)
 				end
 			end
-		else
+		end
+		if not self.controls.charSelectLeague.selIndex then
 			self.controls.charSelectLeague:SetSel(1)
 		end
 	end


### PR DESCRIPTION
### Description of the problem being solved:

Fixes a possible crash when the last imported league doesn't exist in the fetched league list.

### Steps taken to verify a working solution:
- Crash fixed

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
