### PR TITLE
Fix trader pearl slot, row hiding logic, and auth label

### DIFF
--- a/spec/System/TestTradeQuery_spec.lua
+++ b/spec/System/TestTradeQuery_spec.lua
@@ -62,6 +62,29 @@ describe("TradeQuery", function()
 		end)
 	end)
 	describe("GetResultEvaluation", function()
+		it("uses the first visible ring for a Pearl result without a selected slot", function()
+			local tq = new("TradeQuery"):TradeQuery({ itemsTab = {} })
+			tq.statSortSelectionList = {}
+			tq.tradeQueryGenerator = new("TradeQueryGenerator"):TradeQueryGenerator({ itemsTab = {} })
+			tq.itemsTab.slots = {
+				["Ring 1"] = { slotName = "Ring 1", shown = function() return false end },
+				["Ring 2"] = { slotName = "Ring 2", shown = function() return true end },
+			}
+			tq.slotTables[1] = { slotName = "Pearl of Tsoatha", unique = true }
+			tq.resultTbl[1] = {
+				[1] = { item_string = "Rarity: RARE\nBehemoth Hold\nGold Ring" },
+			}
+			local evaluatedSlot
+
+			tq:GetResultEvaluation(1, 1, function(override)
+				evaluatedSlot = override.repSlotName
+				return {}
+			end, {})
+
+			assert.are.equal("Ring 2", evaluatedSlot)
+			assert.are.equal("Ring 2", tq.slotTables[1].selectedSlotName)
+		end)
+
 		it("evaluates a socketed Megalomaniac by node combination", function()
 			local slotTbl = {
 				slotName = "Megalomaniac", unique = true, alreadyCorrupted = true, selectedJewelNodeId = 12345,

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -578,7 +578,7 @@ Highest Weight - Displays the order retrieved from trade]]
 			local rowWithPadding = row_height + row_vertical_padding
 			-- this many items fit in the scrollBar "box" so as the offset moves, we need to dynamically show what is within the boundaries
 			local maxItemsInView = math.floor(self.controls.scrollBar.height / rowWithPadding) - 2
-			if (index < maxItemsInView and (self.controls.scrollBar.offset < (rowWithPadding * (index - 1) + row_vertical_padding))) or
+			if (index <= maxItemsInView and (self.controls.scrollBar.offset < (rowWithPadding * (index - 1) + row_vertical_padding))) or
 				-- the second and in this applies if we have more than 44 slots because we need to hide the next "page" of rows as they go above the line, e.g. #23 could be above or below the "box"
 				(index >= maxItemsInView + 1 and (self.controls.scrollBar.offset > rowWithPadding * (index - maxItemsInView) and self.controls.scrollBar.offset < rowWithPadding * (index - 1))) then
 				return true
@@ -859,6 +859,15 @@ function TradeQueryClass:GetResultEvaluation(row_idx, result_index, calcFunc, ba
 		}
 		table.sort(result.evaluation, function(a, b) return a.weight > b.weight end)
 	else
+		if slotTbl.slotName == "Pearl of Tsoatha" and not slotTbl.selectedSlotName then
+			for index = 1, 3 do
+				local ringSlot = self.itemsTab.slots["Ring " .. index]
+				if ringSlot and ringSlot.shown() then
+					slotTbl.selectedSlotName = ringSlot.slotName
+					break
+				end
+			end
+		end
 		local slotName = jewelNodeId and "Jewel " .. tostring(jewelNodeId) or slotTbl.selectedSlotName or slotTbl.slotName
 		local item = new("Item"):Item(result.item_string)
 

--- a/src/Classes/TradeQuery.lua
+++ b/src/Classes/TradeQuery.lua
@@ -312,7 +312,7 @@ function TradeQueryClass:PriceItem()
 				self.clickTime = nil
 				return "Not authenticated"
 			else
-				return "Logging in... (" .. left .. ") - URL copied to clipboard"
+				return "Logging in... (" .. left .. ")"
 			end
 		else
 			return colorCodes.WARNING.."Not authenticated"
@@ -539,6 +539,7 @@ Highest Weight - Displays the order retrieved from trade]]
 	---@field unique boolean? Row targets a specific unique instead of a slot
 	---@field alreadyCorrupted boolean? The targeted unique only drops corrupted
 	---@field selectedJewelNodeId number? Jewel socket the unique row searches for
