### PR TITLE
Fix Compare Config tab visual issues

### DIFF
--- a/src/Classes/CompareTab.lua
+++ b/src/Classes/CompareTab.lua
@@ -1847,6 +1847,16 @@ function CompareTabClass:Draw(viewPort, inputEvents)
 	end
 
 	self:DrawControls(viewPort)
+	if self.compareViewMode == "CONFIG" and compareEntry then
+		self:DrawConfig(contentVP, compareEntry, true)
+		self:DrawControlList(viewPort, {
+			self.controls.copyConfigBtn,
+			self.controls.configToggleBtn,
+			self.controls.configSearchEdit,
+			self.controls.configPrimarySetLabel,
+			self.controls.configPrimarySetSelect,
+		})
+	end
 	if drawingTree then
 		SetDrawLayer(0)
 	end
@@ -1858,6 +1868,17 @@ end
 -- ============================================================
 -- DRAW HELPERS
 -- ============================================================
+
+function CompareTabClass:DrawControlList(viewPort, controls)
+	local noTooltip = function(control)
+		return self.selControl and self.selControl.hasFocus and self.selControl ~= control
+	end
+	for _, control in ipairs(controls) do
+		if control:IsShown() and control.Draw then
+			control:Draw(viewPort, noTooltip(control))
+		end
+	end
+end
 
 -- Pre-draw tree header/footer backgrounds and position tree controls.
 -- Must run before ProcessControlsInput so controls render on top of backgrounds.
@@ -2176,6 +2197,7 @@ function CompareTabClass:LayoutConfigView(contentVP, compareEntry)
 	local scrollTopAbs = contentVP.y + fixedHeaderHeight
 	local scrollBottomAbs = contentVP.y + contentVP.height
 	local ctrlH = rowHeight
+	local mouseClipRect = { contentVP.x, scrollTopAbs, contentVP.width, scrollBottomAbs - scrollTopAbs }
 	for _, sec in ipairs(sectionLayout) do
 		local sectionAbsX = contentVP.x + sec.x
 		local rowY = sec.y + sectionInnerPad
@@ -2187,11 +2209,13 @@ function CompareTabClass:LayoutConfigView(contentVP, compareEntry)
 			ci.compareControl.y = contentVP.y + fixedHeaderHeight + rowY - self.scrollY
 			local shownFn = function()
 				local ay = ci.primaryControl.y
-				return ay >= scrollTopAbs and ay + ctrlH <= scrollBottomAbs
+				return ay + ctrlH > scrollTopAbs and ay < scrollBottomAbs
 					and self.compareViewMode == "CONFIG" and self:GetActiveCompare() ~= nil
 			end
 			ci.primaryControl.shown = shownFn
 			ci.compareControl.shown = shownFn
+			ci.primaryControl.mouseClipRect = mouseClipRect
+			ci.compareControl.mouseClipRect = mouseClipRect
 			rowY = rowY + rowHeight
 		end
 	end
@@ -4909,7 +4933,7 @@ end
 -- ============================================================
 -- CONFIG VIEW
 -- ============================================================
-function CompareTabClass:DrawConfig(vp, compareEntry)
+function CompareTabClass:DrawConfig(vp, compareEntry, headerOnly)
 	local rowHeight = LAYOUT.configRowHeight
 	local columnHeaderHeight = LAYOUT.configColumnHeaderHeight
 	local fixedHeaderHeight = LAYOUT.configFixedHeaderHeight
@@ -4919,6 +4943,8 @@ function CompareTabClass:DrawConfig(vp, compareEntry)
 
 	-- Fixed header area: row 1 = buttons, row 2 = search/dropdowns, then column headers + separator
 	SetViewport(vp.x, vp.y, vp.width, fixedHeaderHeight)
+	SetDrawColor(0.05, 0.05, 0.05)
+	DrawImage(nil, 0, 0, vp.width, fixedHeaderHeight)
 	-- Controls are drawn by ControlHost (positioned in LayoutConfigView)
 	local colHeaderY = 54
 	SetDrawColor(1, 1, 1)
@@ -4930,6 +4956,10 @@ function CompareTabClass:DrawConfig(vp, compareEntry)
 		colorCodes.WARNING .. (compareEntry.label or "Compare Build"))
 	SetDrawColor(0.5, 0.5, 0.5)
 	DrawImage(nil, 4, colHeaderY + columnHeaderHeight + 4, vp.width - 8, 2)
+	if headerOnly then
+		SetViewport()
+		return
+	end
 
 	-- Scrollable content area (clipped below fixed header)
 	local scrollH = vp.height - fixedHeaderHeight

--- a/src/Classes/CompareTab.lua
+++ b/src/Classes/CompareTab.lua
@@ -3983,7 +3983,7 @@ function CompareTabClass:DrawItems(vp, compareEntry, inputEvents)
 	-- Draw item tooltip on hover (compact mode only, on top of everything)
 	SetViewport()
 	local maxTooltipWidth = m_min(600, m_max(260, vp.width - 24))
-	if hoverItem and hoverItemsTab then
+	if not main.popups[1] and hoverItem and hoverItemsTab then
 		self.itemTooltip:Clear()
 		hoverItemsTab:AddItemTooltip(self.itemTooltip, hoverItem, nil, nil, maxTooltipWidth)
 		SetDrawLayer(nil, 100)
@@ -3992,7 +3992,7 @@ function CompareTabClass:DrawItems(vp, compareEntry, inputEvents)
 	end
 
 	-- Draw stat comparison tooltip when hovering Equip button
-	if hoverEquipItem and hoverEquipSlotName and not hoverItem then
+	if not main.popups[1] and hoverEquipItem and hoverEquipSlotName and not hoverItem then
 		self.itemTooltip:Clear()
 		self.itemTooltip.maxWidth = maxTooltipWidth
 		local calcFunc, calcBase = self.calcs.getMiscCalculator(self.primaryBuild)

--- a/src/Classes/ControlHost.lua
+++ b/src/Classes/ControlHost.lua
@@ -31,7 +31,17 @@ end
 function ControlHostClass:GetMouseOverControl()
 	for _, control in pairs(self.controls) do
 		if control.IsMouseOver and control:IsMouseOver() then
-			return control
+			local clip = control.mouseClipRect
+			if type(clip) == "function" then
+				clip = clip(control)
+			end
+			if not clip then
+				return control
+			end
+			local cursorX, cursorY = GetCursorPos()
+			if cursorX >= clip[1] and cursorY >= clip[2] and cursorX < clip[1] + clip[3] and cursorY < clip[2] + clip[4] then
+				return control
+			end
 		end
 	end
 end


### PR DESCRIPTION
### Description of the problem being solved:
The config tab in the compare builds UI was completely cutting off dropdowns or checkboxes if any of the visual was outside the drawing area instead of just cutting off the visual of part of the object

The trade UI to buy items in the compare tab was also showing tooltips for hovered items in the background

### Before screenshot:
<img width="562" height="35" alt="image" src="https://github.com/user-attachments/assets/040520d7-9413-4970-83f3-2450c0690ba7" />
<img width="783" height="518" alt="image" src="https://github.com/user-attachments/assets/8efbacc6-686b-4a5d-bae9-e4edd83b2ef6" />


### After screenshot:
<img width="565" height="35" alt="image" src="https://github.com/user-attachments/assets/879a082a-3601-4c14-936f-637b58857293" />
<img width="804" height="464" alt="image" src="https://github.com/user-attachments/assets/f157c95e-5fa3-40cb-aaae-eca8ff1224f9" />
