### PR TITLE
Fix Ball Lightning not using enemy radius selector

### DIFF
--- a/spec/System/TestSkills_spec.lua
+++ b/spec/System/TestSkills_spec.lua
@@ -132,6 +132,29 @@ describe("TestSkills", function()
 		assert.are.equals(cappedCombinedDPS, build.calcsTab.mainOutput.CombinedDPS)
 	end)
 
+	it("uses enemy radius when calculating Ball Lightning hits", function()
+		build.skillsTab:PasteSocketGroup("Ball Lightning 20/0  1\n")
+		runCallback("OnFrame")
+
+		local mainSocketGroup = build.skillsTab.socketGroupList[build.mainSocketGroup]
+		mainSocketGroup.displaySkillList[mainSocketGroup.mainActiveSkill].activeEffect.srcInstance.skillPart = 2
+		build.configTab.input.projectileDistance = 40
+		build.configTab.input.enemyRadius = 1
+		build.configTab:BuildModList()
+		build.modFlag = true
+		build.buildFlag = true
+		runCallback("OnFrame")
+		local smallEnemyHits = build.calcsTab.mainOutput.SkillDPSMultiplier
+
+		build.configTab.input.enemyRadius = 11
+		build.configTab:BuildModList()
+		build.modFlag = true
+		build.buildFlag = true
+		runCallback("OnFrame")
+
+		assert.is_true(build.calcsTab.mainOutput.SkillDPSMultiplier > smallEnemyHits)
+	end)
+
 	it("Test Adrenaline affecting blight max stage count", function()
 		build.skillsTab:PasteSocketGroup("Blight 20/0  1\n")
 		runCallback("OnFrame")

--- a/src/Data/Skills/act_int.lua
+++ b/src/Data/Skills/act_int.lua
@@ -1116,9 +1116,10 @@ skills["BallLightning"] = {
 			local ballDistPerStrike = ballDistPerSec * secsPerStrike
 			-- How many times does the ball proc a bolt strike while it is in
 			-- range of the enemy?
-			local enemyRadius = 0 -- for now, we will be conservative and assume no enemy radius
+			local enemyRadius = skillModList:Override(skillCfg, "EnemyRadius") or skillModList:Sum("BASE", skillCfg, "EnemyRadius")
 			local baseStrikeRadius = output.AreaOfEffectRadius
-			local strikeRadius = baseStrikeRadius
+			-- A bolt can hit when its area overlaps any part of the enemy's collision circle.
+			local strikeRadius = baseStrikeRadius + enemyRadius
 			local castDist = 0
 			if skillCfg.skillDist then
 				-- Advanced users can specify exactly the standoff distance

--- a/src/Export/Skills/act_int.txt
+++ b/src/Export/Skills/act_int.txt
@@ -189,9 +189,10 @@ return function(skills, mod, flag, skill)
 			local ballDistPerStrike = ballDistPerSec * secsPerStrike
 			-- How many times does the ball proc a bolt strike while it is in
 			-- range of the enemy?
-			local enemyRadius = 0 -- for now, we will be conservative and assume no enemy radius
+			local enemyRadius = skillModList:Override(skillCfg, "EnemyRadius") or skillModList:Sum("BASE", skillCfg, "EnemyRadius")
 			local baseStrikeRadius = output.AreaOfEffectRadius
-			local strikeRadius = baseStrikeRadius
+			-- A bolt can hit when its area overlaps any part of the enemy's collision circle.
+			local strikeRadius = baseStrikeRadius + enemyRadius
 			local castDist = 0
 			if skillCfg.skillDist then
 				-- Advanced users can specify exactly the standoff distance

--- a/src/Modules/ConfigOptions.lua
+++ b/src/Modules/ConfigOptions.lua
@@ -762,8 +762,8 @@ return {
 	{ var = "VaalMoltenShellDamageMitigated", type = "count", label = "Damage mitigated:", tooltip = "Vaal Molten Shell reflects damage to the enemy,\nbased on the amount of damage it has mitigated in the last second.", ifSkill = "Vaal Molten Shell", apply = function(val, modList, enemyModList)
 		modList:NewMod("SkillData", "LIST", { key = "VaalMoltenShellDamageMitigated", value = val }, "Config", { type = "SkillName", skillName = "Molten Shell" })
 	end },
-	{ label = "Multi-part area skills:", ifSkill = { "Seismic Trap", "Lightning Spire Trap", "Explosive Trap", "Molten Strike" }, includeTransfigured = true },
-	{ var = "enemySizePreset", type = "list", label = "Enemy size preset:", ifSkill = { "Seismic Trap", "Lightning Spire Trap", "Explosive Trap", "Molten Strike" }, includeTransfigured = true, defaultIndex = 2, tooltip = [[
+	{ label = "Multi-part area skills:", ifSkill = { "Seismic Trap", "Lightning Spire Trap", "Explosive Trap", "Molten Strike", "Ball Lightning" }, includeTransfigured = true },
+	{ var = "enemySizePreset", type = "list", label = "Enemy size preset:", ifSkill = { "Seismic Trap", "Lightning Spire Trap", "Explosive Trap", "Molten Strike", "Ball Lightning" }, includeTransfigured = true, defaultIndex = 2, tooltip = [[
 Configure the radius of an enemy hitbox which is used in calculating some area multi-hitting (shotgunning) effects.
 
 Small sets the radius to 2.
@@ -788,7 +788,7 @@ Huge sets the radius to 11.
 			modList:NewMod("EnemyRadius", "BASE", 11, "Config")
 		end
 	end },
-	{ var = "enemyRadius", type = "integer", label = "Enemy radius:", ifSkill = { "Seismic Trap", "Lightning Spire Trap", "Explosive Trap", "Molten Strike" }, includeTransfigured = true, tooltip = "Configure the radius of an enemy hitbox to calculate some area overlapping (shotgunning) effects.", apply = function(val, modList, enemyModList)
+	{ var = "enemyRadius", type = "integer", label = "Enemy radius:", ifSkill = { "Seismic Trap", "Lightning Spire Trap", "Explosive Trap", "Molten Strike", "Ball Lightning" }, includeTransfigured = true, tooltip = "Configure the radius of an enemy hitbox to calculate some area overlapping (shotgunning) effects.", apply = function(val, modList, enemyModList)
 		modList:NewMod("EnemyRadius", "OVERRIDE", m_max(val, 1), "Config")
 	end },
 	{ var = "TotalMinionLife", type = "integer", label = "Minion Life override:", ifMod = "takenFromMinionBeforeYou", tooltip = "Overrides the automatically calculated Life of the minion supported by Companionship.", apply = function(val, modList, enemyModList)


### PR DESCRIPTION
### Description of the problem being solved:
Ball Lightning was using an enemy radius of 0 instead of using the existing radius selection dropdown / override
So it understated it's dps against all targets and especially against large ones

### Link to a build that showcases this PR:
https://maxroll.gg/poe/pob/jc5kaw0h

### Before screenshot:
<img width="309" height="214" alt="image" src="https://github.com/user-attachments/assets/536a0946-518b-4402-8b9c-a7fb0881ef85" />

### After screenshot:
<img width="304" height="218" alt="image" src="https://github.com/user-attachments/assets/50cd313f-d7b3-4ac7-9321-2dce7f14ad03" />