+	---@field selectedSlotName string? A slot name which was selected in the TradeQueryGenerator popup
 
 	---@type TradeQuerySlotTable[]
 	local slotTables = {}
@@ -574,10 +575,12 @@ Highest Weight - Displays the order retrieved from trade]]
 	-- dynamically hide rows that are above or below the scrollBar
 	local hideRowFunc = function(self, index)
 		if scrollBarShown then
-			-- 22 items fit in the scrollBar "box" so as the offset moves, we need to dynamically show what is within the boundaries
-			if (index < 23 and (self.controls.scrollBar.offset < ((row_height + row_vertical_padding)*(index-1) + row_vertical_padding))) or
+			local rowWithPadding = row_height + row_vertical_padding
+			-- this many items fit in the scrollBar "box" so as the offset moves, we need to dynamically show what is within the boundaries
+			local maxItemsInView = math.floor(self.controls.scrollBar.height / rowWithPadding) - 2
+			if (index < maxItemsInView and (self.controls.scrollBar.offset < (rowWithPadding * (index - 1) + row_vertical_padding))) or
 				-- the second and in this applies if we have more than 44 slots because we need to hide the next "page" of rows as they go above the line, e.g. #23 could be above or below the "box"
-				(index >= 23 and (self.controls.scrollBar.offset > (row_height + row_vertical_padding)*(index-22) and self.controls.scrollBar.offset < (row_height + row_vertical_padding)*(index-1))) then
+				(index >= maxItemsInView + 1 and (self.controls.scrollBar.offset > rowWithPadding * (index - maxItemsInView) and self.controls.scrollBar.offset < rowWithPadding * (index - 1))) then
 				return true
 			end
 		else
@@ -856,7 +859,7 @@ function TradeQueryClass:GetResultEvaluation(row_idx, result_index, calcFunc, ba
 		}
 		table.sort(result.evaluation, function(a, b) return a.weight > b.weight end)
 	else
-		local slotName = jewelNodeId and "Jewel " .. tostring(jewelNodeId) or slotTbl.slotName
+		local slotName = jewelNodeId and "Jewel " .. tostring(jewelNodeId) or slotTbl.selectedSlotName or slotTbl.slotName
 		local item = new("Item"):Item(result.item_string)
 
 		local output = self:ReduceOutput(calcFunc({ repSlotName = slotName, repItem = item }))

--- a/src/Classes/TradeQueryGenerator.lua
+++ b/src/Classes/TradeQueryGenerator.lua
@@ -1490,10 +1490,12 @@ Remove: %s will be removed from the search results.]], term, term, term)
 		options.statWeights = statWeights
 		if controls.jewelSlot then
 			slot = controls.jewelSlot:GetSelValue()
+			-- pass node id back to table so evaluation can use the correct socket instead of the unique pseudo slot
 			context.slotTbl.selectedJewelNodeId = slot.nodeId
 		end
 		if controls.ringSlot then
 			slot = controls.ringSlot:GetSelValue()
+			context.slotTbl.selectedSlotName = slot.slotName
 		end
 
 		self:StartQuery(slot, options)


### PR DESCRIPTION
.### Description of the problem being solved:

This fixes:

  - Trader pearl not using the selected ring slot when evaluating items (thanks @mcagnion)
  - Rows not hiding correctly, which could cause the rest of the rows to not show at all due to them being anchored to one another
  - Auth label being too big for the button

### Steps taken to verify a working solution:
- https://poe.ninja/poe1/builds/allflame/character/wakaobuhuiba-3206/AllFlameWardman?i=9&search=items%3DPearl%2Bof%2BTsoatha%26skills%3DSpark%2Bof%2Bthe%2BNova No longer has hidden rows
- Pearl uses correct slot (results still kind of suck because gems don't account for drawbacks in a lot of cases)
- Auth label looks proper

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
