### PR TITLE
Fix "x to Total Mana Cost" mods not working correctly with Life / ES cost conversion

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -381,6 +381,46 @@ describe("TestSkills", function()
 		assert.equals(18, build.calcsTab.mainOutput.LifeCost)
 	end)
 
+	it("converts and rounds flat mana cost separately from base cost", function()
+		build.skillsTab:PasteSocketGroup("Hydrosphere 1/0  1\n")
+		build.configTab.input.customMods = "Skills Cost Life instead of 15% of Mana Cost\n+4 to Total Mana Cost"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.equals(3, build.calcsTab.mainOutput.LifeCost)
+		assert.equals(13, build.calcsTab.mainOutput.ManaCost)
+	end)
+
+	it("moves flat mana cost when all costs are converted", function()
+		build.skillsTab:PasteSocketGroup("Hydrosphere 1/0  1\n")
+		build.configTab.input.customMods = "Skills Cost Life instead of Mana\n+4 to Total Mana Cost"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.equals(16, build.calcsTab.mainOutput.LifeCost)
+		assert.equals(0, build.calcsTab.mainOutput.ManaCost)
+	end)
+
+	it("does not move reduced flat mana cost to life", function()
+		build.skillsTab:PasteSocketGroup("Hydrosphere 1/0  1\n")
+		build.configTab.input.customMods = "Skills Cost Life instead of Mana\nNon-Channelling Skills have -7 to Total Mana Cost"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.equals(12, build.calcsTab.mainOutput.LifeCost)
+		assert.equals(0, build.calcsTab.mainOutput.ManaCost)
+	end)
+
+	it("does not partially convert reduced flat mana cost to life", function()
+		build.skillsTab:PasteSocketGroup("Hydrosphere 1/0  1\n")
+		build.configTab.input.customMods = "Skills Cost Life instead of 15% of Mana Cost\nNon-Channelling Skills have -7 to Total Mana Cost"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.equals(2, build.calcsTab.mainOutput.LifeCost)
+		assert.equals(4, build.calcsTab.mainOutput.ManaCost)
+	end)
+
 	it("Test flat cost is added after cost efficiency for energy shield costs", function()
 		build.skillsTab:PasteSocketGroup("Hydrosphere 1/0  1\n")
 
@@ -391,6 +431,26 @@ describe("TestSkills", function()
 
 		-- 12 / 1.5 + 10 = 18
 		assert.equals(18, build.calcsTab.mainOutput.ESCost)
+	end)
+
+	it("moves flat mana cost to energy shield with the base cost", function()
+		build.skillsTab:PasteSocketGroup("Hydrosphere 1/0  1\n")
+		build.configTab.input.customMods = "Skills Cost Energy Shield instead of Mana or Life\n+4 to Total Mana Cost"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.equals(16, build.calcsTab.mainOutput.ESCost)
+		assert.equals(0, build.calcsTab.mainOutput.ManaCost)
+	end)
+
+	it("does not move reduced flat mana cost to energy shield", function()
+		build.skillsTab:PasteSocketGroup("Hydrosphere 1/0  1\n")
+		build.configTab.input.customMods = "Skills Cost Energy Shield instead of Mana or Life\nNon-Channelling Skills have -7 to Total Mana Cost"
+		build.configTab:BuildModList()
+		runCallback("OnFrame")
+
+		assert.equals(12, build.calcsTab.mainOutput.ESCost)
+		assert.equals(0, build.calcsTab.mainOutput.ManaCost)
 	end)
 	it("Test mana cost efficiency with support gems", function()
 		-- Test interaction between cost efficiency and cost multipliers

--- a/src/Modules/CalcOffence.lua
+++ b/src/Modules/CalcOffence.lua
@@ -1707,6 +1707,11 @@ function calcs.offence(env, actor, activeSkill)
 			if val.type == "Life" then
 				local manaType = resource:gsub("Life", "Mana")
 				if skillModList:Flag(skillCfg, "CostLifeInsteadOfMana") then -- Blood Magic / Lifetap
+					if val.upfront then
+						local manaTotalCost = skillModList:Sum("BASE", skillCfg, manaType.."Cost")
+						val.totalCost = val.totalCost + m_max(0, manaTotalCost)
+						costs[manaType].totalCost = costs[manaType].totalCost - manaTotalCost
+					end
 					val.baseCost = val.baseCost + costs[manaType].baseCost
 					val.baseCostNoMult = val.baseCostNoMult + costs[manaType].baseCostNoMult
 					val.finalBaseCost = val.finalBaseCost + costs[manaType].finalBaseCost
@@ -1717,11 +1722,22 @@ function calcs.offence(env, actor, activeSkill)
 				elseif (additionalLifeCost > 0 or hybridLifeCost > 0) and not skillModList:Flag(skillCfg, "CostESInsteadOfManaOrLife") then
 					val.baseCost = costs[manaType].baseCost
 					val.finalBaseCost = val.finalBaseCost + round(costs[manaType].finalBaseCost * (hybridLifeCost + additionalLifeCost))
+					if val.upfront and hybridLifeCost > 0 then
+						-- Only positive flat mana cost is converted, and it is rounded separately from base cost.
+						val.totalCost = val.totalCost + round(m_max(0, skillModList:Sum("BASE", skillCfg, manaType.."Cost")) * hybridLifeCost)
+					end
 				end
 			elseif val.type == "ES" then
 				local manaType = resource:gsub("ES", "Mana")
 				local lifeType = resource:gsub("ES", "Life")
 			  	if skillModList:Flag(skillCfg, "CostESInsteadOfManaOrLife") then -- Whispers of Infinity
+					if val.upfront then
+						local manaTotalCost = skillModList:Sum("BASE", skillCfg, manaType.."Cost")
+						local lifeTotalCost = skillModList:Sum("BASE", skillCfg, lifeType.."Cost")
+						val.totalCost = val.totalCost + m_max(0, manaTotalCost) + m_max(0, lifeTotalCost)
+						costs[manaType].totalCost = costs[manaType].totalCost - manaTotalCost
+						costs[lifeType].totalCost = costs[lifeType].totalCost - lifeTotalCost
+					end
 					val.baseCost = val.baseCost + costs[manaType].baseCost+ costs[lifeType].baseCost
 					val.baseCostNoMult = val.baseCostNoMult + costs[manaType].baseCostNoMult + costs[lifeType].baseCostNoMult
 					val.finalBaseCost = val.finalBaseCost + costs[manaType].finalBaseCost + costs[lifeType].finalBaseCost


### PR DESCRIPTION
### Description of the problem being solved:
Fix added Total Mana cost when converting to Energy Shield or Life cost.

For some reason the game can only add to the base cost but not subtract from it. So modifiers such as `Non-Channelling Skills have -7 to Total Mana Cost` do not reduce Blood Magic life cost but `Non-Channelling Skills have +7 to Total Mana Cost` would increase it.

Added tests to cover multiple scenarios

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/zq3dhv0h

### Before screenshot:
<img width="464" height="504" alt="image" src="https://github.com/user-attachments/assets/318476e2-9df8-4b00-8e87-75e8c6f05ff2" />
<img width="310" height="262" alt="image" src="https://github.com/user-attachments/assets/c47d6a65-8995-4f03-a138-94a7cb5afba1" />


### After screenshot:
<img width="459" height="506" alt="image" src="https://github.com/user-attachments/assets/7b3c3ea4-950c-4e3b-a8c0-b71f8b6380c4" />
<img width="307" height="234" alt="image" src="https://github.com/user-attachments/assets/3c9fd9a1-0d27-4078-a2fd-b1ecf5022ff7" />
